### PR TITLE
Adding support for the “ember” command line, from ember-cli

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/EmberMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/EmberMojo.java
@@ -1,0 +1,118 @@
+package com.github.eirslett.maven.plugins.frontend.mojo;
+
+import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
+import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.codehaus.plexus.util.Scanner;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+import java.io.File;
+
+@Mojo(name="ember", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+public final class EmberMojo extends AbstractMojo {
+
+    /**
+     * The base directory for running all Node commands. (Usually the directory that contains package.json)
+     */
+    @Parameter(defaultValue = "${basedir}", property = "workingDirectory", required = false)
+    private File workingDirectory;
+
+    /**
+     * Grunt arguments. Default is empty (runs just the "grunt" command).
+     */
+    @Parameter(property = "frontend.ember.arguments")
+    private String arguments;
+    
+    /**
+     * Files that should be checked for changes, in addition to the srcdir files.
+     * {@link #workingDirectory}.
+     */
+    @Parameter(property = "triggerfiles")
+    private File[] triggerfiles;
+    
+    /**
+     * The directory containing front end files that will be processed by grunt.
+     * If this is set then files in the directory will be checked for
+     * modifications before running grunt.
+     */
+    @Parameter(property = "srcdir")
+    private File srcdir;
+
+    /**
+     * The directory where front end files will be output by grunt. If this is
+     * set then they will be refreshed so they correctly show as modified in
+     * Eclipse.
+     */
+    @Parameter(property = "outputdir")
+    private File outputdir;
+
+    /**
+     * Skips execution of this mojo.
+     */
+    @Parameter(property = "skip.ember", defaultValue = "false")
+    private Boolean skip;
+
+    @Component
+    private BuildContext buildContext;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (shouldExecute()) {
+            try {
+                MojoUtils.setSLF4jLogger(getLog());
+                new FrontendPluginFactory(workingDirectory).getEmberRunner().execute(arguments);
+            } catch (TaskRunnerException e) {
+                throw new MojoFailureException("Failed to run task", e);
+            }
+
+            if (outputdir != null) {
+                getLog().info("Refreshing files after ember: " + outputdir);
+                buildContext.refresh(outputdir);
+            }
+        } else {
+            getLog().info("Skipping ember as no modified files in " + srcdir);
+        }
+    }
+
+    private boolean shouldExecute() {
+        if (skip) {
+            return false;
+        }
+
+        // If there is no buildContext, or this is not an incremental build, always execute.
+        if (buildContext == null || !buildContext.isIncremental()) {
+            return true;
+        }
+        
+        if (triggerfiles != null) {
+            for (int i = 0; i < triggerfiles.length; i++) {
+                if (buildContext.hasDelta(triggerfiles[i])) {
+                    return true;
+                }
+            }
+        } else {
+            // Check for changes in the Gruntfile.js
+            if (buildContext.hasDelta(new File(workingDirectory, "Gruntfile.js"))) {
+                return true;
+            }
+        }
+
+        if (srcdir == null) {
+            getLog().info("ember goal doesn't have srcdir set: not checking for modified files");
+            return true;
+        }
+
+        // Check for changes in the srcdir
+        Scanner scanner = buildContext.newScanner(srcdir);
+        scanner.scan();
+        String[] includedFiles = scanner.getIncludedFiles();
+        return (includedFiles != null && includedFiles.length > 0);
+    }
+    
+}

--- a/frontend-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/frontend-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -21,6 +21,7 @@
                     <goal>gulp</goal>
                     <goal>grunt</goal>
                     <goal>bower</goal>
+                    <goal>ember</goal>
                 </goals>
             </pluginExecutionFilter>
             <action>

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/EmberRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/EmberRunner.java
@@ -1,0 +1,17 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import java.io.File;
+import java.util.Arrays;
+
+public interface EmberRunner {
+    public void execute(String args) throws TaskRunnerException;
+}
+
+final class DefaultEmberRunner extends NodeTaskExecutor implements EmberRunner {
+    private static final String TASK_NAME = "ember";
+    private static final String TASK_LOCATION = "/node_modules/ember-cli/bin/ember";
+
+    DefaultEmberRunner(Platform platform, File workingDirectory) {
+        super(TASK_NAME, TASK_LOCATION, workingDirectory, platform, Arrays.asList(""));
+    }
+}

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -35,6 +35,10 @@ public final class FrontendPluginFactory {
         return new DefaultGruntRunner(defaultPlatform, workingDirectory);
     }
 
+    public EmberRunner getEmberRunner() {
+        return new DefaultEmberRunner(defaultPlatform, workingDirectory);
+    }
+
     public KarmaRunner getKarmaRunner(){
         return new DefaultKarmaRunner(defaultPlatform, workingDirectory);
     }


### PR DESCRIPTION
In order to be able to support ember-cli builds with this plugin via Maven, I have added an EmberMojo class, and and "ember" build goal. 

I suppose there might also be an "InstallEmberCli" mojo that executed npm install ember-cli, however. 