### PR TITLE
Better compat with maven release plugin conventions (all mojos)

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
@@ -27,7 +27,7 @@ public final class GruntMojo extends AbstractMojo {
     /**
      * Grunt arguments. Default is empty (runs just the "grunt" command).
      */
-    @Parameter(property = "arguments")
+    @Parameter(property = "frontend.grunt.arguments")
     private String arguments;
     
     /**

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
@@ -27,7 +27,7 @@ public final class GulpMojo extends AbstractMojo {
     /**
      * Gulp arguments. Default is empty (runs just the "gulp" command).
      */
-    @Parameter(property = "arguments")
+    @Parameter(property = "frontend.gulp.arguments")
     private String arguments;
     
     /**

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -30,7 +30,7 @@ public final class NpmMojo extends AbstractMojo {
     /**
      * npm arguments. Default is "install".
      */
-    @Parameter(defaultValue = "install", property = "arguments", required = false)
+    @Parameter(defaultValue = "install", property = "frontend.npm.arguments", required = false)
     private String arguments;
 
     @Parameter(property = "session", defaultValue = "${session}", readonly = true)


### PR DESCRIPTION
As being discussed in https://github.com/eirslett/frontend-maven-plugin/pull/109 the 'arguments' property is already used by the release plugin. Use a unique property name instead in all mojos
