### PR TITLE
Add support for skipping execution

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
@@ -53,6 +53,12 @@ public final class GruntMojo extends AbstractMojo {
     @Parameter(property = "outputdir")
     private File outputdir;
 
+    /**
+     * Skips execution of this mojo.
+     */
+    @Parameter(property = "skip", defaultValue = "false")
+    private Boolean skip;
+
     @Component
     private BuildContext buildContext;
 
@@ -76,6 +82,10 @@ public final class GruntMojo extends AbstractMojo {
     }
 
     private boolean shouldExecute() {
+        if (skip) {
+            return false;
+        }
+
         // If there is no buildContext, or this is not an incremental build, always execute.
         if (buildContext == null || !buildContext.isIncremental()) {
             return true;

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
@@ -53,6 +53,12 @@ public final class GulpMojo extends AbstractMojo {
     @Parameter(property = "outputdir")
     private File outputdir;
 
+    /**
+     * Skips execution of this mojo.
+     */
+    @Parameter(property = "skip", defaultValue = "false")
+    private Boolean skip;
+
     @Component
     private BuildContext buildContext;
 
@@ -76,6 +82,10 @@ public final class GulpMojo extends AbstractMojo {
     }
     
     private boolean shouldExecute() {
+        if (skip) {
+            return false;
+        }
+
         // If there is no buildContext, or this is not an incremental build, always execute.
         if (buildContext == null || !buildContext.isIncremental()) {
             return true;

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -60,16 +60,24 @@ public final class InstallNodeAndNpmMojo extends AbstractMojo {
     @Parameter(property = "session", defaultValue = "${session}", readonly = true)
     private MavenSession session;
 
+    /**
+     * Skips execution of this mojo.
+     */
+    @Parameter(property = "skip", defaultValue = "false")
+    private Boolean skip;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        try {
-            MojoUtils.setSLF4jLogger(getLog());
-            ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session);
-            String nodeDownloadRoot = getNodeDownloadRoot();
-            String npmDownloadRoot = getNpmDownloadRoot();
-            new FrontendPluginFactory(workingDirectory, proxyConfig).getNodeAndNPMInstaller().install(nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot);
-        } catch (InstallationException e) {
-            throw MojoUtils.toMojoFailureException(e);
+        if (!skip) {
+            try {
+                MojoUtils.setSLF4jLogger(getLog());
+                ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session);
+                String nodeDownloadRoot = getNodeDownloadRoot();
+                String npmDownloadRoot = getNpmDownloadRoot();
+                new FrontendPluginFactory(workingDirectory, proxyConfig).getNodeAndNPMInstaller().install(nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot);
+            } catch (InstallationException e) {
+                throw MojoUtils.toMojoFailureException(e);
+            }
         }
     }
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
@@ -40,21 +40,33 @@ public final class KarmaRunMojo extends AbstractMojo {
     @Parameter(property = "testFailureIgnore", required = false, defaultValue = "false")
     private Boolean testFailureIgnore;
 
+    /**
+     * Skips execution of this mojo.
+     */
+    @Parameter(property = "skip", defaultValue = "${skipTests}")
+    private Boolean skip;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        try {
-            MojoUtils.setSLF4jLogger(getLog());
-            if(skipTests){
-                LoggerFactory.getLogger(KarmaRunMojo.class).info("Skipping karma tests.");
-            } else {
-                new FrontendPluginFactory(workingDirectory).getKarmaRunner()
-                        .execute("start " + karmaConfPath);
+        if (!skip) {
+            try {
+                MojoUtils.setSLF4jLogger(getLog());
+                if (skipTests) {
+                    LoggerFactory.getLogger(KarmaRunMojo.class).info("Skipping karma tests.");
+                }
+                else {
+                    new FrontendPluginFactory(workingDirectory).getKarmaRunner()
+                            .execute("start " + karmaConfPath);
+                }
             }
-        } catch (TaskRunnerException e) {
-            if (testFailureIgnore) {
-                LoggerFactory.getLogger(KarmaRunMojo.class).warn("There are ignored test failures/errors for: " + workingDirectory);
-            } else {
-                throw new MojoFailureException("Failed to run task", e);
+            catch (TaskRunnerException e) {
+                if (testFailureIgnore) {
+                    LoggerFactory.getLogger(KarmaRunMojo.class)
+                            .warn("There are ignored test failures/errors for: " + workingDirectory);
+                }
+                else {
+                    throw new MojoFailureException("Failed to run task", e);
+                }
             }
         }
     }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -39,20 +39,32 @@ public final class NpmMojo extends AbstractMojo {
     @Component
     private BuildContext buildContext;
 
+    /**
+     * Skips execution of this mojo.
+     */
+    @Parameter(property = "skip", defaultValue = "false")
+    private Boolean skip;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        File packageJson = new File(workingDirectory, "package.json");
-        if (buildContext == null || buildContext.hasDelta(packageJson) || !buildContext.isIncremental()) {
-            try {
-                setSLF4jLogger(getLog());
+        if (!skip) {
+            File packageJson = new File(workingDirectory, "package.json");
+            if (buildContext == null || buildContext.hasDelta(packageJson) || !buildContext
+                    .isIncremental()) {
+                try {
+                    setSLF4jLogger(getLog());
 
-                ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session);
-                new FrontendPluginFactory(workingDirectory, proxyConfig).getNpmRunner().execute(arguments);
-            } catch (TaskRunnerException e) {
-                throw new MojoFailureException("Failed to run task", e);
+                    ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session);
+                    new FrontendPluginFactory(workingDirectory, proxyConfig).getNpmRunner()
+                            .execute(arguments);
+                }
+                catch (TaskRunnerException e) {
+                    throw new MojoFailureException("Failed to run task", e);
+                }
             }
-        } else {
-            getLog().info("Skipping npm install as package.json unchanged");
+            else {
+                getLog().info("Skipping npm install as package.json unchanged");
+            }
         }
     }
 }


### PR DESCRIPTION
Add options for skipping all mojos. Particularly useful when multiple configurations are being used, e.g. several grunt executions with different targets for karma tests, protractor tests, main build, etc.

Related to https://github.com/eirslett/frontend-maven-plugin/issues/89