### PR TITLE
Maven proxy security

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -6,6 +6,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -14,6 +15,7 @@ import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
 import com.github.eirslett.maven.plugins.frontend.lib.InstallationException;
 import com.github.eirslett.maven.plugins.frontend.lib.NodeAndNPMInstaller;
 import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
 
 @Mojo(name="install-node-and-npm", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public final class InstallNodeAndNpmMojo extends AbstractMojo {
@@ -66,12 +68,15 @@ public final class InstallNodeAndNpmMojo extends AbstractMojo {
     @Parameter(property = "skip.installnodenpm", defaultValue = "false")
     private Boolean skip;
 
+    @Component(role = SettingsDecrypter.class)
+    private SettingsDecrypter decrypter;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (!skip) {
             try {
                 MojoUtils.setSLF4jLogger(getLog());
-                ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session);
+                ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session, decrypter);
                 String nodeDownloadRoot = getNodeDownloadRoot();
                 String npmDownloadRoot = getNpmDownloadRoot();
                 new FrontendPluginFactory(workingDirectory, proxyConfig).getNodeAndNPMInstaller().install(nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot);

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
@@ -5,33 +5,32 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.settings.Proxy;
+import org.apache.maven.settings.crypto.DefaultSettingsDecryptionRequest;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.apache.maven.settings.crypto.SettingsDecryptionResult;
 import org.slf4j.impl.StaticLoggerBinder;
 
 class MojoUtils {
-    static <E extends Throwable> MojoFailureException toMojoFailureException(E e){
-        return new MojoFailureException(e.getMessage()+": "+e.getCause().getMessage(), e);
+    static <E extends Throwable> MojoFailureException toMojoFailureException(E e) {
+        return new MojoFailureException(e.getMessage() + ": " + e.getCause().getMessage(), e);
     }
 
-    static void setSLF4jLogger(Log log){
+    static void setSLF4jLogger(Log log) {
         StaticLoggerBinder.getSingleton().setLog(log);
     }
 
-    static ProxyConfig getProxyConfig(MavenSession mavenSession){
-        if(
-                mavenSession == null ||
+    static ProxyConfig getProxyConfig(MavenSession mavenSession, SettingsDecrypter decrypter) {
+        if (mavenSession == null ||
                 mavenSession.getSettings() == null ||
                 mavenSession.getSettings().getActiveProxy() == null ||
-                !mavenSession.getSettings().getActiveProxy().isActive()
-                ){
+                !mavenSession.getSettings().getActiveProxy().isActive()) {
             return null;
         } else {
             Proxy mavenProxy = mavenSession.getSettings().getActiveProxy();
-            return new ProxyConfig(
-                    mavenProxy.getProtocol(),
-                    mavenProxy.getHost(),
-                    mavenProxy.getPort(),
-                    mavenProxy.getUsername(),
-                    mavenProxy.getPassword());
+            final DefaultSettingsDecryptionRequest decryptionRequest = new DefaultSettingsDecryptionRequest(mavenProxy);
+            SettingsDecryptionResult decryptedResult = decrypter.decrypt(decryptionRequest);
+            mavenProxy = decryptedResult.getProxy();
+            return new ProxyConfig(mavenProxy.getProtocol(), mavenProxy.getHost(), mavenProxy.getPort(), mavenProxy.getUsername(), mavenProxy.getPassword());
         }
     }
 }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -14,6 +14,8 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.codehaus.plexus.component.annotations.Requirement;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
 import static com.github.eirslett.maven.plugins.frontend.mojo.MojoUtils.setSLF4jLogger;
@@ -39,6 +41,9 @@ public final class NpmMojo extends AbstractMojo {
     @Component
     private BuildContext buildContext;
 
+    @Component(role = SettingsDecrypter.class)
+    private SettingsDecrypter decrypter;
+
     /**
      * Skips execution of this mojo.
      */
@@ -54,7 +59,7 @@ public final class NpmMojo extends AbstractMojo {
                 try {
                     setSLF4jLogger(getLog());
 
-                    ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session);
+                    ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session, decrypter);
                     new FrontendPluginFactory(workingDirectory, proxyConfig).getNpmRunner()
                             .execute(arguments);
                 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeTaskExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeTaskExecutor.java
@@ -1,5 +1,7 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
+import static com.github.eirslett.maven.plugins.frontend.lib.Utils.*;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -7,8 +9,6 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static com.github.eirslett.maven.plugins.frontend.lib.Utils.*;
 
 abstract class NodeTaskExecutor {
     private final Logger logger;
@@ -43,20 +43,29 @@ abstract class NodeTaskExecutor {
     }
 
     private List<String> getArguments(String args) {
-        List<String> arguments =  new ArrayList<String>();
-        if(args != null && !args.equals("null") && !args.isEmpty()) {
+        List<String> arguments = new ArrayList<String>();
+        if (args != null && !args.equals("null") && !args.isEmpty()) {
             arguments.addAll(Arrays.asList(args.split("\\s+")));
         }
 
-        for(String argument: additionalArguments){
-            if(!arguments.contains(argument)){
+        for (String argument : additionalArguments) {
+            if (!arguments.contains(argument)) {
                 arguments.add(argument);
             }
         }
         return arguments;
     }
 
-    private static String taskToString(String taskName, List<String> commands) {
-        return "'" + taskName + " " + implode(" ",commands) + "'";
+    private static String taskToString(String taskName, List<String> arguments) {
+        List<String> clonedArguments = new ArrayList<String>(arguments);
+        for (int i = 0; i < clonedArguments.size(); i++) {
+            final String s = clonedArguments.get(i);
+            final boolean maskMavenProxyPassword = s.contains("proxy=");
+            if (maskMavenProxyPassword) {
+                final String first = s.replaceFirst("//(?<keep>.*):.*@", "//${keep}:***@");
+                clonedArguments.set(i, first);
+            }
+        }
+        return "'" + taskName + " " + implode(" ", clonedArguments) + "'";
     }
 }


### PR DESCRIPTION
Maven supports encrypted passwords for server and proxy configurations in the settings.xml (see http://maven.apache.org/guides/mini/guide-encryption.html).
This pull request makes it possible to have the encrypted password in the settings.xml.

Furthermore, when the plugin runs it logs the password in clear/plain text which I think could be improved upon so I am masking the password when the arguments are displayed in the log.

This feature will make it possible for me to use it at the  company I work for =)