### PR TITLE
Configuring where node gets installed

### DIFF
--- a/frontend-maven-plugin/src/it/example project/pom.xml
+++ b/frontend-maven-plugin/src/it/example project/pom.xml
@@ -14,7 +14,9 @@
                 <artifactId>frontend-maven-plugin</artifactId>
                 <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
                 <version>@project.version@</version>
-
+                <configuration>
+					<nodeInstallDirectory>target</nodeInstallDirectory>
+                </configuration>
                 <executions>
 
                     <execution>

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/BowerMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/BowerMojo.java
@@ -15,6 +15,12 @@ import java.io.File;
 public final class BowerMojo extends AbstractMojo {
 
     /**
+     * The directory to install Node and related executables.
+     */
+    @Parameter(defaultValue = "${basedir}", property = "nodeInstallDirectory", required = false)
+    private File nodeInstallDirectory;
+
+    /**
      * The base directory for running all Node commands. (Usually the directory that contains package.json)
      */
     @Parameter(defaultValue = "${basedir}", property = "workingDirectory", required = false)
@@ -30,7 +36,7 @@ public final class BowerMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
             MojoUtils.setSLF4jLogger(getLog());
-            new FrontendPluginFactory(workingDirectory).getBowerRunner().execute(arguments);
+            new FrontendPluginFactory(nodeInstallDirectory, workingDirectory).getBowerRunner().execute(arguments);
         } catch (TaskRunnerException e) {
             throw new MojoFailureException("Failed to run task", e);
         }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
@@ -19,6 +19,12 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 public final class GruntMojo extends AbstractMojo {
 
     /**
+     * The directory to install Node and related executables.
+     */
+    @Parameter(defaultValue = "${basedir}", property = "nodeInstallDirectory", required = false)
+    private File nodeInstallDirectory;
+
+    /**
      * The base directory for running all Node commands. (Usually the directory that contains package.json)
      */
     @Parameter(defaultValue = "${basedir}", property = "workingDirectory", required = false)
@@ -61,7 +67,7 @@ public final class GruntMojo extends AbstractMojo {
         if (shouldExecute()) {
             try {
                 MojoUtils.setSLF4jLogger(getLog());
-                new FrontendPluginFactory(workingDirectory).getGruntRunner().execute(arguments);
+                new FrontendPluginFactory(nodeInstallDirectory, workingDirectory).getGruntRunner().execute(arguments);
             } catch (TaskRunnerException e) {
                 throw new MojoFailureException("Failed to run task", e);
             }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
@@ -19,6 +19,12 @@ import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
 public final class GulpMojo extends AbstractMojo {
 
     /**
+     * The directory to install Node and related executables.
+     */
+    @Parameter(defaultValue = "${basedir}", property = "nodeInstallDirectory", required = false)
+    private File nodeInstallDirectory;
+
+    /**
      * The base directory for running all Node commands. (Usually the directory that contains package.json)
      */
     @Parameter(defaultValue = "${basedir}", property = "workingDirectory", required = false)
@@ -61,7 +67,7 @@ public final class GulpMojo extends AbstractMojo {
         if (shouldExecute()) {
             try {
                 MojoUtils.setSLF4jLogger(getLog());
-                new FrontendPluginFactory(workingDirectory).getGulpRunner().execute(arguments);
+                new FrontendPluginFactory(nodeInstallDirectory, workingDirectory).getGulpRunner().execute(arguments);
             } catch (TaskRunnerException e) {
                 throw new MojoFailureException("Failed to run task", e);
             }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -19,6 +19,12 @@ import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 public final class InstallNodeAndNpmMojo extends AbstractMojo {
 
     /**
+     * The directory to install Node and related executables.
+     */
+    @Parameter(defaultValue = "${basedir}", property = "nodeInstallDirectory", required = false)
+    private File nodeInstallDirectory;
+
+    /**
      * The base directory for running all Node commands. (Usually the directory that contains package.json)
      */
     @Parameter(property = "workingDirectory", defaultValue = "${basedir}")
@@ -67,7 +73,7 @@ public final class InstallNodeAndNpmMojo extends AbstractMojo {
             ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session);
             String nodeDownloadRoot = getNodeDownloadRoot();
             String npmDownloadRoot = getNpmDownloadRoot();
-            new FrontendPluginFactory(workingDirectory, proxyConfig).getNodeAndNPMInstaller().install(nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot);
+            new FrontendPluginFactory(nodeInstallDirectory, workingDirectory, proxyConfig).getNodeAndNPMInstaller().install(nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot);
         } catch (InstallationException e) {
             throw MojoUtils.toMojoFailureException(e);
         }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
@@ -17,6 +17,12 @@ import org.slf4j.LoggerFactory;
 public final class KarmaRunMojo extends AbstractMojo {
 
     /**
+     * The directory to install Node and related executables.
+     */
+    @Parameter(defaultValue = "${basedir}", property = "nodeInstallDirectory", required = false)
+    private File nodeInstallDirectory;
+
+    /**
      * The base directory for running all Node commands. (Usually the directory that contains package.json)
      */
     @Parameter(defaultValue = "${basedir}", property = "workingDirectory", required = false)
@@ -47,7 +53,7 @@ public final class KarmaRunMojo extends AbstractMojo {
             if(skipTests){
                 LoggerFactory.getLogger(KarmaRunMojo.class).info("Skipping karma tests.");
             } else {
-                new FrontendPluginFactory(workingDirectory).getKarmaRunner()
+                new FrontendPluginFactory(nodeInstallDirectory, workingDirectory).getKarmaRunner()
                         .execute("start " + karmaConfPath);
             }
         } catch (TaskRunnerException e) {

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -20,6 +20,12 @@ import static com.github.eirslett.maven.plugins.frontend.mojo.MojoUtils.setSLF4j
 
 @Mojo(name="npm",  defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public final class NpmMojo extends AbstractMojo {
+    
+    /**
+     * The directory to install Node and related executables.
+     */
+    @Parameter(defaultValue = "${basedir}", property = "nodeInstallDirectory", required = false)
+    private File nodeInstallDirectory;
 
     /**
      * The base directory for running all Node commands. (Usually the directory that contains package.json)
@@ -57,7 +63,7 @@ public final class NpmMojo extends AbstractMojo {
                     setSLF4jLogger(getLog());
     
                     ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session);
-                    new FrontendPluginFactory(workingDirectory, proxyConfig).getNpmRunner().execute(arguments);
+                    new FrontendPluginFactory(nodeInstallDirectory, workingDirectory, proxyConfig).getNpmRunner().execute(arguments);
                 } catch (TaskRunnerException e) {
                     throw new MojoFailureException("Failed to run task", e);
                 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/BowerRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/BowerRunner.java
@@ -8,12 +8,12 @@ public interface BowerRunner {
     public void execute(String args) throws TaskRunnerException;
 }
 
-final class DefaultBowerRunner extends NodeTaskExecutor implements BowerRunner {
+final class DefaultBowerRunner extends WorkingDirTaskExecutor implements BowerRunner {
 
     private static final String TASK_NAME = "bower";
     private static final String TASK_LOCATION = "/node_modules/bower/bin/bower";
 
-    DefaultBowerRunner(Platform platform, File workingDirectory) {
-        super(TASK_NAME, TASK_LOCATION, workingDirectory, platform, new ArrayList<String>());
+    DefaultBowerRunner(Platform platform, File nodeInstallDirectory, File workingDirectory) {
+        super(TASK_NAME, TASK_LOCATION, nodeInstallDirectory, workingDirectory, platform, new ArrayList<String>());
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -4,19 +4,22 @@ import java.io.File;
 
 public final class FrontendPluginFactory {
     private static final Platform defaultPlatform = Platform.guess();
+    private final File nodeInstallDirectory;
     private final File workingDirectory;
     private final ProxyConfig proxy;
 
-    public FrontendPluginFactory(File workingDirectory){
-        this(workingDirectory, null);
+    public FrontendPluginFactory(File nodeInstallDirectory, File workingDirectory){
+        this(nodeInstallDirectory, workingDirectory, null);
     }
-    public FrontendPluginFactory(File workingDirectory, ProxyConfig proxy){
+    public FrontendPluginFactory(File nodeInstallDirectory, File workingDirectory, ProxyConfig proxy){
+        this.nodeInstallDirectory = nodeInstallDirectory;
         this.workingDirectory = workingDirectory;
         this.proxy = proxy;
     }
 
     public NodeAndNPMInstaller getNodeAndNPMInstaller(){
         return new DefaultNodeAndNPMInstaller(
+                nodeInstallDirectory,
                 workingDirectory,
                 defaultPlatform,
                 new DefaultArchiveExtractor(),
@@ -24,22 +27,22 @@ public final class FrontendPluginFactory {
     }
     
     public BowerRunner getBowerRunner() {
-        return new DefaultBowerRunner(defaultPlatform, workingDirectory);
+        return new DefaultBowerRunner(defaultPlatform, nodeInstallDirectory, workingDirectory);
     }    
 
     public NpmRunner getNpmRunner() {
-        return new DefaultNpmRunner(defaultPlatform, workingDirectory, proxy);
+        return new DefaultNpmRunner(defaultPlatform, nodeInstallDirectory, workingDirectory, proxy);
     }
 
     public GruntRunner getGruntRunner(){
-        return new DefaultGruntRunner(defaultPlatform, workingDirectory);
+        return new DefaultGruntRunner(defaultPlatform, nodeInstallDirectory, workingDirectory);
     }
 
     public KarmaRunner getKarmaRunner(){
-        return new DefaultKarmaRunner(defaultPlatform, workingDirectory);
+        return new DefaultKarmaRunner(defaultPlatform, nodeInstallDirectory, workingDirectory);
     }
 
     public GulpRunner getGulpRunner(){
-        return new DefaultGulpRunner(defaultPlatform, workingDirectory);
+        return new DefaultGulpRunner(defaultPlatform, nodeInstallDirectory, workingDirectory);
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GruntRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GruntRunner.java
@@ -7,11 +7,11 @@ public interface GruntRunner {
     public void execute(String args) throws TaskRunnerException;
 }
 
-final class DefaultGruntRunner extends NodeTaskExecutor implements GruntRunner {
+final class DefaultGruntRunner extends WorkingDirTaskExecutor implements GruntRunner {
     private static final String TASK_NAME = "grunt";
     private static final String TASK_LOCATION = "/node_modules/grunt-cli/bin/grunt";
 
-    DefaultGruntRunner(Platform platform, File workingDirectory) {
-        super(TASK_NAME, TASK_LOCATION, workingDirectory, platform, Arrays.asList("--no-color"));
+    DefaultGruntRunner(Platform platform, File nodeInstallDirectory, File workingDirectory) {
+        super(TASK_NAME, TASK_LOCATION, nodeInstallDirectory, workingDirectory, platform, Arrays.asList("--no-color"));
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GulpRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GulpRunner.java
@@ -7,11 +7,11 @@ public interface GulpRunner {
     public void execute(String args) throws TaskRunnerException;
 }
 
-final class DefaultGulpRunner extends NodeTaskExecutor implements GulpRunner {
+final class DefaultGulpRunner extends WorkingDirTaskExecutor implements GulpRunner {
     private static final String TASK_NAME = "gulp";
     private static final String TASK_LOCATION = "/node_modules/gulp/bin/gulp.js";
 
-    DefaultGulpRunner(Platform platform, File workingDirectory) {
-        super(TASK_NAME, TASK_LOCATION, workingDirectory, platform, Arrays.asList("--no-color"));
+    DefaultGulpRunner(Platform platform, File nodeInstallDirectory, File workingDirectory) {
+        super(TASK_NAME, TASK_LOCATION, nodeInstallDirectory, workingDirectory, platform, Arrays.asList("--no-color"));
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/KarmaRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/KarmaRunner.java
@@ -7,11 +7,11 @@ public interface KarmaRunner {
     public void execute(String args) throws TaskRunnerException;
 }
 
-final class DefaultKarmaRunner extends NodeTaskExecutor implements KarmaRunner {
+final class DefaultKarmaRunner extends WorkingDirTaskExecutor implements KarmaRunner {
     static final String TASK_NAME = "karma";
     static final String TASK_LOCATION = "/node_modules/karma/bin/karma";
 
-    DefaultKarmaRunner(Platform platform, File workingDirectory) {
-        super(TASK_NAME, TASK_LOCATION, workingDirectory, platform, Arrays.asList("--no-colors"));
+    DefaultKarmaRunner(Platform platform, File nodeInstallDirectory, File workingDirectory) {
+        super(TASK_NAME, TASK_LOCATION, nodeInstallDirectory, workingDirectory, platform, Arrays.asList("--no-colors"));
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutor.java
@@ -8,8 +8,8 @@ import java.util.List;
 final class NodeExecutor {
     private final ProcessExecutor executor;
 
-    public NodeExecutor(File workingDirectory, List<String> arguments, Platform platform){
-        final String node = workingDirectory + Utils.normalize("/node/node");
+    public NodeExecutor(File nodeInstallDirectory, File workingDirectory, List<String> arguments, Platform platform){
+        final String node = nodeInstallDirectory + Utils.normalize("/node/node");
         this.executor = new ProcessExecutor(workingDirectory, Utils.prepend(node, arguments), platform);
     }
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
@@ -12,8 +12,8 @@ final class DefaultNpmRunner extends NodeTaskExecutor implements NpmRunner {
     static final String TASK_NAME = "npm";
     static final String TASK_LOCATION = "/node/npm/bin/npm-cli.js";
 
-    public DefaultNpmRunner(Platform platform, File workingDirectory, ProxyConfig proxy) {
-        super(TASK_NAME, TASK_LOCATION, workingDirectory, platform, buildArguments(proxy));
+    public DefaultNpmRunner(Platform platform, File nodeInstallDirectory, File workingDirectory, ProxyConfig proxy) {
+        super(TASK_NAME, TASK_LOCATION, nodeInstallDirectory, workingDirectory, platform, buildArguments(proxy));
     }
 
     private static List<String> buildArguments(ProxyConfig proxy) {

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/WorkingDirTaskExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/WorkingDirTaskExecutor.java
@@ -1,0 +1,20 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import java.io.File;
+import java.util.List;
+
+public class WorkingDirTaskExecutor extends NodeTaskExecutor {
+
+    private final File workingDirectory;
+    public WorkingDirTaskExecutor(String taskName, String taskLocation, File nodeInstallDirectory,
+            File workingDirectory, Platform platform, List<String> additionalArguments) {
+        super(taskName, taskLocation, nodeInstallDirectory, workingDirectory, platform, additionalArguments);
+        this.workingDirectory = workingDirectory;
+    }
+    
+    @Override
+    protected File getTaskInstallDirectory() {
+        return workingDirectory;
+    }
+
+}


### PR DESCRIPTION
Added a configuration element <nodeInstallDirectory> to specify where node and other executables are installed. Defaults to
${project.basedir}. Absolute paths and paths relative to project.basedir
are supported. Fixes issue
[#18](https://github.com/eirslett/frontend-maven-plugin/issues/18)