### PR TITLE
Use the maven configured proxy for npm install

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -3,14 +3,15 @@ package com.github.eirslett.maven.plugins.frontend.mojo;
 import java.io.File;
 
 import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
+import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.slf4j.Logger;
 
 import static com.github.eirslett.maven.plugins.frontend.mojo.MojoUtils.setSLF4jLogger;
 
@@ -29,11 +30,16 @@ public final class NpmMojo extends AbstractMojo {
     @Parameter(defaultValue = "install", property = "arguments", required = false)
     private String arguments;
 
+    @Parameter(property = "session", defaultValue = "${session}", readonly = true)
+    private MavenSession session;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
             setSLF4jLogger(getLog());
-            new FrontendPluginFactory(workingDirectory).getNpmRunner()
+
+            ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session);
+            new FrontendPluginFactory(workingDirectory, proxyConfig).getNpmRunner()
                     .execute(arguments);
         } catch (TaskRunnerException e) {
             throw new MojoFailureException(e.getMessage());

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -24,7 +24,7 @@ public final class FrontendPluginFactory {
     }
 
     public NpmRunner getNpmRunner() {
-        return new DefaultNpmRunner(defaultPlatform, workingDirectory);
+        return new DefaultNpmRunner(defaultPlatform, workingDirectory, proxy);
     }
 
     public GruntRunner getGruntRunner(){

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
@@ -1,7 +1,8 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
 import java.io.File;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 public interface NpmRunner {
     public void execute(String args) throws TaskRunnerException;
@@ -11,7 +12,16 @@ final class DefaultNpmRunner extends NodeTaskExecutor implements NpmRunner {
     static final String TASK_NAME = "npm";
     static final String TASK_LOCATION = "/node/npm/bin/npm-cli.js";
 
-    public DefaultNpmRunner(Platform platform, File workingDirectory) {
-        super(TASK_NAME, TASK_LOCATION, workingDirectory, platform, Arrays.asList("--color=false"));
+    public DefaultNpmRunner(Platform platform, File workingDirectory, ProxyConfig proxy) {
+        super(TASK_NAME, TASK_LOCATION, workingDirectory, platform, buildArguments(proxy));
+    }
+
+    private static List<String> buildArguments(ProxyConfig proxy) {
+        List<String> arguments = new ArrayList<String>();
+        arguments.add("--color=false");
+        if (proxy != null) {
+            arguments.add("--https-proxy=" + proxy.getUri().toString());
+        }
+        return arguments;
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProxyConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProxyConfig.java
@@ -1,5 +1,8 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 public class ProxyConfig {
     public final String protocol;
     public final String host;
@@ -19,6 +22,15 @@ public class ProxyConfig {
         return username != null && !username.isEmpty();
     }
 
+    public URI getUri() {
+        String authentication = useAuthentication() ? username + ":" + password : null;
+        try {
+            return new URI(protocol, authentication, host, port, null, null, null);
+        } catch (URISyntaxException e) {
+            throw new ProxyConfigException("Invalid proxy settings", e);
+        }
+    }
+
     @Override
     public String toString() {
         return "ProxyConfig{" +
@@ -27,5 +39,13 @@ public class ProxyConfig {
                 ", port=" + port +
                 (useAuthentication()? ", with username/passport authentication" : "") +
                 '}';
+    }
+
+    class ProxyConfigException extends RuntimeException {
+
+        private ProxyConfigException(String message, Exception cause) {
+            super(message, cause);
+        }
+
     }
 }


### PR DESCRIPTION
Fixes https://github.com/eirslett/frontend-maven-plugin/issues/47. I've verified that it works both with and without a proxy set. I've been unable to check that using proxy credentials work, as I don't have access to a proxy that require them, but I see no reason why it shouldn't.
