### PR TITLE
Fix example of testFailureIgnore flag in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ By default, no colors will be shown in the log.
 ```
 __Skipping tests:__ If you run maven with the `-DskipTests` flag, karma tests will be skipped.
 
-__Ignoring failed tests:__ If you want to ignore test failures run maven with the `-Dmaven-frontend-plugin.testFailureIgnore` flag, karma test results will not stop the build but test results will remain
+__Ignoring failed tests:__ If you want to ignore test failures run maven with the `-DtestFailureIgnore` flag, karma test results will not stop the build but test results will remain
 in test output files. Suitable for continuous integration tool builds.
 
 __Why karma.conf.ci.js?__ When using Karma, you should have two separate


### PR DESCRIPTION
The example of how to ignore test results in the `README.md` file is outdated, it changed in commit 57c7950 from `maven-frontend-plugin.testFailureIgnore` to `testFailureIgnore`.
