### PR TITLE
SLF4J done the right way

### DIFF
--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -11,11 +11,14 @@
     <packaging>maven-plugin</packaging>
 
     <name>Maven Frontend Plugin</name>
+    <prerequisites>
+        <maven>3.1.0</maven>
+    </prerequisites>
 
     <description>
         This Maven plugin lets you install Node/NPM locally
         for your project, install dependencies with NPM,
-        install dependencies with bower, run Grunt or gulp tasks, 
+        install dependencies with bower, run Grunt or gulp tasks,
         and/or run Karma tests.
     </description>
 
@@ -50,7 +53,7 @@
             <artifactId>slf4j-maven-plugin-log</artifactId>
             <version>1.0.0</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.sonatype.plexus</groupId>
             <artifactId>plexus-build-api</artifactId>
@@ -83,6 +86,22 @@
 
             <!-- For the integration test -->
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>mrm-maven-plugin</artifactId>
+                <version>1.0-beta-2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>start</goal>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                  <propertyName>repository.proxy.url</propertyName>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
                 <version>1.8</version>
@@ -93,6 +112,9 @@
                     <settingsFile>src/it/settings.xml</settingsFile>
                     <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
                     <streamLogs>true</streamLogs>
+                    <filterProperties>
+                        <repository.proxy.url>${repository.proxy.url}</repository.proxy.url>
+                    </filterProperties>
                 </configuration>
 
                 <executions>

--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -49,12 +49,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.googlecode.slf4j-maven-plugin-log</groupId>
-            <artifactId>slf4j-maven-plugin-log</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.sonatype.plexus</groupId>
             <artifactId>plexus-build-api</artifactId>
             <version>0.0.7</version>

--- a/frontend-maven-plugin/src/it/settings.xml
+++ b/frontend-maven-plugin/src/it/settings.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0"?>
 <settings>
-    <!-- Configuration for the maven-invoker-plugin (integration test) -->
+  <mirrors>
+    <mirror>
+      <id>mrm-maven-plugin</id>
+      <name>Mock Repository Manager</name>
+      <url>@repository.proxy.url@</url>
+      <mirrorOf>*</mirrorOf>
+    </mirror>
+  </mirrors>
     <profiles>
         <profile>
             <id>it-repo</id>
@@ -10,7 +17,7 @@
             <repositories>
                 <repository>
                     <id>local.central</id>
-                    <url>@localRepositoryUrl@</url>
+                    <url>@repository.proxy.url@</url>
                     <releases>
                         <enabled>true</enabled>
                     </releases>
@@ -22,7 +29,7 @@
             <pluginRepositories>
                 <pluginRepository>
                     <id>local.central</id>
-                    <url>@localRepositoryUrl@</url>
+                    <url>@repository.proxy.url@</url>
                     <releases>
                         <enabled>true</enabled>
                     </releases>

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/BowerMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/BowerMojo.java
@@ -36,7 +36,6 @@ public final class BowerMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         if(!skip) {
             try {
-                MojoUtils.setSLF4jLogger(getLog());
                 new FrontendPluginFactory(workingDirectory).getBowerRunner().execute(arguments);
             } catch (TaskRunnerException e) {
                 throw new MojoFailureException("Failed to run task", e);

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/EmberMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/EmberMojo.java
@@ -28,14 +28,14 @@ public final class EmberMojo extends AbstractMojo {
      */
     @Parameter(property = "frontend.ember.arguments")
     private String arguments;
-    
+
     /**
      * Files that should be checked for changes, in addition to the srcdir files.
      * {@link #workingDirectory}.
      */
     @Parameter(property = "triggerfiles")
     private File[] triggerfiles;
-    
+
     /**
      * The directory containing front end files that will be processed by grunt.
      * If this is set then files in the directory will be checked for
@@ -65,7 +65,6 @@ public final class EmberMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (shouldExecute()) {
             try {
-                MojoUtils.setSLF4jLogger(getLog());
                 new FrontendPluginFactory(workingDirectory).getEmberRunner().execute(arguments);
             } catch (TaskRunnerException e) {
                 throw new MojoFailureException("Failed to run task", e);
@@ -89,7 +88,7 @@ public final class EmberMojo extends AbstractMojo {
         if (buildContext == null || !buildContext.isIncremental()) {
             return true;
         }
-        
+
         if (triggerfiles != null) {
             for (int i = 0; i < triggerfiles.length; i++) {
                 if (buildContext.hasDelta(triggerfiles[i])) {
@@ -114,5 +113,5 @@ public final class EmberMojo extends AbstractMojo {
         String[] includedFiles = scanner.getIncludedFiles();
         return (includedFiles != null && includedFiles.length > 0);
     }
-    
+
 }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
@@ -29,14 +29,14 @@ public final class GruntMojo extends AbstractMojo {
      */
     @Parameter(property = "frontend.grunt.arguments")
     private String arguments;
-    
+
     /**
      * Files that should be checked for changes, in addition to the srcdir files.
      * Defaults to Gruntfile.js in the {@link #workingDirectory}.
      */
     @Parameter(property = "triggerfiles")
     private File[] triggerfiles;
-    
+
     /**
      * The directory containing front end files that will be processed by grunt.
      * If this is set then files in the directory will be checked for
@@ -66,7 +66,6 @@ public final class GruntMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (shouldExecute()) {
             try {
-                MojoUtils.setSLF4jLogger(getLog());
                 new FrontendPluginFactory(workingDirectory).getGruntRunner().execute(arguments);
             } catch (TaskRunnerException e) {
                 throw new MojoFailureException("Failed to run task", e);
@@ -90,7 +89,7 @@ public final class GruntMojo extends AbstractMojo {
         if (buildContext == null || !buildContext.isIncremental()) {
             return true;
         }
-        
+
         if (triggerfiles != null) {
             for (int i = 0; i < triggerfiles.length; i++) {
                 if (buildContext.hasDelta(triggerfiles[i])) {
@@ -115,5 +114,5 @@ public final class GruntMojo extends AbstractMojo {
         String[] includedFiles = scanner.getIncludedFiles();
         return (includedFiles != null && includedFiles.length > 0);
     }
-    
+
 }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
@@ -29,14 +29,14 @@ public final class GulpMojo extends AbstractMojo {
      */
     @Parameter(property = "frontend.gulp.arguments")
     private String arguments;
-    
+
     /**
      * Files that should be checked for changes, in addition to the srcdir files.
      * Defaults to gulpfile.js in the {@link #workingDirectory}.
      */
     @Parameter(property = "triggerfiles")
     private File[] triggerfiles;
-    
+
     /**
      * The directory containing front end files that will be processed by gulp.
      * If this is set then files in the directory will be checked for
@@ -66,7 +66,6 @@ public final class GulpMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (shouldExecute()) {
             try {
-                MojoUtils.setSLF4jLogger(getLog());
                 new FrontendPluginFactory(workingDirectory).getGulpRunner().execute(arguments);
             } catch (TaskRunnerException e) {
                 throw new MojoFailureException("Failed to run task", e);
@@ -80,7 +79,7 @@ public final class GulpMojo extends AbstractMojo {
             getLog().info("Skipping gulp as no modified files in " + srcdir);
         }
     }
-    
+
     private boolean shouldExecute() {
         if (skip) {
             return false;
@@ -90,7 +89,7 @@ public final class GulpMojo extends AbstractMojo {
         if (buildContext == null || !buildContext.isIncremental()) {
             return true;
         }
-        
+
         if (triggerfiles != null) {
             for (int i = 0; i < triggerfiles.length; i++) {
                 if (buildContext.hasDelta(triggerfiles[i])) {
@@ -115,5 +114,5 @@ public final class GulpMojo extends AbstractMojo {
         String[] includedFiles = scanner.getIncludedFiles();
         return (includedFiles != null && includedFiles.length > 0);
     }
-    
+
 }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -75,7 +75,6 @@ public final class InstallNodeAndNpmMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (!skip) {
             try {
-                MojoUtils.setSLF4jLogger(getLog());
                 ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session, decrypter);
                 String nodeDownloadRoot = getNodeDownloadRoot();
                 String npmDownloadRoot = getNpmDownloadRoot();

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
@@ -50,7 +50,6 @@ public final class KarmaRunMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (!skip) {
             try {
-                MojoUtils.setSLF4jLogger(getLog());
                 if (skipTests) {
                     LoggerFactory.getLogger(KarmaRunMojo.class).info("Skipping karma tests.");
                 }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
@@ -3,20 +3,14 @@ package com.github.eirslett.maven.plugins.frontend.mojo;
 import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.crypto.DefaultSettingsDecryptionRequest;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.apache.maven.settings.crypto.SettingsDecryptionResult;
-import org.slf4j.impl.StaticLoggerBinder;
 
 class MojoUtils {
     static <E extends Throwable> MojoFailureException toMojoFailureException(E e) {
         return new MojoFailureException(e.getMessage() + ": " + e.getCause().getMessage(), e);
-    }
-
-    static void setSLF4jLogger(Log log) {
-        StaticLoggerBinder.getSingleton().setLog(log);
     }
 
     static ProxyConfig getProxyConfig(MavenSession mavenSession, SettingsDecrypter decrypter) {

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -15,10 +15,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.sonatype.plexus.build.incremental.BuildContext;
-
-import static com.github.eirslett.maven.plugins.frontend.mojo.MojoUtils.setSLF4jLogger;
 
 @Mojo(name="npm",  defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public final class NpmMojo extends AbstractMojo {
@@ -37,7 +34,7 @@ public final class NpmMojo extends AbstractMojo {
 
     @Parameter(property = "session", defaultValue = "${session}", readonly = true)
     private MavenSession session;
-    
+
     @Component
     private BuildContext buildContext;
 
@@ -57,8 +54,6 @@ public final class NpmMojo extends AbstractMojo {
             if (buildContext == null || buildContext.hasDelta(packageJson) || !buildContext
                     .isIncremental()) {
                 try {
-                    setSLF4jLogger(getLog());
-
                     ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session, decrypter);
                     new FrontendPluginFactory(workingDirectory, proxyConfig).getNpmRunner()
                             .execute(arguments);


### PR DESCRIPTION
* [Maven 3.1.x uses SLF4J as built in logger](http://maven.apache.org/maven-logging.html)
* With Maven 3.3.1 the shim that has been used actually breaks the build.
* The shim is pointless anyway as the minimum version of Maven for this plugin is 3.1.0