### PR TITLE
Allows usage of command-line options to a grunt goal target

### DIFF
--- a/src/main/java/com/github/eirslett/maven/plugins/frontend/GruntMojo.java
+++ b/src/main/java/com/github/eirslett/maven/plugins/frontend/GruntMojo.java
@@ -22,8 +22,6 @@ public final class GruntMojo extends AbstractMojo {
     @Parameter
     private String target;
 
-	@Parameter
-	private String options;
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         Log logger = getLog();


### PR DESCRIPTION
You can not currently pass useful options to grunt, such as `--no-color`.  But with this change, you can!

```
...
<execution>
    <id>javascript tests</id>
    <phase>test</phase>
    <goals>
        <goal>grunt</goal>
    </goals>
    <configuration>
        <target>jasmine --no-color</target>
    </configuration>
</execution>
...
```
