### PR TITLE
Fixed stack trace of task runner exception being discarded

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
@@ -10,7 +10,6 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.slf4j.Logger;
 
 @Mojo(name="grunt", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public final class GruntMojo extends AbstractMojo {
@@ -34,7 +33,7 @@ public final class GruntMojo extends AbstractMojo {
             new FrontendPluginFactory(workingDirectory).getGruntRunner()
                     .execute(arguments);
         } catch (TaskRunnerException e) {
-            throw new MojoFailureException(e.getMessage());
+            throw new MojoFailureException("Failed to run task", e);
         }
     }
 }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
@@ -10,7 +10,6 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.slf4j.Logger;
 
 @Mojo(name="gulp", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public final class GulpMojo extends AbstractMojo {
@@ -34,7 +33,7 @@ public final class GulpMojo extends AbstractMojo {
             new FrontendPluginFactory(workingDirectory).getGulpRunner()
                     .execute(arguments);
         } catch (TaskRunnerException e) {
-            throw new MojoFailureException(e.getMessage());
+            throw new MojoFailureException("Failed to run task", e);
         }
     }
 }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
@@ -54,7 +54,7 @@ public final class KarmaRunMojo extends AbstractMojo {
 			if (testFailureIgnore) {
 				LoggerFactory.getLogger(KarmaRunMojo.class).warn("There are ignored test failures/errors for: " + workingDirectory);
 			} else {
-            	throw new MojoFailureException(e.getMessage());
+                throw new MojoFailureException("Failed to run task", e);
 			}
         }
     }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
@@ -9,7 +9,7 @@ import org.slf4j.impl.StaticLoggerBinder;
 
 class MojoUtils {
     static <E extends Throwable> MojoFailureException toMojoFailureException(E e){
-        return new MojoFailureException(e.getMessage()+": "+e.getCause().getMessage());
+        return new MojoFailureException(e.getMessage()+": "+e.getCause().getMessage(), e);
     }
 
     static void setSLF4jLogger(Log log){

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -42,7 +42,7 @@ public final class NpmMojo extends AbstractMojo {
             new FrontendPluginFactory(workingDirectory, proxyConfig).getNpmRunner()
                     .execute(arguments);
         } catch (TaskRunnerException e) {
-            throw new MojoFailureException(e.getMessage());
+            throw new MojoFailureException("Failed to run task", e);
         }
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeTaskExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeTaskExecutor.java
@@ -1,16 +1,14 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.github.eirslett.maven.plugins.frontend.lib.Utils.implode;
-import static com.github.eirslett.maven.plugins.frontend.lib.Utils.normalize;
-import static com.github.eirslett.maven.plugins.frontend.lib.Utils.prepend;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.github.eirslett.maven.plugins.frontend.lib.Utils.*;
 
 abstract class NodeTaskExecutor {
     private final Logger logger;
@@ -40,7 +38,7 @@ abstract class NodeTaskExecutor {
                 throw new TaskRunnerException(taskToString(taskName, arguments) + " failed. (error code "+result+")");
             }
         } catch (ProcessExecutionException e) {
-            throw new TaskRunnerException(taskToString(taskName, arguments) + " failed.");
+            throw new TaskRunnerException(taskToString(taskName, arguments) + " failed.", e);
         }
     }
 


### PR DESCRIPTION
This should fix the cause being discarded when tasks fail. In order to debug configuration issues, it's useful to know exactly what went wrong. In the current implementation, the only error you'll ever see is: `'gulp build --no-color' failed`, which is not terribly helpful when it comes to determining the root cause of an issue.

This patch should print an error including the complete stack trace of the cause, for example:

```
[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:0.0.16-SNAPSHOT:gulp (gulp-build) on project proposal-tool-frontend: Failed to run task: 'gulp build --no-c
olor' failed. java.io.IOException: Cannot run program "c:\bla\bla\src\node\node" (in directory "c:
\blabla\src"): CreateProcess error=2, The system cannot find the file specified -> [Help 1]
```

Using the `-X` Maven parameter outputs the entire stack trace, as expected.
