### PR TITLE
Implemented a global mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea
 *.iml
 target
+.classpath
+.project
+.settings

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractNodeJSMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractNodeJSMojo.java
@@ -1,0 +1,23 @@
+package com.github.eirslett.maven.plugins.frontend.mojo;
+
+import java.io.File;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+public abstract class AbstractNodeJSMojo extends AbstractMojo {
+
+	/**
+	 * Should this command use a local installed instance of npm (in the system PATH).
+	 * Else the instance installed by install-npm is used.
+	 */
+	@Parameter(property = "npm.useGlobal", defaultValue = "false", required = false)
+	protected boolean useGlobal;
+
+    /**
+     * The base directory for running all Node commands. (Usually the directory that contains package.json)
+     */
+    @Parameter(defaultValue = "${basedir}", property = "workingDirectory", required = false)
+    protected File workingDirectory;
+	
+}

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
@@ -4,7 +4,7 @@ import java.io.File;
 
 import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
 import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
-import org.apache.maven.plugin.AbstractMojo;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -12,13 +12,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 @Mojo(name="grunt", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
-public final class GruntMojo extends AbstractMojo {
-
-    /**
-     * The base directory for running all Node commands. (Usually the directory that contains package.json)
-     */
-    @Parameter(defaultValue = "${basedir}", property = "workingDirectory", required = false)
-    private File workingDirectory;
+public final class GruntMojo extends AbstractNodeJSMojo {
 
     /**
      * Grunt arguments. Default is empty (runs just the "grunt" command).
@@ -30,7 +24,7 @@ public final class GruntMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
             MojoUtils.setSLF4jLogger(getLog());
-            new FrontendPluginFactory(workingDirectory).getGruntRunner()
+            new FrontendPluginFactory(workingDirectory, useGlobal).getGruntRunner()
                     .execute(arguments);
         } catch (TaskRunnerException e) {
             throw new MojoFailureException("Failed to run task", e);

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
@@ -4,7 +4,7 @@ import java.io.File;
 
 import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
 import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
-import org.apache.maven.plugin.AbstractMojo;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -12,13 +12,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 @Mojo(name="gulp", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
-public final class GulpMojo extends AbstractMojo {
-
-    /**
-     * The base directory for running all Node commands. (Usually the directory that contains package.json)
-     */
-    @Parameter(defaultValue = "${basedir}", property = "workingDirectory", required = false)
-    private File workingDirectory;
+public final class GulpMojo extends AbstractNodeJSMojo {
 
     /**
      * Gulp arguments. Default is empty (runs just the "gulp" command).
@@ -30,7 +24,7 @@ public final class GulpMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
             MojoUtils.setSLF4jLogger(getLog());
-            new FrontendPluginFactory(workingDirectory).getGulpRunner()
+            new FrontendPluginFactory(workingDirectory, useGlobal).getGulpRunner()
                     .execute(arguments);
         } catch (TaskRunnerException e) {
             throw new MojoFailureException("Failed to run task", e);

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -3,7 +3,6 @@ package com.github.eirslett.maven.plugins.frontend.mojo;
 import java.io.File;
 
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -16,13 +15,7 @@ import com.github.eirslett.maven.plugins.frontend.lib.NodeAndNPMInstaller;
 import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 
 @Mojo(name="install-node-and-npm", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
-public final class InstallNodeAndNpmMojo extends AbstractMojo {
-
-    /**
-     * The base directory for running all Node commands. (Usually the directory that contains package.json)
-     */
-    @Parameter(property = "workingDirectory", defaultValue = "${basedir}")
-    private File workingDirectory;
+public final class InstallNodeAndNpmMojo extends AbstractNodeJSMojo {
 
     /**
      * Where to download Node.js binary from. Defaults to http://nodejs.org/dist/
@@ -64,10 +57,16 @@ public final class InstallNodeAndNpmMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
             MojoUtils.setSLF4jLogger(getLog());
+            
+            if (useGlobal) {
+            	getLog().warn("preinstalled mode is set, skipping downloading of node an npm.");
+            	return;
+            }
+            
             ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session);
             String nodeDownloadRoot = getNodeDownloadRoot();
             String npmDownloadRoot = getNpmDownloadRoot();
-            new FrontendPluginFactory(workingDirectory, proxyConfig).getNodeAndNPMInstaller().install(nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot);
+            new FrontendPluginFactory(workingDirectory, proxyConfig, useGlobal).getNodeAndNPMInstaller().install(nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot);
         } catch (InstallationException e) {
             throw MojoUtils.toMojoFailureException(e);
         }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
@@ -4,7 +4,7 @@ import java.io.File;
 
 import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
 import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
-import org.apache.maven.plugin.AbstractMojo;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -14,13 +14,7 @@ import org.slf4j.LoggerFactory;
 
 
 @Mojo(name="karma",  defaultPhase = LifecyclePhase.TEST)
-public final class KarmaRunMojo extends AbstractMojo {
-
-    /**
-     * The base directory for running all Node commands. (Usually the directory that contains package.json)
-     */
-    @Parameter(defaultValue = "${basedir}", property = "workingDirectory", required = false)
-    private File workingDirectory;
+public final class KarmaRunMojo extends AbstractNodeJSMojo {
 
     /**
      * Path to your karma configuration file, relative to the working directory (default is "karma.conf.js")
@@ -47,7 +41,7 @@ public final class KarmaRunMojo extends AbstractMojo {
             if(skipTests){
                 LoggerFactory.getLogger(KarmaRunMojo.class).info("Skipping karma tests.");
             } else {
-                new FrontendPluginFactory(workingDirectory).getKarmaRunner()
+                new FrontendPluginFactory(workingDirectory, useGlobal).getKarmaRunner()
                         .execute("start " + karmaConfPath);
             }
         } catch (TaskRunnerException e) {

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -3,10 +3,11 @@ package com.github.eirslett.maven.plugins.frontend.mojo;
 import java.io.File;
 
 import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
+import com.github.eirslett.maven.plugins.frontend.lib.NpmRunner;
 import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
+
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -16,13 +17,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import static com.github.eirslett.maven.plugins.frontend.mojo.MojoUtils.setSLF4jLogger;
 
 @Mojo(name="npm",  defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
-public final class NpmMojo extends AbstractMojo {
-
-    /**
-     * The base directory for running all Node commands. (Usually the directory that contains package.json)
-     */
-    @Parameter(defaultValue = "${basedir}", property = "workingDirectory", required = false)
-    private File workingDirectory;
+public final class NpmMojo extends AbstractNodeJSMojo {
 
     /**
      * npm arguments. Default is "install".
@@ -39,8 +34,9 @@ public final class NpmMojo extends AbstractMojo {
             setSLF4jLogger(getLog());
 
             ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session);
-            new FrontendPluginFactory(workingDirectory, proxyConfig).getNpmRunner()
-                    .execute(arguments);
+            
+            NpmRunner npmRunner = new FrontendPluginFactory(workingDirectory, proxyConfig, useGlobal).getNpmRunner();
+			npmRunner.execute(arguments);
         } catch (TaskRunnerException e) {
             throw new MojoFailureException("Failed to run task", e);
         }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -6,13 +6,15 @@ public final class FrontendPluginFactory {
     private static final Platform defaultPlatform = Platform.guess();
     private final File workingDirectory;
     private final ProxyConfig proxy;
+	private final boolean local;
 
-    public FrontendPluginFactory(File workingDirectory){
-        this(workingDirectory, null);
+    public FrontendPluginFactory(File workingDirectory, boolean local){
+        this(workingDirectory, null, local);
     }
-    public FrontendPluginFactory(File workingDirectory, ProxyConfig proxy){
+    public FrontendPluginFactory(File workingDirectory, ProxyConfig proxy, boolean local){
         this.workingDirectory = workingDirectory;
         this.proxy = proxy;
+		this.local = local;
     }
 
     public NodeAndNPMInstaller getNodeAndNPMInstaller(){
@@ -24,18 +26,18 @@ public final class FrontendPluginFactory {
     }
 
     public NpmRunner getNpmRunner() {
-        return new DefaultNpmRunner(defaultPlatform, workingDirectory, proxy);
+        return local ? new LocalNpmRunner(defaultPlatform, workingDirectory) : new DefaultNpmRunner(defaultPlatform, workingDirectory, proxy);
     }
-
+    
     public GruntRunner getGruntRunner(){
-        return new DefaultGruntRunner(defaultPlatform, workingDirectory);
+        return new DefaultGruntRunner(defaultPlatform, workingDirectory, local);
     }
 
     public KarmaRunner getKarmaRunner(){
-        return new DefaultKarmaRunner(defaultPlatform, workingDirectory);
+        return new DefaultKarmaRunner(defaultPlatform, workingDirectory, local);
     }
 
     public GulpRunner getGulpRunner(){
-        return new DefaultGulpRunner(defaultPlatform, workingDirectory);
+        return new DefaultGulpRunner(defaultPlatform, workingDirectory, local);
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GruntRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GruntRunner.java
@@ -11,7 +11,7 @@ final class DefaultGruntRunner extends NodeTaskExecutor implements GruntRunner {
     private static final String TASK_NAME = "grunt";
     private static final String TASK_LOCATION = "/node_modules/grunt-cli/bin/grunt";
 
-    DefaultGruntRunner(Platform platform, File workingDirectory) {
-        super(TASK_NAME, TASK_LOCATION, workingDirectory, platform, Arrays.asList("--no-color"));
+    DefaultGruntRunner(Platform platform, File workingDirectory, boolean local) {
+        super(TASK_NAME, TASK_LOCATION, workingDirectory, platform, Arrays.asList("--no-color"), local);
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GulpRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GulpRunner.java
@@ -11,7 +11,7 @@ final class DefaultGulpRunner extends NodeTaskExecutor implements GulpRunner {
     private static final String TASK_NAME = "gulp";
     private static final String TASK_LOCATION = "/node_modules/gulp/bin/gulp.js";
 
-    DefaultGulpRunner(Platform platform, File workingDirectory) {
-        super(TASK_NAME, TASK_LOCATION, workingDirectory, platform, Arrays.asList("--no-color"));
+    DefaultGulpRunner(Platform platform, File workingDirectory, boolean local) {
+        super(TASK_NAME, TASK_LOCATION, workingDirectory, platform, Arrays.asList("--no-color"), local);
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/KarmaRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/KarmaRunner.java
@@ -11,7 +11,7 @@ final class DefaultKarmaRunner extends NodeTaskExecutor implements KarmaRunner {
     static final String TASK_NAME = "karma";
     static final String TASK_LOCATION = "/node_modules/karma/bin/karma";
 
-    DefaultKarmaRunner(Platform platform, File workingDirectory) {
-        super(TASK_NAME, TASK_LOCATION, workingDirectory, platform, Arrays.asList("--no-colors"));
+    DefaultKarmaRunner(Platform platform, File workingDirectory, boolean local) {
+        super(TASK_NAME, TASK_LOCATION, workingDirectory, platform, Arrays.asList("--no-colors"), local);
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeAndNPMInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeAndNPMInstaller.java
@@ -103,7 +103,7 @@ final class DefaultNodeAndNPMInstaller implements NodeAndNPMInstaller {
             try {
                 final File nodeFile = new File(workingDirectory + nodeExeutable);
                 if(nodeFile.exists()){
-                    final String version = new NodeExecutor(workingDirectory, Arrays.asList("--version"), platform).executeAndGetResult();
+                    final String version = new NodeExecutor(workingDirectory, Arrays.asList("--version"), platform, false).executeAndGetResult();
 
                     if(version.equals(nodeVersion)){
                         logger.info("Node " + version + " is already installed.");

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutor.java
@@ -8,9 +8,16 @@ import java.util.List;
 final class NodeExecutor {
     private final ProcessExecutor executor;
 
-    public NodeExecutor(File workingDirectory, List<String> arguments, Platform platform){
-        final String node = workingDirectory + Utils.normalize("/node/node");
-        this.executor = new ProcessExecutor(workingDirectory, Utils.prepend(node, arguments), platform);
+    private final boolean local;
+    
+//    public NodeExecutor(File workingDirectory, List<String> arguments, Platform platform){
+//    	this(workingDirectory, arguments, platform, false);
+//    }
+//
+    public NodeExecutor(File workingDirectory, List<String> arguments, Platform platform, boolean local) {
+    	this.local = local;
+		final String node = local ? "node" : workingDirectory + Utils.normalize("/node/node");
+    	this.executor = new ProcessExecutor(workingDirectory, Utils.prepend(node, arguments), platform);
     }
 
     public String executeAndGetResult() throws ProcessExecutionException {

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeTaskExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeTaskExecutor.java
@@ -17,9 +17,11 @@ abstract class NodeTaskExecutor {
     private final Platform platform;
     private final File workingDirectory;
     private final List<String> additionalArguments;
+	private final boolean local;
 
-    public NodeTaskExecutor(String taskName, String taskLocation, File workingDirectory, Platform platform, List<String> additionalArguments) {
-        this.logger = LoggerFactory.getLogger(getClass());
+    public NodeTaskExecutor(String taskName, String taskLocation, File workingDirectory, Platform platform, List<String> additionalArguments, boolean local) {
+        this.local = local;
+		this.logger = LoggerFactory.getLogger(getClass());
         this.taskName = taskName;
         this.taskLocation = taskLocation;
         this.platform = platform;
@@ -33,7 +35,7 @@ abstract class NodeTaskExecutor {
         logger.info("Running " + taskToString(taskName, arguments) + " in " + workingDirectory);
 
         try {
-            final int result = new NodeExecutor(workingDirectory, prepend(absoluteTaskLocation, arguments), platform).executeAndRedirectOutput(logger);
+            final int result = new NodeExecutor(workingDirectory, prepend(absoluteTaskLocation, arguments), platform, true).executeAndRedirectOutput(logger);
             if(result != 0){
                 throw new TaskRunnerException(taskToString(taskName, arguments) + " failed. (error code "+result+")");
             }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
@@ -1,8 +1,16 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
+import static com.github.eirslett.maven.plugins.frontend.lib.Utils.implode;
+import static com.github.eirslett.maven.plugins.frontend.lib.Utils.normalize;
+import static com.github.eirslett.maven.plugins.frontend.lib.Utils.prepend;
+
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public interface NpmRunner {
     public void execute(String args) throws TaskRunnerException;
@@ -13,7 +21,7 @@ final class DefaultNpmRunner extends NodeTaskExecutor implements NpmRunner {
     static final String TASK_LOCATION = "/node/npm/bin/npm-cli.js";
 
     public DefaultNpmRunner(Platform platform, File workingDirectory, ProxyConfig proxy) {
-        super(TASK_NAME, TASK_LOCATION, workingDirectory, platform, buildArguments(proxy));
+        super(TASK_NAME, TASK_LOCATION, workingDirectory, platform, buildArguments(proxy), false);
     }
 
     private static List<String> buildArguments(ProxyConfig proxy) {
@@ -28,4 +36,50 @@ final class DefaultNpmRunner extends NodeTaskExecutor implements NpmRunner {
         }
         return arguments;
     }
+    
 }
+
+final class LocalNpmRunner implements NpmRunner {
+    private final String taskName;
+	private Platform platform;
+	private File workingDirectory;
+	private Logger logger;
+
+    public LocalNpmRunner(Platform platform, File workingDirectory) {
+    	this.logger = LoggerFactory.getLogger(getClass());
+		this.platform = platform;
+		this.workingDirectory = workingDirectory;
+		this.taskName = platform.isWindows() ? "npm.cmd" : "npm";
+    }
+
+    public final void execute(String args) throws TaskRunnerException {
+        final List<String> arguments = getArguments(args);
+        logger.info("Running " + taskToString(taskName, arguments) + " in " + workingDirectory);
+
+        try {
+        	int result = new ProcessExecutor(workingDirectory, prepend(taskName, arguments), platform).executeAndRedirectOutput(logger);
+            if(result != 0){
+                throw new TaskRunnerException(taskToString(taskName, arguments) + " failed. (error code "+result+")");
+            }
+        } catch (ProcessExecutionException e) {
+            throw new TaskRunnerException(taskToString(taskName, arguments) + " failed.", e);
+        }
+    }
+    
+    private List<String> getArguments(String args) {
+        List<String> arguments =  new ArrayList<String>();
+        if(args != null && !args.equals("null") && !args.isEmpty()) {
+            arguments.addAll(Arrays.asList(args.split("\\s+")));
+        }
+
+        if(!arguments.contains("--color=false")){
+            arguments.add("--color=false");
+        }
+        return arguments;
+    }
+    
+    private static String taskToString(String taskName, List<String> commands) {
+        return "'" + taskName + " " + implode(" ",commands) + "'";
+    }
+}
+


### PR DESCRIPTION
Using the configuration parameter useGlobal (${npm.useGlobal}), no node
nor npm is installed. Instead, a globally installed instance in the path
is used. This is usefully for corporate installations.
