### PR TITLE
Automatic versioning in invoker tests

### DIFF
--- a/frontend-maven-plugin/src/it/example project/pom.xml
+++ b/frontend-maven-plugin/src/it/example project/pom.xml
@@ -10,8 +10,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>@project.groupId@</groupId>
-                <artifactId>@project.artifactId@</artifactId>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
                 <version>@project.version@</version>
 
                 <executions>


### PR DESCRIPTION
This avoids manual version bumping in the tests after a new version of the project has been released (like commit 5d87cce4b67e9d0a9ed36f70ff54b09e3a2484b7)

This pull request uses the maven-invoker-plugin [filtering](http://maven.apache.org/plugins/maven-invoker-plugin/examples/filtering.html) feature to perform that.
In addition, groupId and artifactId are now also filtered.
