### PR TITLE
npmmojo to allow any npm command without having to write new mojos

### DIFF
--- a/src/it/example/pom.xml
+++ b/src/it/example/pom.xml
@@ -31,8 +31,12 @@
                     <execution>
                         <id>npm install</id>
                         <goals>
-                            <goal>npm-install</goal>
+                            <goal>npm</goal>
                         </goals>
+                        <!-- Optional configuration which provides for running any npm command -->
+                        <configuration>
+                            <command>install</command>
+                        </configuration>
                     </execution>
 
                     <execution>

--- a/src/main/java/com/github/eirslett/maven/plugins/frontend/NpmMojo.java
+++ b/src/main/java/com/github/eirslett/maven/plugins/frontend/NpmMojo.java
@@ -10,19 +10,22 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
-@Mojo(name="npm-install",  defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
-public final class NpmInstallMojo extends AbstractMojo {
+@Mojo(name="npm",  defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+public final class NpmMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${basedir}", property = "workingDirectory", required = false)
     private File workingDirectory;
 
+    @Parameter(defaultValue = "install", property = "command", required = false)
+    private String command;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        getLog().info("Running NPM install in "+workingDirectory.toString());
+        getLog().info("Running NPM '" + command + "' in "+workingDirectory.toString());
         final String npmPath = workingDirectory+"/node/npm/bin/npm-cli.js".replace("/", File.separator);
-        int result = new NodeExecutor(workingDirectory, Arrays.asList(npmPath, "install")).executeAndRedirectOutput(getLog());
+        int result = new NodeExecutor(workingDirectory, Arrays.asList(npmPath, command)).executeAndRedirectOutput(getLog());
         if(result != 0){
-            throw new MojoFailureException("NPM install failed.");
+            throw new MojoFailureException("NPM '" + command + "' failed.");
         }
     }
 }


### PR DESCRIPTION
A refactoring which prevents you from having to write a new mojo for each npm command. 
You can override with the following config:
<exectuion>
 <i>npm something</id>
 <goals>
  <goal>npm</goal>
 </goals>
 <configuration>
  <command>run something</command>
 </configuration>
</exectuion>

This could enable you to have everything configured with NPM and hence being abel to have any test runner or build tool without having to write a Java class to do it. 

This is a breaking change as the mojo and goal is renamed to reflect the change in behaviour.
