### PR TITLE
Added extra logging for node download/version

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeAndNPMInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeAndNPMInstaller.java
@@ -158,6 +158,9 @@ final class DefaultNodeAndNPMInstaller implements NodeAndNPMInstaller {
             String downloadUrl = "";
             try {
                 logger.info("Installing node version " + nodeVersion);
+                if (!nodeVersion.startsWith("v")) {
+                    logger.warn("Node version does not start with naming convention 'v'.");
+                }
                 final String longNodeFilename = platform.getLongNodeFilename(nodeVersion);
                 downloadUrl = downloadRoot + platform.getNodeDownloadFilename(nodeVersion);
 
@@ -204,16 +207,16 @@ final class DefaultNodeAndNPMInstaller implements NodeAndNPMInstaller {
         }
 
         private void installNodeForWindows() throws InstallationException {
+            final String downloadUrl = downloadRoot + platform.getNodeDownloadFilename(nodeVersion);
             try {
-                logger.info("Installing node version " + nodeVersion);
-                final String downloadUrl = downloadRoot + platform.getNodeDownloadFilename(nodeVersion);
+                logger.info("Installing node version " + nodeVersion);                
 
                 new File(workingDirectory+"\\node").mkdirs();
 
                 downloadFile(downloadUrl, workingDirectory +"\\node\\node.exe");
                 logger.info("Installed node.exe locally.");
             } catch (DownloadException e) {
-                throw new InstallationException("Could not download Node.js", e);
+                throw new InstallationException("Could not download Node.js from: " + downloadUrl, e);
             }
         }
 


### PR DESCRIPTION
The user is now highlighted if they specify a standard node version (0.10.1) then they are warned that they have omitted the 'v'. For new users this can be confusing.
If the download fails it reports the url to the user, previously there was no url information.
