### PR TITLE
Added ability to continue maven build even when tests are failing. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ By default, no colors will be shown in the log.
 ```
 __Skipping tests:__ If you run maven with the `-DskipTests` flag, karma tests will be skipped.
 
+__Ignoring failed tests:__ If you want to ignore test failures run maven with the `-Dmaven-frontend-plugin.testFailureIgnore` flag, karma test results will not stop the build but test results will remain
+in test output files. Suitable for continuous integration tool builds.
+
 __Why karma.conf.ci.js?__ When using Karma, you should have two separate
 configurations: `karma.conf.js` and `karma.conf.ci.js`. (The second one should inherit configuration
 from the first one, and override some options. The example project shows you how to set it up.)

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
@@ -34,6 +34,12 @@ public final class KarmaRunMojo extends AbstractMojo {
     @Parameter(property = "skipTests", required = false, defaultValue = "false")
     private Boolean skipTests;
 
+    /**
+     * Whether you should continue build when some test will fail (default is false)
+     */
+    @Parameter(property = "maven-frontend-plugin.testFailureIgnore", required = false, defaultValue = "false")
+    private Boolean testFailureIgnore;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
@@ -45,7 +51,11 @@ public final class KarmaRunMojo extends AbstractMojo {
                         .execute("start " + karmaConfPath);
             }
         } catch (TaskRunnerException e) {
-            throw new MojoFailureException(e.getMessage());
+			if (testFailureIgnore) {
+				LoggerFactory.getLogger(KarmaRunMojo.class).warn("There are ignored test failures/errors for: " + workingDirectory);
+			} else {
+            	throw new MojoFailureException(e.getMessage());
+			}
         }
     }
 }


### PR DESCRIPTION
Configuration is possible using property maven-frontend-plugin.testFailureIgnore similarly as in maven-surefie-plugin.
This corresponds to https://github.com/eirslett/frontend-maven-plugin/issues/31
