### PR TITLE
Guarantee unix style file separator characters in download URL.

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FileDownloader.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FileDownloader.java
@@ -45,13 +45,15 @@ final class DefaultFileDownloader implements FileDownloader {
     }
 
     public void download(String downloadUrl, String destination) throws DownloadException {
+        String fixedDownloadUrl = downloadUrl;
         try {
-            URI downloadURI = new URI(downloadUrl);
+            fixedDownloadUrl = FilenameUtils.separatorsToUnix(fixedDownloadUrl);
+            URI downloadURI = new URI(fixedDownloadUrl);
             if ("file".equalsIgnoreCase(downloadURI.getScheme())) {
                 FileUtils.copyFile(new File(downloadURI), new File(destination));
             }
             else {
-                CloseableHttpResponse response = execute(downloadUrl);
+                CloseableHttpResponse response = execute(fixedDownloadUrl);
                 int statusCode = response.getStatusLine().getStatusCode();
                 if(statusCode != 200){
                     throw new DownloadException("Got error code "+ statusCode +" from the server.");
@@ -63,10 +65,10 @@ final class DefaultFileDownloader implements FileDownloader {
                 fos.close();
             }
         } catch (IOException e) {
-            throw new DownloadException("Could not download "+downloadUrl, e);
+            throw new DownloadException("Could not download "+fixedDownloadUrl, e);
         }
         catch (URISyntaxException e) {
-            throw new DownloadException("Could not download "+downloadUrl, e);
+            throw new DownloadException("Could not download "+fixedDownloadUrl, e);
         }
     }
 


### PR DESCRIPTION
This pull request is intended to ensure the download works when the "file://" protocol is used as `nodeDownloadRoot`. Take the following example:

```XML
<execution>
	<id>install node and npm</id>
	<goals>
		<goal>install-node-and-npm</goal>
	</goals>
	<phase>generate-resources</phase>
	<configuration>
		<nodeVersion>v0.12.0</nodeVersion>
		<npmVersion>2.5.1</npmVersion>
		<nodeDownloadRoot>file:///${project.build.directory}/nodeunpacked/</nodeDownloadRoot>
	</configuration>
</execution>
```

This would result in something like this on a Mac:

`file:////Users/rick/projects/myapp/target/nodeunpacked/`

which works despite the extra forwardslash in `file:////`.

But on Windows it results in something like this:

`file:///C:\Users\rick\projects\myapp\target/nodeunpacked/`

which breaks because of the backslashes.

We do not have control over the use of backslashes when we use built-in maven properties (like `${project.build.directory}`).

This proposed change ensures that backslashes are converted to forwardslashes before being used as a download URL. Thus our Windows URL would become:

`file:///C:/Users/rick/projects/myapp/target/nodeunpacked/`

Which works!