### PR TITLE
Add npm to the path when executing processes

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProcessExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProcessExecutor.java
@@ -85,12 +85,15 @@ final class ProcessExecutor {
                 }
             }
         }
-        if (pathVarValue == null) {
-            environment.put(pathVarName, workingDirectory + File.separator + "node");
+
+        StringBuilder pathBuilder = new StringBuilder();
+        if (pathVarValue != null) {
+            pathBuilder.append(pathVarValue).append(File.pathSeparator);
         }
-        else {
-            environment.put(pathVarName, workingDirectory + File.separator + "node" + File.pathSeparator + pathVarValue);
-        }
+        pathBuilder.append(workingDirectory + File.separator + "node").append(File.pathSeparator);
+        pathBuilder.append(workingDirectory + File.separator + "node/npm/bin");
+        environment.put(pathVarName, pathBuilder.toString());
+
         return pbuilder;
     }
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProcessExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProcessExecutor.java
@@ -91,7 +91,7 @@ final class ProcessExecutor {
             pathBuilder.append(pathVarValue).append(File.pathSeparator);
         }
         pathBuilder.append(workingDirectory + File.separator + "node").append(File.pathSeparator);
-        pathBuilder.append(workingDirectory + File.separator + "node/npm/bin");
+        pathBuilder.append(workingDirectory + File.separator + "node" + File.separator + "npm" + File.separator + "bin");
         environment.put(pathVarName, pathBuilder.toString());
 
         return pbuilder;


### PR DESCRIPTION
Some modules have post-install scripts that want to use the npm executable. I have simply added npm to the PATH environment variable used when running node.

See imagemin/imagemin#68 and kevva/bin-wrapper#35 for examples of this causing problems.