### PR TITLE
Adding "--proxy" modification for HTTP proxy

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
@@ -20,6 +20,7 @@ final class DefaultNpmRunner extends NodeTaskExecutor implements NpmRunner {
         List<String> arguments = new ArrayList<String>();
         arguments.add("--color=false");
         if (proxy != null) {
+            arguments.add("--proxy=" + proxy.getUri().toString());
             arguments.add("--https-proxy=" + proxy.getUri().toString());
         }
         return arguments;


### PR DESCRIPTION
Our build machine has the proxy on HTTP, not HTTPS, so the "https-proxy" argument was not sufficient to cover this case, but the additional use of the "proxy" argument solved our issue. Please add this change to the code. Hopefully, if it is included, we can get a release fairly soon so we can pull from the central maven repo.
