### PR TITLE
m2e integration: npm goal shouldn't be run incremental builds, only on full builds

### DIFF
--- a/frontend-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/frontend-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -5,6 +5,7 @@
 			<pluginExecutionFilter>
 				<goals>
 					<goal>install-node-and-npm</goal>
+					<goal>npm</goal>
 				</goals>
 			</pluginExecutionFilter>
 			<action>
@@ -17,7 +18,6 @@
         <pluginExecution>
             <pluginExecutionFilter>
                 <goals>
-                    <goal>npm</goal>
                     <goal>gulp</goal>
                     <goal>grunt</goal>
                 </goals>


### PR DESCRIPTION
I made an error when I create the M2E lifecycle mapping. The `npm` command should only be run on full project builds, rather than on every incremental build even if the `package.json` has changed. There are lots of reasons to change the `package.json` file, that don't necessarily mean that `npm` should be run.

This speeds up incremental builds by several seconds by skipping `npm install`.
