### PR TITLE
Better compat with maven release plugin conventions

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -27,7 +27,7 @@ public final class NpmMojo extends AbstractMojo {
     /**
      * npm arguments. Default is "install".
      */
-    @Parameter(defaultValue = "install", property = "arguments", required = false)
+    @Parameter(defaultValue = "install", property = "frontend.arguments", required = false)
     private String arguments;
 
     @Parameter(property = "session", defaultValue = "${session}", readonly = true)


### PR DESCRIPTION
By convention, the property `arguments` is used in the maven release plugin to pass arguments through to the forked process, release builds will fail if you use that property name
