### PR TITLE
skip configuration parameter created: skip plugin execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,38 @@ The default  The working directory is where you've put `package.json`, and eithe
     
     <!-- optional -->
     <configuration>
+        ...
         <workingDirectory>src/main/frontend</workingDirectory>
+    </configuration>
+    
+    <executions>
+      ...
+    </executions>
+</plugin>
+```
+### Skip plugin execution
+If you want to skip execution in a specific profile, then set _skip.frontend property_ in the profile:
+```xml
+<profile>
+    <id>local</id>
+    <properties>
+        ...
+        <skip.frontend>true</skip.frontend>
+        ...
+    </properties>
+</profile>
+```
+And set in the _skip_ option in the plugin configuration:
+```xml
+<plugin>
+    <groupId>com.github.eirslett</groupId>
+    <artifactId>frontend-maven-plugin</artifactId>
+    <version>...</version>
+    
+    <!-- optional -->
+    <configuration>
+        ...
+        <skip>${skip.frontend}</skip>
     </configuration>
     
     <executions>

--- a/frontend-maven-plugin/src/it/example project/invoker.properties
+++ b/frontend-maven-plugin/src/it/example project/invoker.properties
@@ -1,0 +1,7 @@
+# test with skip plugin, configuration: skip.frontend=true
+invoker.goal.1=clean install
+invoker.systemPropertiesFile.1 = test-1.properties
+
+# test with default configuration
+invoker.goal.2=clean install
+invoker.systemPropertiesFile.2 = test-2.properties

--- a/frontend-maven-plugin/src/it/example project/pom.xml
+++ b/frontend-maven-plugin/src/it/example project/pom.xml
@@ -14,6 +14,10 @@
                 <artifactId>frontend-maven-plugin</artifactId>
                 <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
                 <version>0.0.17-SNAPSHOT</version>
+		<configuration>
+		    <!-- optional -->
+		    <skip>${skip.frontend}</skip>
+		</configuration>
 
                 <executions>
 

--- a/frontend-maven-plugin/src/it/example project/test-1.properties
+++ b/frontend-maven-plugin/src/it/example project/test-1.properties
@@ -1,0 +1,1 @@
+skip.frontend=true

--- a/frontend-maven-plugin/src/it/example project/test-2.properties
+++ b/frontend-maven-plugin/src/it/example project/test-2.properties
@@ -1,0 +1,1 @@
+skip.frontend=false

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/FrontendMavenMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/FrontendMavenMojo.java
@@ -1,0 +1,23 @@
+package com.github.eirslett.maven.plugins.frontend.mojo;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Frontend maven plugin for Mojos.
+ */
+public abstract class FrontendMavenMojo extends AbstractMojo {
+
+    /**
+     * Skip the executions.
+     * @parameter expression="${skip.frontend}"
+     * default-value="false"
+     * @since 0.17
+     */
+    @Parameter(defaultValue = "false", property = "skip", required = false)
+    private boolean skip;
+
+    public boolean isSkip() {
+        return skip;
+    }
+}

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
@@ -4,7 +4,6 @@ import java.io.File;
 
 import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
 import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -12,14 +11,14 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 @Mojo(name="grunt", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
-public final class GruntMojo extends AbstractMojo {
+public final class GruntMojo extends FrontendMavenMojo {
 
     /**
      * The base directory for running all Node commands. (Usually the directory that contains package.json)
      */
     @Parameter(defaultValue = "${basedir}", property = "workingDirectory", required = false)
     private File workingDirectory;
-
+    
     /**
      * Grunt arguments. Default is empty (runs just the "grunt" command).
      */
@@ -28,6 +27,10 @@ public final class GruntMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (isSkip()) {
+            getLog().info("Frontend Plugin execution skipped");
+            return;
+        }
         try {
             MojoUtils.setSLF4jLogger(getLog());
             new FrontendPluginFactory(workingDirectory).getGruntRunner()

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
@@ -4,7 +4,6 @@ import java.io.File;
 
 import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
 import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -12,7 +11,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 @Mojo(name="gulp", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
-public final class GulpMojo extends AbstractMojo {
+public final class GulpMojo extends FrontendMavenMojo {
 
     /**
      * The base directory for running all Node commands. (Usually the directory that contains package.json)
@@ -28,6 +27,10 @@ public final class GulpMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (isSkip()) {
+            getLog().info("Frontend Plugin execution skipped");
+            return;
+        }
         try {
             MojoUtils.setSLF4jLogger(getLog());
             new FrontendPluginFactory(workingDirectory).getGulpRunner()

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -3,7 +3,6 @@ package com.github.eirslett.maven.plugins.frontend.mojo;
 import java.io.File;
 
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -16,7 +15,7 @@ import com.github.eirslett.maven.plugins.frontend.lib.NodeAndNPMInstaller;
 import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 
 @Mojo(name="install-node-and-npm", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
-public final class InstallNodeAndNpmMojo extends AbstractMojo {
+public final class InstallNodeAndNpmMojo extends FrontendMavenMojo {
 
     /**
      * The base directory for running all Node commands. (Usually the directory that contains package.json)
@@ -62,6 +61,10 @@ public final class InstallNodeAndNpmMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (isSkip()) {
+            getLog().info("Frontend Plugin execution skipped");
+            return;
+        }
         try {
             MojoUtils.setSLF4jLogger(getLog());
             ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session);

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
@@ -4,7 +4,6 @@ import java.io.File;
 
 import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
 import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -14,7 +13,7 @@ import org.slf4j.LoggerFactory;
 
 
 @Mojo(name="karma",  defaultPhase = LifecyclePhase.TEST)
-public final class KarmaRunMojo extends AbstractMojo {
+public final class KarmaRunMojo extends FrontendMavenMojo {
 
     /**
      * The base directory for running all Node commands. (Usually the directory that contains package.json)
@@ -42,6 +41,10 @@ public final class KarmaRunMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (isSkip()) {
+            getLog().info("Frontend Plugin execution skipped");
+            return;
+        }
         try {
             MojoUtils.setSLF4jLogger(getLog());
             if(skipTests){

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -6,7 +6,6 @@ import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
 import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -16,7 +15,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import static com.github.eirslett.maven.plugins.frontend.mojo.MojoUtils.setSLF4jLogger;
 
 @Mojo(name="npm",  defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
-public final class NpmMojo extends AbstractMojo {
+public final class NpmMojo extends FrontendMavenMojo {
 
     /**
      * The base directory for running all Node commands. (Usually the directory that contains package.json)
@@ -35,6 +34,10 @@ public final class NpmMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (isSkip()) {
+            getLog().info("Frontend Plugin execution skipped");
+            return;
+        }
         try {
             setSLF4jLogger(getLog());
 


### PR DESCRIPTION
I've added skip configuration property. It is skipping execution of plugin.

``` xml
<profile>
    <id>local</id>
    <properties>
        ...
        <skip.frontend>true</skip.frontend>
        ...
    </properties>
</profile>
```

And set in the _skip_ option in the plugin configuration:

``` xml
<plugin>
    <groupId>com.github.eirslett</groupId>
    <artifactId>frontend-maven-plugin</artifactId>
    <version>...</version>
    <!-- optional -->
    <configuration>
        ...
        <skip>${skip.frontend}</skip>
    </configuration>
    <executions>
      ...
    </executions>
</plugin>
```

**Background:** I have a Spring Boot REST project with AngularJS client. If a server side developer build the project, then unneccessary build client.

**Test:** I added a test for testing skip configuration and default behaviour.

**Refactored**: FrontendMavenMojo has been created for all Mojo with skip member. It may be contains _workingDirectory_ in the future.
