### PR TITLE
Try to fix build - upgrade versions

### DIFF
--- a/frontend-maven-plugin/src/it/example project/npm-shrinkwrap.json
+++ b/frontend-maven-plugin/src/it/example project/npm-shrinkwrap.json
@@ -2,273 +2,1974 @@
   "name": "example",
   "version": "0.0.1",
   "dependencies": {
+    "bower": {
+      "version": "1.3.12",
+      "from": "bower@>=1.3.12 <1.4.0",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.3.12.tgz",
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.5",
+          "from": "abbrev@>=1.0.0 <2.0.0"
+        },
+        "archy": {
+          "version": "0.0.2",
+          "from": "archy@0.0.2",
+          "resolved": "https://registry.npmjs.org/archy/-/archy-0.0.2.tgz"
+        },
+        "bower-config": {
+          "version": "0.5.2",
+          "from": "bower-config@>=0.5.2 <0.6.0",
+          "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.2.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <2.1.0"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.0 <0.7.0",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@>=0.0.2 <0.1.0"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.0.3",
+              "from": "osenv@0.0.3",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
+            }
+          }
+        },
+        "bower-endpoint-parser": {
+          "version": "0.2.2",
+          "from": "bower-endpoint-parser@>=0.2.2 <0.3.0",
+          "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz"
+        },
+        "bower-json": {
+          "version": "0.4.0",
+          "from": "bower-json@>=0.4.0 <0.5.0",
+          "dependencies": {
+            "deep-extend": {
+              "version": "0.2.11",
+              "from": "deep-extend@>=0.2.5 <0.3.0",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <2.1.0"
+            },
+            "intersect": {
+              "version": "0.0.3",
+              "from": "intersect@>=0.0.3 <0.1.0"
+            }
+          }
+        },
+        "bower-logger": {
+          "version": "0.2.2",
+          "from": "bower-logger@>=0.2.2 <0.3.0"
+        },
+        "bower-registry-client": {
+          "version": "0.2.4",
+          "from": "bower-registry-client@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.4.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.8 <0.3.0"
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <2.1.0"
+            },
+            "lru-cache": {
+              "version": "2.3.1",
+              "from": "lru-cache@>=2.3.0 <2.4.0"
+            },
+            "request": {
+              "version": "2.51.0",
+              "from": "request@>=2.51.0 <2.52.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.8.0",
+                  "from": "caseless@>=0.8.0 <0.9.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@>=0.5.0 <0.6.0"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.0",
+                      "from": "async@>=0.9.0 <0.10.0"
+                    },
+                    "mime-types": {
+                      "version": "2.0.10",
+                      "from": "mime-types@>=2.0.3 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.8.0",
+                          "from": "mime-db@>=1.8.0 <1.9.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "mime-types@>=1.0.1 <1.1.0"
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "qs": {
+                  "version": "2.3.3",
+                  "from": "qs@>=2.3.1 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0"
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "from": "tough-cookie@>=0.12.0",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@>=0.2.0",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.5.0",
+                  "from": "oauth-sign@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                },
+                "hawk": {
+                  "version": "1.1.1",
+                  "from": "hawk@1.1.1",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@>=0.9.0 <0.10.0"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@>=0.4.0 <0.5.0"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@>=0.2.0 <0.3.0"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@>=0.2.0 <0.3.0"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "request-replay": {
+              "version": "0.2.0",
+              "from": "request-replay@>=0.2.0 <0.3.0"
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            }
+          }
+        },
+        "cardinal": {
+          "version": "0.4.0",
+          "from": "cardinal@0.4.0",
+          "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.0.tgz",
+          "dependencies": {
+            "redeyed": {
+              "version": "0.4.4",
+              "from": "redeyed@>=0.4.0 <0.5.0",
+              "dependencies": {
+                "esprima": {
+                  "version": "1.0.4",
+                  "from": "esprima@>=1.0.4 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                }
+              }
+            }
+          }
+        },
+        "chalk": {
+          "version": "0.5.0",
+          "from": "chalk@0.5.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.0.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0"
+            }
+          }
+        },
+        "chmodr": {
+          "version": "0.1.0",
+          "from": "chmodr@0.1.0",
+          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz"
+        },
+        "decompress-zip": {
+          "version": "0.0.8",
+          "from": "decompress-zip@0.0.8",
+          "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.0.8.tgz",
+          "dependencies": {
+            "mkpath": {
+              "version": "0.1.0",
+              "from": "mkpath@>=0.1.0 <0.2.0"
+            },
+            "binary": {
+              "version": "0.3.0",
+              "from": "binary@>=0.3.0 <0.4.0",
+              "dependencies": {
+                "chainsaw": {
+                  "version": "0.1.0",
+                  "from": "chainsaw@>=0.1.0 <0.2.0",
+                  "dependencies": {
+                    "traverse": {
+                      "version": "0.3.9",
+                      "from": "traverse@>=0.3.0 <0.4.0"
+                    }
+                  }
+                },
+                "buffers": {
+                  "version": "0.1.1",
+                  "from": "buffers@>=0.1.1 <0.2.0"
+                }
+              }
+            },
+            "touch": {
+              "version": "0.0.2",
+              "from": "touch@0.0.2",
+              "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.2.tgz",
+              "dependencies": {
+                "nopt": {
+                  "version": "1.0.10",
+                  "from": "nopt@>=1.0.10 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.8 <1.2.0",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0"
+                }
+              }
+            },
+            "nopt": {
+              "version": "2.2.1",
+              "from": "nopt@>=2.2.0 <2.3.0"
+            }
+          }
+        },
+        "fstream": {
+          "version": "1.0.4",
+          "from": "fstream@>=1.0.2 <1.1.0",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.4.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <2.1.0"
+            }
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.2",
+          "from": "fstream-ignore@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0"
+            },
+            "minimatch": {
+              "version": "2.0.4",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "4.0.6",
+          "from": "glob@>=4.0.2 <4.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0"
+            },
+            "minimatch": {
+              "version": "1.0.0",
+              "from": "minimatch@>=1.0.0 <2.0.0",
+              "dependencies": {
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0"
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@>=1.3.0 <2.0.0",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "3.0.6",
+          "from": "graceful-fs@>=3.0.1 <3.1.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+        },
+        "handlebars": {
+          "version": "2.0.0",
+          "from": "handlebars@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
+          "dependencies": {
+            "optimist": {
+              "version": "0.3.7",
+              "from": "optimist@>=0.3.0 <0.4.0",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@>=0.0.2 <0.1.0"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.3.6",
+              "from": "uglify-js@>=2.3.0 <2.4.0",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0"
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.7 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "inquirer": {
+          "version": "0.7.1",
+          "from": "inquirer@0.7.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.7.1.tgz",
+          "dependencies": {
+            "cli-color": {
+              "version": "0.3.3",
+              "from": "cli-color@>=0.3.2 <0.4.0",
+              "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "from": "d@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.6",
+                  "from": "es5-ext@>=0.10.6 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
+                  "dependencies": {
+                    "es6-iterator": {
+                      "version": "0.1.3",
+                      "from": "es6-iterator@>=0.1.3 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
+                },
+                "memoizee": {
+                  "version": "0.3.8",
+                  "from": "memoizee@>=0.3.8 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
+                  "dependencies": {
+                    "es6-weak-map": {
+                      "version": "0.1.3",
+                      "from": "es6-weak-map@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.3.tgz",
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "from": "es6-iterator@>=0.1.3 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                        },
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "from": "es6-symbol@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "event-emitter": {
+                      "version": "0.3.3",
+                      "from": "event-emitter@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                    },
+                    "lru-queue": {
+                      "version": "0.1.0",
+                      "from": "lru-queue@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+                    },
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "next-tick@>=0.2.2 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                    }
+                  }
+                },
+                "timers-ext": {
+                  "version": "0.1.0",
+                  "from": "timers-ext@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+                  "dependencies": {
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "next-tick@>=0.2.2 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "figures": {
+              "version": "1.3.5",
+              "from": "figures@>=1.3.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+            },
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0"
+            },
+            "mute-stream": {
+              "version": "0.0.4",
+              "from": "mute-stream@0.0.4",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+            },
+            "readline2": {
+              "version": "0.1.1",
+              "from": "readline2@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "rx": {
+              "version": "2.5.2",
+              "from": "rx@>=2.2.27 <3.0.0",
+              "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.2.tgz"
+            },
+            "through": {
+              "version": "2.3.7",
+              "from": "through@>=2.3.4 <2.4.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+            }
+          }
+        },
+        "insight": {
+          "version": "0.4.3",
+          "from": "insight@0.4.3",
+          "resolved": "https://registry.npmjs.org/insight/-/insight-0.4.3.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.0",
+              "from": "async@>=0.9.0 <0.10.0"
+            },
+            "chalk": {
+              "version": "0.5.1",
+              "from": "chalk@>=0.5.1 <0.6.0",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "1.1.0",
+                  "from": "ansi-styles@>=1.1.0 <2.0.0"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "0.1.0",
+                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "0.3.0",
+                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "0.2.0",
+                  "from": "supports-color@>=0.2.0 <0.3.0"
+                }
+              }
+            },
+            "configstore": {
+              "version": "0.3.2",
+              "from": "configstore@>=0.3.1 <0.4.0",
+              "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+              "dependencies": {
+                "js-yaml": {
+                  "version": "3.2.7",
+                  "from": "js-yaml@>=3.1.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "1.0.2",
+                      "from": "argparse@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "3.6.0",
+                          "from": "lodash@>=3.2.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+                        },
+                        "sprintf-js": {
+                          "version": "1.0.2",
+                          "from": "sprintf-js@>=1.0.2 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "2.0.0",
+                      "from": "esprima@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "2.0.0",
+                  "from": "object-assign@>=2.0.0 <3.0.0"
+                },
+                "user-home": {
+                  "version": "1.1.1",
+                  "from": "user-home@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                },
+                "uuid": {
+                  "version": "2.0.1",
+                  "from": "uuid@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+                },
+                "xdg-basedir": {
+                  "version": "1.0.1",
+                  "from": "xdg-basedir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
+                }
+              }
+            },
+            "inquirer": {
+              "version": "0.6.0",
+              "from": "inquirer@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.6.0.tgz",
+              "dependencies": {
+                "cli-color": {
+                  "version": "0.3.3",
+                  "from": "cli-color@>=0.3.2 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "d@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                    },
+                    "es5-ext": {
+                      "version": "0.10.6",
+                      "from": "es5-ext@>=0.10.6 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "from": "es6-iterator@>=0.1.3 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                        },
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "from": "es6-symbol@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "memoizee": {
+                      "version": "0.3.8",
+                      "from": "memoizee@>=0.3.8 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
+                      "dependencies": {
+                        "es6-weak-map": {
+                          "version": "0.1.3",
+                          "from": "es6-weak-map@>=0.1.2 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.3.tgz",
+                          "dependencies": {
+                            "es6-iterator": {
+                              "version": "0.1.3",
+                              "from": "es6-iterator@>=0.1.3 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                            },
+                            "es6-symbol": {
+                              "version": "2.0.1",
+                              "from": "es6-symbol@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "event-emitter": {
+                          "version": "0.3.3",
+                          "from": "event-emitter@>=0.3.1 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                        },
+                        "lru-queue": {
+                          "version": "0.1.0",
+                          "from": "lru-queue@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+                        },
+                        "next-tick": {
+                          "version": "0.2.2",
+                          "from": "next-tick@>=0.2.2 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                        }
+                      }
+                    },
+                    "timers-ext": {
+                      "version": "0.1.0",
+                      "from": "timers-ext@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+                      "dependencies": {
+                        "next-tick": {
+                          "version": "0.2.2",
+                          "from": "next-tick@>=0.2.2 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "2.4.1",
+                  "from": "lodash@>=2.4.1 <2.5.0"
+                },
+                "mute-stream": {
+                  "version": "0.0.4",
+                  "from": "mute-stream@0.0.4",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                },
+                "readline2": {
+                  "version": "0.1.1",
+                  "from": "readline2@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+                  "dependencies": {
+                    "strip-ansi": {
+                      "version": "2.0.1",
+                      "from": "strip-ansi@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "1.1.1",
+                          "from": "ansi-regex@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "rx": {
+                  "version": "2.5.2",
+                  "from": "rx@>=2.2.27 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.2.tgz"
+                },
+                "through": {
+                  "version": "2.3.7",
+                  "from": "through@>=2.3.4 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+                }
+              }
+            },
+            "lodash.debounce": {
+              "version": "2.4.1",
+              "from": "lodash.debounce@>=2.4.1 <3.0.0",
+              "dependencies": {
+                "lodash.isfunction": {
+                  "version": "2.4.1",
+                  "from": "lodash.isfunction@>=2.4.1 <2.5.0"
+                },
+                "lodash.isobject": {
+                  "version": "2.4.1",
+                  "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                  "dependencies": {
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "lodash._objecttypes@>=2.4.1 <2.5.0"
+                    }
+                  }
+                },
+                "lodash.now": {
+                  "version": "2.4.1",
+                  "from": "lodash.now@>=2.4.1 <2.5.0",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "lodash._isnative@>=2.4.1 <2.5.0"
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "1.0.0",
+              "from": "object-assign@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
+            },
+            "os-name": {
+              "version": "1.0.3",
+              "from": "os-name@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
+              "dependencies": {
+                "osx-release": {
+                  "version": "1.0.0",
+                  "from": "osx-release@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.0.0.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.1.1",
+                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                    }
+                  }
+                },
+                "win-release": {
+                  "version": "1.0.0",
+                  "from": "win-release@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.0.0.tgz"
+                }
+              }
+            },
+            "tough-cookie": {
+              "version": "0.12.1",
+              "from": "tough-cookie@>=0.12.1 <0.13.0",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@>=0.2.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "is-root": {
+          "version": "1.0.0",
+          "from": "is-root@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
+        },
+        "junk": {
+          "version": "1.0.1",
+          "from": "junk@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.1.tgz"
+        },
+        "lockfile": {
+          "version": "1.0.0",
+          "from": "lockfile@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.0.tgz"
+        },
+        "lru-cache": {
+          "version": "2.5.2",
+          "from": "lru-cache@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "from": "mkdirp@0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "mout": {
+          "version": "0.9.1",
+          "from": "mout@>=0.9.0 <0.10.0"
+        },
+        "nopt": {
+          "version": "3.0.1",
+          "from": "nopt@>=3.0.0 <3.1.0"
+        },
+        "opn": {
+          "version": "1.0.1",
+          "from": "opn@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.1.tgz"
+        },
+        "osenv": {
+          "version": "0.1.0",
+          "from": "osenv@0.1.0",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
+        },
+        "p-throttler": {
+          "version": "0.1.0",
+          "from": "p-throttler@0.1.0",
+          "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.0.tgz",
+          "dependencies": {
+            "q": {
+              "version": "0.9.7",
+              "from": "q@>=0.9.2 <0.10.0",
+              "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+            }
+          }
+        },
+        "promptly": {
+          "version": "0.2.0",
+          "from": "promptly@0.2.0",
+          "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
+          "dependencies": {
+            "read": {
+              "version": "1.0.5",
+              "from": "read@>=1.0.4 <1.1.0",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.4",
+                  "from": "mute-stream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                }
+              }
+            }
+          }
+        },
+        "q": {
+          "version": "1.0.1",
+          "from": "q@>=1.0.1 <1.1.0"
+        },
+        "request": {
+          "version": "2.42.0",
+          "from": "request@2.42.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
+          "dependencies": {
+            "bl": {
+              "version": "0.9.4",
+              "from": "bl@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.6.0",
+              "from": "caseless@>=0.6.0 <0.7.0"
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "forever-agent@>=0.5.0 <0.6.0"
+            },
+            "qs": {
+              "version": "1.2.2",
+              "from": "qs@>=1.2.0 <1.3.0"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.0",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0"
+            },
+            "mime-types": {
+              "version": "1.0.2",
+              "from": "mime-types@>=1.0.1 <1.1.0"
+            },
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.0",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0"
+            },
+            "tough-cookie": {
+              "version": "0.12.1",
+              "from": "tough-cookie@>=0.12.0",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@>=0.2.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                }
+              }
+            },
+            "form-data": {
+              "version": "0.1.4",
+              "from": "form-data@>=0.1.0 <0.2.0",
+              "dependencies": {
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@>=1.2.11 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "async": {
+                  "version": "0.9.0",
+                  "from": "async@>=0.9.0 <0.10.0"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "http-signature@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "asn1@0.1.11",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "ctype@0.5.3",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.4.0",
+              "from": "oauth-sign@>=0.4.0 <0.5.0"
+            },
+            "hawk": {
+              "version": "1.1.1",
+              "from": "hawk@1.1.1",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "0.9.1",
+                  "from": "hoek@>=0.9.0 <0.10.0"
+                },
+                "boom": {
+                  "version": "0.4.2",
+                  "from": "boom@>=0.4.0 <0.5.0"
+                },
+                "cryptiles": {
+                  "version": "0.2.2",
+                  "from": "cryptiles@>=0.2.0 <0.3.0"
+                },
+                "sntp": {
+                  "version": "0.2.4",
+                  "from": "sntp@>=0.2.0 <0.3.0"
+                }
+              }
+            },
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "aws-sign2@>=0.5.0 <0.6.0"
+            },
+            "stringstream": {
+              "version": "0.0.4",
+              "from": "stringstream@>=0.0.4 <0.1.0"
+            }
+          }
+        },
+        "request-progress": {
+          "version": "0.3.0",
+          "from": "request-progress@0.3.0",
+          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.0.tgz",
+          "dependencies": {
+            "throttleit": {
+              "version": "0.0.2",
+              "from": "throttleit@>=0.0.2 <0.1.0"
+            }
+          }
+        },
+        "retry": {
+          "version": "0.6.0",
+          "from": "retry@0.6.0",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "rimraf@>=2.2.0 <2.3.0"
+        },
+        "semver": {
+          "version": "2.3.2",
+          "from": "semver@>=2.3.0 <2.4.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+        },
+        "shell-quote": {
+          "version": "1.4.3",
+          "from": "shell-quote@>=1.4.1 <1.5.0",
+          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+          "dependencies": {
+            "jsonify": {
+              "version": "0.0.0",
+              "from": "jsonify@>=0.0.0 <0.1.0"
+            },
+            "array-filter": {
+              "version": "0.0.1",
+              "from": "array-filter@>=0.0.0 <0.1.0"
+            },
+            "array-reduce": {
+              "version": "0.0.0",
+              "from": "array-reduce@>=0.0.0 <0.1.0"
+            },
+            "array-map": {
+              "version": "0.0.0",
+              "from": "array-map@>=0.0.0 <0.1.0"
+            }
+          }
+        },
+        "stringify-object": {
+          "version": "1.0.1",
+          "from": "stringify-object@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz"
+        },
+        "tar-fs": {
+          "version": "0.5.2",
+          "from": "tar-fs@0.5.2",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-0.5.2.tgz",
+          "dependencies": {
+            "pump": {
+              "version": "0.3.5",
+              "from": "pump@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/pump/-/pump-0.3.5.tgz",
+              "dependencies": {
+                "once": {
+                  "version": "1.2.0",
+                  "from": "once@>=1.2.0 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.2.0.tgz"
+                },
+                "end-of-stream": {
+                  "version": "1.0.0",
+                  "from": "end-of-stream@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@>=1.3.0 <1.4.0",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "tar-stream": {
+              "version": "0.4.7",
+              "from": "tar-stream@>=0.4.6 <0.5.0",
+              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
+                },
+                "end-of-stream": {
+                  "version": "1.1.0",
+                  "from": "end-of-stream@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@>=1.3.0 <1.4.0",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.27-1 <2.0.0",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <5.0.0"
+                }
+              }
+            }
+          }
+        },
+        "tmp": {
+          "version": "0.0.23",
+          "from": "tmp@0.0.23",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz"
+        },
+        "update-notifier": {
+          "version": "0.2.0",
+          "from": "update-notifier@0.2.0",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.2.0.tgz",
+          "dependencies": {
+            "configstore": {
+              "version": "0.3.2",
+              "from": "configstore@>=0.3.1 <0.4.0",
+              "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+              "dependencies": {
+                "js-yaml": {
+                  "version": "3.2.7",
+                  "from": "js-yaml@>=3.1.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "1.0.2",
+                      "from": "argparse@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "3.6.0",
+                          "from": "lodash@>=3.2.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+                        },
+                        "sprintf-js": {
+                          "version": "1.0.2",
+                          "from": "sprintf-js@>=1.0.2 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "2.0.0",
+                      "from": "esprima@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "2.0.0",
+                  "from": "object-assign@>=2.0.0 <3.0.0"
+                },
+                "user-home": {
+                  "version": "1.1.1",
+                  "from": "user-home@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                },
+                "uuid": {
+                  "version": "2.0.1",
+                  "from": "uuid@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+                },
+                "xdg-basedir": {
+                  "version": "1.0.1",
+                  "from": "xdg-basedir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
+                }
+              }
+            },
+            "latest-version": {
+              "version": "0.2.0",
+              "from": "latest-version@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-0.2.0.tgz",
+              "dependencies": {
+                "package-json": {
+                  "version": "0.2.0",
+                  "from": "package-json@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/package-json/-/package-json-0.2.0.tgz",
+                  "dependencies": {
+                    "got": {
+                      "version": "0.3.0",
+                      "from": "got@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/got/-/got-0.3.0.tgz",
+                      "dependencies": {
+                        "object-assign": {
+                          "version": "0.3.1",
+                          "from": "object-assign@>=0.3.0 <0.4.0"
+                        }
+                      }
+                    },
+                    "registry-url": {
+                      "version": "0.1.1",
+                      "from": "registry-url@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-0.1.1.tgz",
+                      "dependencies": {
+                        "npmconf": {
+                          "version": "2.1.1",
+                          "from": "npmconf@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
+                          "dependencies": {
+                            "config-chain": {
+                              "version": "1.1.8",
+                              "from": "config-chain@>=1.1.8 <1.2.0",
+                              "dependencies": {
+                                "proto-list": {
+                                  "version": "1.2.3",
+                                  "from": "proto-list@>=1.2.1 <1.3.0"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.0 <2.1.0"
+                            },
+                            "ini": {
+                              "version": "1.3.3",
+                              "from": "ini@>=1.2.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+                            },
+                            "once": {
+                              "version": "1.3.1",
+                              "from": "once@>=1.3.0 <1.4.0",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            },
+                            "uid-number": {
+                              "version": "0.0.5",
+                              "from": "uid-number@0.0.5",
+                              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "semver-diff": {
+              "version": "0.1.0",
+              "from": "semver-diff@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-0.1.0.tgz"
+            },
+            "string-length": {
+              "version": "0.1.2",
+              "from": "string-length@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/string-length/-/string-length-0.1.2.tgz",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "0.2.2",
+                  "from": "strip-ansi@>=0.2.1 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.2.2.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.1.0",
+                      "from": "ansi-regex@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "which": {
+          "version": "1.0.9",
+          "from": "which@>=1.0.5 <1.1.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+        }
+      }
+    },
     "grunt": {
-      "version": "0.4.2",
-      "from": "grunt@~0.4.1",
+      "version": "0.4.5",
+      "from": "grunt@>=0.4.1 <0.5.0",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@~0.1.22"
+          "from": "async@>=0.1.22 <0.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@~1.3.3"
+          "from": "coffee-script@>=1.3.3 <1.4.0",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@~0.6.2"
+          "from": "colors@>=0.6.2 <0.7.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
-          "from": "dateformat@1.0.2-1.2.3"
+          "from": "dateformat@1.0.2-1.2.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
         },
         "eventemitter2": {
-          "version": "0.4.13",
-          "from": "eventemitter2@~0.4.13"
+          "version": "0.4.14",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
-          "version": "0.1.2",
-          "from": "findup-sync@~0.1.2",
+          "version": "0.1.3",
+          "from": "findup-sync@>=0.1.0 <0.2.0",
           "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@>=3.2.9 <3.3.0",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0"
+                    }
+                  }
+                }
+              }
+            },
             "lodash": {
-              "version": "1.0.1",
-              "from": "lodash@~1.0.1"
+              "version": "2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@~3.1.21",
+          "from": "glob@>=3.1.21 <3.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@~1.2.0"
+              "from": "graceful-fs@>=1.2.0 <1.3.0"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@~1.0.0"
+              "from": "inherits@>=1.0.0 <2.0.0"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3"
+          "from": "hooker@>=0.2.3 <0.3.0",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@~0.2.11"
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@~0.2",
+          "from": "minimatch@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.5.0",
-              "from": "lru-cache@2"
+              "version": "2.5.2",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@~1.0.0"
+              "from": "sigmund@>=1.0.0 <1.1.0"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@~1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
-              "version": "1.0.4",
-              "from": "abbrev@1"
+              "version": "1.0.5",
+              "from": "abbrev@>=1.0.0 <2.0.0"
             }
           }
         },
         "rimraf": {
-          "version": "2.0.3",
-          "from": "rimraf@~2.0.3",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "1.1.14",
-              "from": "graceful-fs@~1.1"
-            }
-          }
+          "version": "2.2.8",
+          "from": "rimraf@>=2.2.0 <2.3.0"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@~0.9.2"
+          "from": "lodash@>=0.9.2 <0.10.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@~2.2.1"
+          "from": "underscore.string@>=2.2.1 <2.3.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
-          "version": "1.0.5",
-          "from": "which@~1.0.5"
+          "version": "1.0.9",
+          "from": "which@>=1.0.5 <1.1.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@~2.0.5",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
-              "version": "0.1.15",
-              "from": "argparse@~ 0.1.11",
+              "version": "0.1.16",
+              "from": "argparse@>=0.1.11 <0.2.0",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
-                  "version": "1.4.4",
-                  "from": "underscore@~1.4.3"
+                  "version": "1.7.0",
+                  "from": "underscore@>=1.7.0 <1.8.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
-                  "version": "2.3.3",
-                  "from": "underscore.string@~2.3.1"
+                  "version": "2.4.0",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~ 1.0.2"
+              "from": "esprima@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@~0.1.1"
+          "from": "exit@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@~0.1.0"
+          "from": "getobject@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
+        },
+        "grunt-legacy-util": {
+          "version": "0.2.0",
+          "from": "grunt-legacy-util@>=0.2.0 <0.3.0"
+        },
+        "grunt-legacy-log": {
+          "version": "0.1.1",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
+          "dependencies": {
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0"
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "from": "underscore.string@>=2.3.3 <2.4.0"
+            }
+          }
         }
       }
     },
     "grunt-cli": {
-      "version": "0.1.11",
-      "from": "grunt-cli@~0.1.9",
+      "version": "0.1.13",
+      "from": "grunt-cli@>=0.1.9 <0.2.0",
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@~1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
-              "version": "1.0.4",
-              "from": "abbrev@1"
+              "version": "1.0.5",
+              "from": "abbrev@>=1.0.0 <2.0.0"
             }
           }
         },
         "findup-sync": {
-          "version": "0.1.2",
-          "from": "findup-sync@~0.1.2",
+          "version": "0.1.3",
+          "from": "findup-sync@>=0.1.0 <0.2.0",
           "dependencies": {
             "glob": {
-              "version": "3.1.21",
-              "from": "glob@~3.1.21",
+              "version": "3.2.11",
+              "from": "glob@>=3.2.9 <3.3.0",
               "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0"
+                },
                 "minimatch": {
-                  "version": "0.2.14",
-                  "from": "minimatch@~0.2.11",
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.5.0",
-                      "from": "lru-cache@2"
+                      "version": "2.5.2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0"
+                      "from": "sigmund@>=1.0.0 <1.1.0"
                     }
                   }
-                },
-                "graceful-fs": {
-                  "version": "1.2.3",
-                  "from": "graceful-fs@~1.2.0"
-                },
-                "inherits": {
-                  "version": "1.0.0",
-                  "from": "inherits@1"
                 }
               }
             },
             "lodash": {
-              "version": "1.0.1",
-              "from": "lodash@~1.0.1"
+              "version": "2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0"
             }
           }
         },
         "resolve": {
           "version": "0.3.1",
-          "from": "resolve@~0.3.1"
+          "from": "resolve@>=0.3.1 <0.4.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
         }
       }
     },
-    "grunt-karma": {
-      "version": "0.7.2",
-      "from": "grunt-karma@~0.7.0",
+    "grunt-contrib-jshint": {
+      "version": "0.6.5",
+      "from": "grunt-contrib-jshint@>=0.6.4 <0.7.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.6.5.tgz",
       "dependencies": {
-        "optimist": {
-          "version": "0.6.0",
-          "from": "optimist@~0.6.0",
+        "jshint": {
+          "version": "2.1.11",
+          "from": "jshint@>=2.1.10 <2.2.0",
+          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.1.11.tgz",
           "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "from": "wordwrap@~0.0.2"
+            "shelljs": {
+              "version": "0.1.4",
+              "from": "shelljs@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.1.4.tgz"
             },
-            "minimist": {
-              "version": "0.0.5",
-              "from": "minimist@~0.0.1"
+            "underscore": {
+              "version": "1.4.4",
+              "from": "underscore@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+            },
+            "cli": {
+              "version": "0.4.5",
+              "from": "cli@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.5.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.5",
+                  "from": "glob@>=3.1.4",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.5.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <2.1.0"
+                    },
+                    "minimatch": {
+                      "version": "2.0.4",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "balanced-match@>=0.2.0 <0.3.0"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@>=1.3.0 <1.4.0",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "minimatch": {
+              "version": "0.4.0",
+              "from": "minimatch@>=0.0.0 <1.0.0",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.2",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0"
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "0.1.6",
+              "from": "console-browserify@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.6.tgz"
             }
           }
         }
       }
     },
+    "grunt-karma": {
+      "version": "0.7.3",
+      "from": "grunt-karma@>=0.7.0 <0.8.0",
+      "resolved": "https://registry.npmjs.org/grunt-karma/-/grunt-karma-0.7.3.tgz",
+      "dependencies": {
+        "optimist": {
+          "version": "0.6.1",
+          "from": "optimist@>=0.6.1 <0.7.0",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@>=0.0.2 <0.1.0"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "minimist@>=0.0.1 <0.1.0"
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.4.1",
+          "from": "lodash@>=2.4.1 <2.5.0"
+        }
+      }
+    },
     "karma": {
-      "version": "0.11.12",
-      "from": "karma@~0.11.2",
+      "version": "0.12.31",
+      "from": "karma@>=0.12.0 <0.13.0",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-0.12.31.tgz",
       "dependencies": {
         "di": {
           "version": "0.0.1",
-          "from": "di@~0.0.1"
+          "from": "di@>=0.0.1 <0.1.0",
+          "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
         },
         "socket.io": {
           "version": "0.9.16",
-          "from": "socket.io@~0.9.13",
+          "from": "socket.io@0.9.16",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.16.tgz",
           "dependencies": {
             "socket.io-client": {
               "version": "0.9.16",
               "from": "socket.io-client@0.9.16",
+              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
               "dependencies": {
                 "uglify-js": {
                   "version": "1.2.5",
-                  "from": "uglify-js@1.2.5"
+                  "from": "uglify-js@1.2.5",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
                 },
                 "ws": {
-                  "version": "0.4.31",
-                  "from": "ws@0.4.x",
+                  "version": "0.4.32",
+                  "from": "ws@>=0.4.0 <0.5.0",
                   "dependencies": {
                     "commander": {
-                      "version": "0.6.1",
-                      "from": "commander@~0.6.1"
+                      "version": "2.1.0",
+                      "from": "commander@>=2.1.0 <2.2.0"
                     },
                     "nan": {
-                      "version": "0.3.2",
-                      "from": "nan@~0.3.0"
+                      "version": "1.0.0",
+                      "from": "nan@>=1.0.0 <1.1.0"
                     },
                     "tinycolor": {
                       "version": "0.0.1",
-                      "from": "tinycolor@0.x"
+                      "from": "tinycolor@>=0.0.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
                     },
                     "options": {
-                      "version": "0.0.5",
-                      "from": "options@>=0.0.5"
+                      "version": "0.0.6",
+                      "from": "options@>=0.0.5",
+                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                     }
                   }
                 },
                 "xmlhttprequest": {
                   "version": "1.4.2",
-                  "from": "xmlhttprequest@1.4.2"
+                  "from": "xmlhttprequest@1.4.2",
+                  "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
                 },
                 "active-x-obfuscator": {
                   "version": "0.0.1",
                   "from": "active-x-obfuscator@0.0.1",
+                  "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
                   "dependencies": {
                     "zeparser": {
                       "version": "0.0.5",
-                      "from": "zeparser@0.0.5"
+                      "from": "zeparser@0.0.5",
+                      "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
                     }
                   }
                 }
@@ -276,251 +1977,1314 @@
             },
             "policyfile": {
               "version": "0.0.4",
-              "from": "policyfile@0.0.4"
+              "from": "policyfile@0.0.4",
+              "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
             },
             "base64id": {
               "version": "0.1.0",
-              "from": "base64id@0.1.0"
+              "from": "base64id@0.1.0",
+              "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
             },
             "redis": {
               "version": "0.7.3",
-              "from": "redis@0.7.3"
+              "from": "redis@0.7.3",
+              "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
             }
           }
         },
         "chokidar": {
-          "version": "0.8.1",
-          "from": "chokidar@~0.8.0"
+          "version": "1.0.1",
+          "from": "chokidar@>=0.8.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.1.tgz",
+          "dependencies": {
+            "anymatch": {
+              "version": "1.2.1",
+              "from": "anymatch@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.2.1.tgz",
+              "dependencies": {
+                "micromatch": {
+                  "version": "2.1.5",
+                  "from": "micromatch@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.5.tgz",
+                  "dependencies": {
+                    "arr-diff": {
+                      "version": "1.0.1",
+                      "from": "arr-diff@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
+                      "dependencies": {
+                        "array-slice": {
+                          "version": "0.2.3",
+                          "from": "array-slice@>=0.2.2 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+                        }
+                      }
+                    },
+                    "braces": {
+                      "version": "1.8.0",
+                      "from": "braces@>=1.8.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
+                      "dependencies": {
+                        "expand-range": {
+                          "version": "1.8.1",
+                          "from": "expand-range@>=1.8.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                          "dependencies": {
+                            "fill-range": {
+                              "version": "2.2.2",
+                              "from": "fill-range@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
+                              "dependencies": {
+                                "is-number": {
+                                  "version": "1.1.2",
+                                  "from": "is-number@>=1.1.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
+                                },
+                                "isobject": {
+                                  "version": "1.0.0",
+                                  "from": "isobject@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz"
+                                },
+                                "randomatic": {
+                                  "version": "1.1.0",
+                                  "from": "randomatic@>=1.1.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.2",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "preserve": {
+                          "version": "0.2.0",
+                          "from": "preserve@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                        },
+                        "repeat-element": {
+                          "version": "1.1.0",
+                          "from": "repeat-element@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.0.tgz"
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "2.1.3",
+                      "from": "debug@>=2.1.3 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.0",
+                          "from": "ms@0.7.0",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                        }
+                      }
+                    },
+                    "expand-brackets": {
+                      "version": "0.1.1",
+                      "from": "expand-brackets@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
+                    },
+                    "filename-regex": {
+                      "version": "2.0.0",
+                      "from": "filename-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                    },
+                    "kind-of": {
+                      "version": "1.1.0",
+                      "from": "kind-of@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+                    },
+                    "object.omit": {
+                      "version": "0.2.1",
+                      "from": "object.omit@>=0.2.1 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
+                      "dependencies": {
+                        "for-own": {
+                          "version": "0.1.3",
+                          "from": "for-own@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                          "dependencies": {
+                            "for-in": {
+                              "version": "0.1.4",
+                              "from": "for-in@>=0.1.4 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                            }
+                          }
+                        },
+                        "isobject": {
+                          "version": "0.2.0",
+                          "from": "isobject@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
+                        }
+                      }
+                    },
+                    "parse-glob": {
+                      "version": "3.0.0",
+                      "from": "parse-glob@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.0.tgz",
+                      "dependencies": {
+                        "glob-base": {
+                          "version": "0.2.0",
+                          "from": "glob-base@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
+                        },
+                        "is-dotfile": {
+                          "version": "1.0.0",
+                          "from": "is-dotfile@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz"
+                        },
+                        "is-extglob": {
+                          "version": "1.0.0",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "regex-cache": {
+                      "version": "0.3.0",
+                      "from": "regex-cache@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.3.0.tgz",
+                      "dependencies": {
+                        "benchmarked": {
+                          "version": "0.1.4",
+                          "from": "benchmarked@>=0.1.3 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/benchmarked/-/benchmarked-0.1.4.tgz",
+                          "dependencies": {
+                            "ansi": {
+                              "version": "0.3.0",
+                              "from": "ansi@>=0.3.0 <0.4.0"
+                            },
+                            "benchmark": {
+                              "version": "1.0.0",
+                              "from": "benchmark@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                            },
+                            "chalk": {
+                              "version": "1.0.0",
+                              "from": "chalk@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.0.1",
+                                  "from": "ansi-styles@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.3",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "1.0.3",
+                                  "from": "has-ansi@>=1.0.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "1.1.1",
+                                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                    },
+                                    "get-stdin": {
+                                      "version": "4.0.1",
+                                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "2.0.1",
+                                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "1.1.1",
+                                      "from": "ansi-regex@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "1.3.1",
+                                  "from": "supports-color@>=1.3.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                                }
+                              }
+                            },
+                            "extend-shallow": {
+                              "version": "1.1.2",
+                              "from": "extend-shallow@>=1.1.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.2.tgz"
+                            },
+                            "file-reader": {
+                              "version": "1.0.0",
+                              "from": "file-reader@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/file-reader/-/file-reader-1.0.0.tgz",
+                              "dependencies": {
+                                "extend-shallow": {
+                                  "version": "0.2.0",
+                                  "from": "extend-shallow@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-0.2.0.tgz",
+                                  "dependencies": {
+                                    "array-slice": {
+                                      "version": "0.2.3",
+                                      "from": "array-slice@>=0.2.2 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+                                    }
+                                  }
+                                },
+                                "map-files": {
+                                  "version": "0.3.0",
+                                  "from": "map-files@>=0.3.0 <0.4.0",
+                                  "resolved": "https://registry.npmjs.org/map-files/-/map-files-0.3.0.tgz",
+                                  "dependencies": {
+                                    "globby": {
+                                      "version": "0.1.1",
+                                      "from": "globby@>=0.1.1 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/globby/-/globby-0.1.1.tgz",
+                                      "dependencies": {
+                                        "array-differ": {
+                                          "version": "0.1.0",
+                                          "from": "array-differ@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz"
+                                        },
+                                        "array-union": {
+                                          "version": "0.1.0",
+                                          "from": "array-union@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
+                                          "dependencies": {
+                                            "array-uniq": {
+                                              "version": "0.1.1",
+                                              "from": "array-uniq@>=0.1.0 <0.2.0",
+                                              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz"
+                                            }
+                                          }
+                                        },
+                                        "async": {
+                                          "version": "0.9.0",
+                                          "from": "async@>=0.9.0 <0.10.0"
+                                        },
+                                        "glob": {
+                                          "version": "4.5.3",
+                                          "from": "glob@>=4.0.2 <5.0.0",
+                                          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                                          "dependencies": {
+                                            "inflight": {
+                                              "version": "1.0.4",
+                                              "from": "inflight@>=1.0.4 <2.0.0",
+                                              "dependencies": {
+                                                "wrappy": {
+                                                  "version": "1.0.1",
+                                                  "from": "wrappy@>=1.0.0 <2.0.0"
+                                                }
+                                              }
+                                            },
+                                            "inherits": {
+                                              "version": "2.0.1",
+                                              "from": "inherits@>=2.0.0 <3.0.0"
+                                            },
+                                            "minimatch": {
+                                              "version": "2.0.4",
+                                              "from": "minimatch@>=2.0.1 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                                              "dependencies": {
+                                                "brace-expansion": {
+                                                  "version": "1.1.0",
+                                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                                  "dependencies": {
+                                                    "balanced-match": {
+                                                      "version": "0.2.0",
+                                                      "from": "balanced-match@>=0.2.0 <0.3.0"
+                                                    },
+                                                    "concat-map": {
+                                                      "version": "0.0.1",
+                                                      "from": "concat-map@0.0.1",
+                                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "once": {
+                                              "version": "1.3.1",
+                                              "from": "once@>=1.3.0 <2.0.0",
+                                              "dependencies": {
+                                                "wrappy": {
+                                                  "version": "1.0.1",
+                                                  "from": "wrappy@>=1.0.0 <2.0.0"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "relative": {
+                                      "version": "0.1.6",
+                                      "from": "relative@>=0.1.6 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/relative/-/relative-0.1.6.tgz",
+                                      "dependencies": {
+                                        "normalize-path": {
+                                          "version": "0.1.1",
+                                          "from": "normalize-path@>=0.1.1 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-0.1.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "read-yaml": {
+                                  "version": "1.0.0",
+                                  "from": "read-yaml@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/read-yaml/-/read-yaml-1.0.0.tgz",
+                                  "dependencies": {
+                                    "js-yaml": {
+                                      "version": "3.2.7",
+                                      "from": "js-yaml@>=3.2.3 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+                                      "dependencies": {
+                                        "argparse": {
+                                          "version": "1.0.2",
+                                          "from": "argparse@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                                          "dependencies": {
+                                            "lodash": {
+                                              "version": "3.6.0",
+                                              "from": "lodash@>=3.2.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+                                            },
+                                            "sprintf-js": {
+                                              "version": "1.0.2",
+                                              "from": "sprintf-js@>=1.0.2 <1.1.0",
+                                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "esprima": {
+                                          "version": "2.0.0",
+                                          "from": "esprima@>=2.0.0 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "xtend": {
+                                      "version": "4.0.0",
+                                      "from": "xtend@>=4.0.0 <5.0.0"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "for-own": {
+                              "version": "0.1.3",
+                              "from": "for-own@>=0.1.3 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                              "dependencies": {
+                                "for-in": {
+                                  "version": "0.1.4",
+                                  "from": "for-in@>=0.1.4 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                                }
+                              }
+                            },
+                            "has-values": {
+                              "version": "0.1.3",
+                              "from": "has-values@>=0.1.2 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.3.tgz"
+                            }
+                          }
+                        },
+                        "chalk": {
+                          "version": "0.5.1",
+                          "from": "chalk@>=0.5.1 <0.6.0",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "1.1.0",
+                              "from": "ansi-styles@>=1.1.0 <2.0.0"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.3",
+                              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "0.1.0",
+                              "from": "has-ansi@>=0.1.0 <0.2.0",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "0.2.1",
+                                  "from": "ansi-regex@>=0.2.0 <0.3.0"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "0.3.0",
+                              "from": "strip-ansi@>=0.3.0 <0.4.0",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "0.2.1",
+                                  "from": "ansi-regex@>=0.2.0 <0.3.0"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "0.2.0",
+                              "from": "supports-color@>=0.2.0 <0.3.0"
+                            }
+                          }
+                        },
+                        "micromatch": {
+                          "version": "1.6.2",
+                          "from": "micromatch@>=1.2.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-1.6.2.tgz",
+                          "dependencies": {
+                            "extglob": {
+                              "version": "0.2.0",
+                              "from": "extglob@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.2.0.tgz"
+                            },
+                            "parse-glob": {
+                              "version": "2.1.1",
+                              "from": "parse-glob@>=2.1.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-2.1.1.tgz",
+                              "dependencies": {
+                                "glob-base": {
+                                  "version": "0.1.1",
+                                  "from": "glob-base@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.1.1.tgz"
+                                },
+                                "glob-path-regex": {
+                                  "version": "1.0.0",
+                                  "from": "glob-path-regex@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/glob-path-regex/-/glob-path-regex-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "to-key": {
+                          "version": "1.0.0",
+                          "from": "to-key@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/to-key/-/to-key-1.0.0.tgz",
+                          "dependencies": {
+                            "arr-map": {
+                              "version": "1.0.0",
+                              "from": "arr-map@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-1.0.0.tgz"
+                            },
+                            "for-in": {
+                              "version": "0.1.4",
+                              "from": "for-in@>=0.1.4 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "arrify": {
+              "version": "1.0.0",
+              "from": "arrify@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+            },
+            "async-each": {
+              "version": "0.1.6",
+              "from": "async-each@>=0.1.5 <0.2.0",
+              "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+            },
+            "glob-parent": {
+              "version": "1.2.0",
+              "from": "glob-parent@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
+            },
+            "is-binary-path": {
+              "version": "1.0.0",
+              "from": "is-binary-path@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
+              "dependencies": {
+                "binary-extensions": {
+                  "version": "1.3.0",
+                  "from": "binary-extensions@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.0.tgz"
+                }
+              }
+            },
+            "is-glob": {
+              "version": "1.1.3",
+              "from": "is-glob@>=1.1.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
+            },
+            "readdirp": {
+              "version": "1.3.0",
+              "from": "readdirp@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
         },
         "glob": {
-          "version": "3.2.8",
-          "from": "glob@>= 3.1.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.8.tgz",
+          "version": "3.2.11",
+          "from": "glob@>=3.2.7 <3.3.0",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2"
+              "from": "inherits@>=2.0.0 <3.0.0"
+            },
+            "minimatch": {
+              "version": "0.3.0",
+              "from": "minimatch@>=0.3.0 <0.4.0",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.2",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0"
+                }
+              }
             }
           }
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@~0.2.11",
+          "from": "minimatch@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.5.0",
-              "from": "lru-cache@2"
+              "version": "2.5.2",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@~1.0.0"
+              "from": "sigmund@>=1.0.0 <1.1.0"
             }
           }
         },
         "http-proxy": {
           "version": "0.10.4",
-          "from": "http-proxy@~0.10",
+          "from": "http-proxy@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz",
           "dependencies": {
             "pkginfo": {
               "version": "0.3.0",
-              "from": "pkginfo@0.3.x"
+              "from": "pkginfo@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
             },
             "utile": {
               "version": "0.2.1",
-              "from": "utile@~0.2.1",
+              "from": "utile@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
               "dependencies": {
                 "async": {
-                  "version": "0.2.9",
-                  "from": "async@~0.2.9"
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.9 <0.3.0"
                 },
                 "deep-equal": {
-                  "version": "0.1.2",
-                  "from": "deep-equal@*"
+                  "version": "1.0.0",
+                  "from": "deep-equal@*",
+                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
                 },
                 "i": {
-                  "version": "0.3.2",
-                  "from": "i@0.3.x"
+                  "version": "0.3.3",
+                  "from": "i@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
                 },
                 "mkdirp": {
-                  "version": "0.3.5",
-                  "from": "mkdirp@0.x.x"
+                  "version": "0.5.0",
+                  "from": "mkdirp@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
                 },
                 "ncp": {
                   "version": "0.4.2",
-                  "from": "ncp@0.4.x"
+                  "from": "ncp@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                 }
               }
             }
           }
         },
         "optimist": {
-          "version": "0.6.0",
-          "from": "optimist@~0.6.0",
+          "version": "0.6.1",
+          "from": "optimist@>=0.6.0 <0.7.0",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2"
+              "from": "wordwrap@>=0.0.2 <0.1.0"
             },
             "minimist": {
-              "version": "0.0.5",
-              "from": "minimist@~0.0.1"
+              "version": "0.0.10",
+              "from": "minimist@>=0.0.1 <0.1.0"
             }
           }
         },
-        "coffee-script": {
-          "version": "1.6.3",
-          "from": "coffee-script@~1.6"
-        },
         "rimraf": {
-          "version": "2.2.5",
-          "from": "rimraf@~2.2.5"
+          "version": "2.2.8",
+          "from": "rimraf@>=2.2.0 <2.3.0"
         },
         "q": {
           "version": "0.9.7",
-          "from": "q@~0.9.7"
+          "from": "q@>=0.9.7 <0.10.0",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@~0.6.2"
+          "from": "colors@>=0.6.2 <0.7.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@~2.4.1"
+          "from": "lodash@>=2.4.1 <2.5.0"
         },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@~1.2.11"
+          "from": "mime@>=1.2.11 <1.3.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "log4js": {
-          "version": "0.6.9",
-          "from": "log4js@~0.6.3",
+          "version": "0.6.22",
+          "from": "log4js@>=0.6.3 <0.7.0",
+          "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.22.tgz",
           "dependencies": {
             "async": {
-              "version": "0.1.15",
-              "from": "async@0.1.15"
+              "version": "0.2.10",
+              "from": "async@>=0.2.0 <0.3.0"
+            },
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.26 <1.1.0",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0"
+                }
+              }
             },
             "semver": {
               "version": "1.1.4",
-              "from": "semver@~1.1.4"
-            },
-            "readable-stream": {
-              "version": "1.0.24",
-              "from": "readable-stream@~1.0.2"
+              "from": "semver@>=1.1.4 <1.2.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz"
             }
           }
         },
         "useragent": {
-          "version": "2.0.7",
-          "from": "useragent@~2.0.4",
+          "version": "2.0.10",
+          "from": "useragent@>=2.0.4 <2.1.0",
+          "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.0.10.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.2.4",
-              "from": "lru-cache@2.2.x"
+              "from": "lru-cache@>=2.2.0 <2.3.0"
             }
           }
         },
         "graceful-fs": {
-          "version": "2.0.1",
-          "from": "graceful-fs@~2.0.1"
+          "version": "2.0.3",
+          "from": "graceful-fs@>=2.0.1 <2.1.0"
         },
         "connect": {
-          "version": "2.12.0",
-          "from": "connect@~2.12.0",
+          "version": "2.26.6",
+          "from": "connect@>=2.26.0 <2.27.0",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-2.26.6.tgz",
           "dependencies": {
-            "batch": {
-              "version": "0.5.0",
-              "from": "batch@0.5.0"
+            "basic-auth-connect": {
+              "version": "1.0.0",
+              "from": "basic-auth-connect@1.0.0",
+              "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
             },
-            "qs": {
-              "version": "0.6.6",
-              "from": "qs@0.6.6"
-            },
-            "cookie-signature": {
-              "version": "1.0.1",
-              "from": "cookie-signature@1.0.1"
-            },
-            "buffer-crc32": {
-              "version": "0.2.1",
-              "from": "buffer-crc32@0.2.1"
-            },
-            "cookie": {
-              "version": "0.1.0",
-              "from": "cookie@0.1.0"
-            },
-            "send": {
-              "version": "0.1.4",
-              "from": "send@0.1.4",
+            "body-parser": {
+              "version": "1.8.4",
+              "from": "body-parser@>=1.8.4 <1.9.0",
               "dependencies": {
-                "range-parser": {
-                  "version": "0.0.4",
-                  "from": "range-parser@0.0.4"
+                "iconv-lite": {
+                  "version": "0.4.4",
+                  "from": "iconv-lite@0.4.4",
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
+                },
+                "on-finished": {
+                  "version": "2.1.0",
+                  "from": "on-finished@2.1.0",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.0.5",
+                      "from": "ee-first@1.0.5",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+                    }
+                  }
+                },
+                "raw-body": {
+                  "version": "1.3.0",
+                  "from": "raw-body@1.3.0",
+                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz"
                 }
               }
             },
             "bytes": {
-              "version": "0.2.1",
-              "from": "bytes@0.2.1"
+              "version": "1.0.0",
+              "from": "bytes@1.0.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
             },
-            "fresh": {
-              "version": "0.2.0",
-              "from": "fresh@0.2.0"
+            "cookie": {
+              "version": "0.1.2",
+              "from": "cookie@0.1.2",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
             },
-            "pause": {
-              "version": "0.0.1",
-              "from": "pause@0.0.1"
+            "cookie-parser": {
+              "version": "1.3.4",
+              "from": "cookie-parser@>=1.3.3 <1.4.0",
+              "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.4.tgz",
+              "dependencies": {
+                "cookie-signature": {
+                  "version": "1.0.6",
+                  "from": "cookie-signature@1.0.6",
+                  "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+                }
+              }
             },
-            "uid2": {
-              "version": "0.0.3",
-              "from": "uid2@0.0.3"
+            "cookie-signature": {
+              "version": "1.0.5",
+              "from": "cookie-signature@1.0.5",
+              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
+            },
+            "compression": {
+              "version": "1.1.2",
+              "from": "compression@>=1.1.2 <1.2.0",
+              "resolved": "https://registry.npmjs.org/compression/-/compression-1.1.2.tgz",
+              "dependencies": {
+                "accepts": {
+                  "version": "1.1.4",
+                  "from": "accepts@>=1.1.2 <1.2.0",
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.0.10",
+                      "from": "mime-types@>=2.0.4 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.8.0",
+                          "from": "mime-db@>=1.8.0 <1.9.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                        }
+                      }
+                    },
+                    "negotiator": {
+                      "version": "0.4.9",
+                      "from": "negotiator@0.4.9",
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+                    }
+                  }
+                },
+                "compressible": {
+                  "version": "2.0.2",
+                  "from": "compressible@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.2.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.8.0",
+                      "from": "mime-db@>=1.1.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                    }
+                  }
+                },
+                "vary": {
+                  "version": "1.0.0",
+                  "from": "vary@>=1.0.0 <1.1.0"
+                }
+              }
+            },
+            "connect-timeout": {
+              "version": "1.3.0",
+              "from": "connect-timeout@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.3.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "csurf": {
+              "version": "1.6.6",
+              "from": "csurf@>=1.6.2 <1.7.0",
+              "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.6.6.tgz",
+              "dependencies": {
+                "csrf": {
+                  "version": "2.0.6",
+                  "from": "csrf@>=2.0.5 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/csrf/-/csrf-2.0.6.tgz",
+                  "dependencies": {
+                    "base64-url": {
+                      "version": "1.2.1",
+                      "from": "base64-url@1.2.1",
+                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+                    },
+                    "rndm": {
+                      "version": "1.1.0",
+                      "from": "rndm@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.1.0.tgz"
+                    },
+                    "scmp": {
+                      "version": "1.0.0",
+                      "from": "scmp@1.0.0",
+                      "resolved": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz"
+                    },
+                    "uid-safe": {
+                      "version": "1.1.0",
+                      "from": "uid-safe@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.1.0.tgz",
+                      "dependencies": {
+                        "native-or-bluebird": {
+                          "version": "1.1.2",
+                          "from": "native-or-bluebird@>=1.1.2 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "http-errors": {
+                  "version": "1.2.8",
+                  "from": "http-errors@>=1.2.8 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0"
+                    },
+                    "statuses": {
+                      "version": "1.2.1",
+                      "from": "statuses@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                    }
+                  }
+                }
+              }
             },
             "debug": {
-              "version": "0.7.4",
-              "from": "debug@>= 0.7.3 < 1"
+              "version": "2.0.0",
+              "from": "debug@>=2.0.0 <2.1.0",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
             },
-            "methods": {
-              "version": "0.1.0",
-              "from": "methods@0.1.0"
+            "depd": {
+              "version": "0.4.5",
+              "from": "depd@0.4.5",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
             },
-            "raw-body": {
-              "version": "1.1.2",
-              "from": "raw-body@1.1.2"
+            "errorhandler": {
+              "version": "1.2.4",
+              "from": "errorhandler@>=1.2.2 <1.3.0",
+              "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.2.4.tgz",
+              "dependencies": {
+                "accepts": {
+                  "version": "1.1.4",
+                  "from": "accepts@>=1.1.2 <1.2.0",
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.0.10",
+                      "from": "mime-types@>=2.0.4 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.8.0",
+                          "from": "mime-db@>=1.8.0 <1.9.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                        }
+                      }
+                    },
+                    "negotiator": {
+                      "version": "0.4.9",
+                      "from": "negotiator@0.4.9",
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+                    }
+                  }
+                },
+                "escape-html": {
+                  "version": "1.0.1",
+                  "from": "escape-html@1.0.1",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+                }
+              }
             },
-            "negotiator": {
+            "express-session": {
+              "version": "1.8.2",
+              "from": "express-session@>=1.8.2 <1.9.0",
+              "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.8.2.tgz",
+              "dependencies": {
+                "crc": {
+                  "version": "3.0.0",
+                  "from": "crc@3.0.0",
+                  "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
+                },
+                "uid-safe": {
+                  "version": "1.0.1",
+                  "from": "uid-safe@1.0.1",
+                  "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
+                  "dependencies": {
+                    "mz": {
+                      "version": "1.3.0",
+                      "from": "mz@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/mz/-/mz-1.3.0.tgz",
+                      "dependencies": {
+                        "native-or-bluebird": {
+                          "version": "1.2.0",
+                          "from": "native-or-bluebird@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz"
+                        },
+                        "thenify": {
+                          "version": "3.1.0",
+                          "from": "thenify@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.1.0.tgz"
+                        },
+                        "thenify-all": {
+                          "version": "1.6.0",
+                          "from": "thenify-all@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz"
+                        }
+                      }
+                    },
+                    "base64-url": {
+                      "version": "1.2.1",
+                      "from": "base64-url@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+                    }
+                  }
+                },
+                "utils-merge": {
+                  "version": "1.0.0",
+                  "from": "utils-merge@1.0.0",
+                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                }
+              }
+            },
+            "finalhandler": {
+              "version": "0.2.0",
+              "from": "finalhandler@0.2.0",
+              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.2.0.tgz",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.1",
+                  "from": "escape-html@1.0.1",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+                }
+              }
+            },
+            "fresh": {
+              "version": "0.2.4",
+              "from": "fresh@0.2.4",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
+            },
+            "media-typer": {
               "version": "0.3.0",
-              "from": "negotiator@0.3.0",
-              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz"
+              "from": "media-typer@0.3.0",
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+            },
+            "method-override": {
+              "version": "2.2.0",
+              "from": "method-override@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.2.0.tgz",
+              "dependencies": {
+                "methods": {
+                  "version": "1.1.0",
+                  "from": "methods@1.1.0",
+                  "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
+                },
+                "vary": {
+                  "version": "1.0.0",
+                  "from": "vary@>=1.0.0 <1.1.0"
+                }
+              }
+            },
+            "morgan": {
+              "version": "1.3.2",
+              "from": "morgan@>=1.3.2 <1.4.0",
+              "dependencies": {
+                "basic-auth": {
+                  "version": "1.0.0",
+                  "from": "basic-auth@1.0.0",
+                  "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
+                },
+                "on-finished": {
+                  "version": "2.1.0",
+                  "from": "on-finished@2.1.0",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.0.5",
+                      "from": "ee-first@1.0.5",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+                    }
+                  }
+                }
+              }
             },
             "multiparty": {
-              "version": "2.2.0",
-              "from": "multiparty@2.2.0",
+              "version": "3.3.2",
+              "from": "multiparty@3.3.2",
+              "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
               "dependencies": {
                 "readable-stream": {
-                  "version": "1.1.10",
-                  "from": "readable-stream@~1.1.9",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.9 <1.2.0",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
-                    "debuglog": {
-                      "version": "0.0.2",
-                      "from": "debuglog@0.0.2"
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0"
                     }
                   }
                 },
                 "stream-counter": {
                   "version": "0.2.0",
-                  "from": "stream-counter@~0.2.0"
+                  "from": "stream-counter@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
                 }
               }
+            },
+            "on-headers": {
+              "version": "1.0.0",
+              "from": "on-headers@>=1.0.0 <1.1.0"
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0"
+            },
+            "qs": {
+              "version": "2.2.4",
+              "from": "qs@2.2.4",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.4.tgz"
+            },
+            "response-time": {
+              "version": "2.0.1",
+              "from": "response-time@>=2.0.1 <2.1.0"
+            },
+            "serve-favicon": {
+              "version": "2.1.7",
+              "from": "serve-favicon@>=2.1.5 <2.2.0",
+              "dependencies": {
+                "etag": {
+                  "version": "1.5.1",
+                  "from": "etag@>=1.5.0 <1.6.0",
+                  "dependencies": {
+                    "crc": {
+                      "version": "3.2.1",
+                      "from": "crc@3.2.1",
+                      "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
+                    }
+                  }
+                },
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "serve-index": {
+              "version": "1.2.1",
+              "from": "serve-index@>=1.2.1 <1.3.0",
+              "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.2.1.tgz",
+              "dependencies": {
+                "accepts": {
+                  "version": "1.1.4",
+                  "from": "accepts@>=1.1.0 <1.2.0",
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.0.10",
+                      "from": "mime-types@>=2.0.4 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.8.0",
+                          "from": "mime-db@>=1.8.0 <1.9.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                        }
+                      }
+                    },
+                    "negotiator": {
+                      "version": "0.4.9",
+                      "from": "negotiator@0.4.9",
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+                    }
+                  }
+                },
+                "batch": {
+                  "version": "0.5.1",
+                  "from": "batch@0.5.1",
+                  "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.1.tgz"
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.6.5",
+              "from": "serve-static@>=1.6.4 <1.7.0",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.5.tgz",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.1",
+                  "from": "escape-html@1.0.1",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+                },
+                "send": {
+                  "version": "0.9.3",
+                  "from": "send@0.9.3",
+                  "resolved": "https://registry.npmjs.org/send/-/send-0.9.3.tgz",
+                  "dependencies": {
+                    "destroy": {
+                      "version": "1.0.3",
+                      "from": "destroy@1.0.3",
+                      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+                    },
+                    "etag": {
+                      "version": "1.4.0",
+                      "from": "etag@>=1.4.0 <1.5.0",
+                      "dependencies": {
+                        "crc": {
+                          "version": "3.0.0",
+                          "from": "crc@3.0.0",
+                          "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
+                        }
+                      }
+                    },
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "ms@0.6.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                    },
+                    "on-finished": {
+                      "version": "2.1.0",
+                      "from": "on-finished@2.1.0",
+                      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+                      "dependencies": {
+                        "ee-first": {
+                          "version": "1.0.5",
+                          "from": "ee-first@1.0.5",
+                          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+                        }
+                      }
+                    },
+                    "range-parser": {
+                      "version": "1.0.2",
+                      "from": "range-parser@>=1.0.2 <1.1.0"
+                    }
+                  }
+                },
+                "utils-merge": {
+                  "version": "1.0.0",
+                  "from": "utils-merge@1.0.0",
+                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                }
+              }
+            },
+            "type-is": {
+              "version": "1.5.7",
+              "from": "type-is@>=1.5.2 <1.6.0",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
+              "dependencies": {
+                "mime-types": {
+                  "version": "2.0.10",
+                  "from": "mime-types@>=2.0.9 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.8.0",
+                      "from": "mime-db@>=1.1.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "vhost": {
+              "version": "3.0.0",
+              "from": "vhost@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.0.tgz"
+            },
+            "pause": {
+              "version": "0.0.1",
+              "from": "pause@0.0.1",
+              "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
             }
           }
         },
         "source-map": {
-          "version": "0.1.31",
-          "from": "source-map@~0.1.31",
+          "version": "0.1.43",
+          "from": "source-map@>=0.1.31 <0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "dependencies": {
             "amdefine": {
               "version": "0.1.0",
@@ -530,142 +3294,362 @@
         }
       }
     },
-    "grunt-contrib-jshint": {
-      "version": "0.6.5",
-      "from": "grunt-contrib-jshint@~0.6.4",
+    "karma-jasmine": {
+      "version": "0.1.5",
+      "from": "karma-jasmine@>=0.1.5 <0.2.0",
+      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.1.5.tgz"
+    },
+    "karma-phantomjs-launcher": {
+      "version": "0.1.4",
+      "from": "karma-phantomjs-launcher@>=0.1.1 <0.2.0",
       "dependencies": {
-        "jshint": {
-          "version": "2.1.11",
-          "from": "jshint@~2.1.10",
+        "phantomjs": {
+          "version": "1.9.16",
+          "from": "phantomjs@>=1.9.0 <1.10.0",
+          "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.16.tgz",
           "dependencies": {
-            "shelljs": {
-              "version": "0.1.4",
-              "from": "shelljs@0.1.x"
+            "adm-zip": {
+              "version": "0.4.4",
+              "from": "adm-zip@0.4.4",
+              "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
             },
-            "underscore": {
-              "version": "1.4.4",
-              "from": "underscore@1.4.x"
-            },
-            "cli": {
-              "version": "0.4.5",
-              "from": "cli@0.4.x",
+            "fs-extra": {
+              "version": "0.16.5",
+              "from": "fs-extra@>=0.16.0 <0.17.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
               "dependencies": {
-                "glob": {
-                  "version": "3.2.8",
-                  "from": "glob@>= 3.1.4",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.8.tgz",
+                "graceful-fs": {
+                  "version": "3.0.6",
+                  "from": "graceful-fs@>=3.0.5 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                },
+                "jsonfile": {
+                  "version": "2.0.0",
+                  "from": "jsonfile@>=2.0.0 <3.0.0"
+                },
+                "rimraf": {
+                  "version": "2.3.2",
+                  "from": "rimraf@>=2.2.8 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
                   "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2"
+                    "glob": {
+                      "version": "4.5.3",
+                      "from": "glob@>=4.4.2 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0"
+                        },
+                        "minimatch": {
+                          "version": "2.0.4",
+                          "from": "minimatch@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.0",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.2.0",
+                                  "from": "balanced-match@>=0.2.0 <0.3.0"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.1",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }
               }
             },
-            "minimatch": {
-              "version": "0.2.14",
-              "from": "minimatch@~0.2",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@2"
-                },
-                "sigmund": {
-                  "version": "1.0.0",
-                  "from": "sigmund@~1.0.0"
-                }
-              }
-            },
-            "console-browserify": {
-              "version": "0.1.6",
-              "from": "console-browserify@0.1.x"
-            }
-          }
-        }
-      }
-    },
-    "karma-jasmine": {
-      "version": "0.1.5",
-      "from": "karma-jasmine@~0.1.5"
-    },
-    "karma-phantomjs-launcher": {
-      "version": "0.1.1",
-      "from": "karma-phantomjs-launcher@~0.1.1",
-      "dependencies": {
-        "phantomjs": {
-          "version": "1.9.2-6",
-          "from": "phantomjs@~1.9",
-          "dependencies": {
-            "adm-zip": {
-              "version": "0.2.1",
-              "from": "adm-zip@0.2.1"
-            },
             "kew": {
-              "version": "0.1.7",
-              "from": "kew@~0.1.7"
-            },
-            "ncp": {
-              "version": "0.4.2",
-              "from": "ncp@0.4.2"
+              "version": "0.4.0",
+              "from": "kew@0.4.0",
+              "resolved": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz"
             },
             "npmconf": {
-              "version": "0.0.24",
-              "from": "npmconf@0.0.24",
+              "version": "2.1.1",
+              "from": "npmconf@2.1.1",
+              "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
               "dependencies": {
                 "config-chain": {
                   "version": "1.1.8",
-                  "from": "config-chain@~1.1.1",
+                  "from": "config-chain@>=1.1.8 <1.2.0",
                   "dependencies": {
                     "proto-list": {
-                      "version": "1.2.2",
-                      "from": "proto-list@~1.2.1"
+                      "version": "1.2.3",
+                      "from": "proto-list@>=1.2.1 <1.3.0"
                     }
                   }
                 },
                 "inherits": {
-                  "version": "1.0.0",
-                  "from": "inherits@1"
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <2.1.0"
                 },
-                "once": {
-                  "version": "1.1.1",
-                  "from": "once@~1.1.1"
+                "ini": {
+                  "version": "1.3.3",
+                  "from": "ini@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
                 },
-                "osenv": {
-                  "version": "0.0.3",
-                  "from": "osenv@0.0.3"
-                },
-                "nopt": {
-                  "version": "2.1.2",
-                  "from": "nopt@2",
+                "mkdirp": {
+                  "version": "0.5.0",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.4",
-                      "from": "abbrev@1"
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
-                "semver": {
-                  "version": "1.1.4",
-                  "from": "semver@~1.1.0"
+                "nopt": {
+                  "version": "3.0.1",
+                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.5",
+                      "from": "abbrev@>=1.0.0 <2.0.0"
+                    }
+                  }
                 },
-                "ini": {
-                  "version": "1.1.0",
-                  "from": "ini@~1.1.0"
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@>=1.3.0 <1.4.0",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.1.0",
+                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
+                },
+                "semver": {
+                  "version": "4.3.3",
+                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
+                },
+                "uid-number": {
+                  "version": "0.0.5",
+                  "from": "uid-number@0.0.5",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
                 }
               }
             },
-            "mkdirp": {
-              "version": "0.3.5",
-              "from": "mkdirp@0.3.5"
+            "progress": {
+              "version": "1.1.8",
+              "from": "progress@1.1.8",
+              "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
             },
-            "rimraf": {
-              "version": "2.2.5",
-              "from": "rimraf@~2.2.5"
+            "request": {
+              "version": "2.42.0",
+              "from": "request@2.42.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.6.0",
+                  "from": "caseless@>=0.6.0 <0.7.0"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@>=0.5.0 <0.6.0"
+                },
+                "qs": {
+                  "version": "1.2.2",
+                  "from": "qs@>=1.2.0 <1.3.0"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "mime-types@>=1.0.1 <1.1.0"
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0"
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "from": "tough-cookie@>=0.12.0",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@>=0.2.0",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                    }
+                  }
+                },
+                "form-data": {
+                  "version": "0.1.4",
+                  "from": "form-data@>=0.1.0 <0.2.0",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.7",
+                      "from": "combined-stream@>=0.0.4 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        }
+                      }
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "mime@>=1.2.11 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                    },
+                    "async": {
+                      "version": "0.9.0",
+                      "from": "async@>=0.9.0 <0.10.0"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.4.0",
+                  "from": "oauth-sign@>=0.4.0 <0.5.0"
+                },
+                "hawk": {
+                  "version": "1.1.1",
+                  "from": "hawk@1.1.1",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@>=0.9.0 <0.10.0"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@>=0.4.0 <0.5.0"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@>=0.2.0 <0.3.0"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@>=0.2.0 <0.3.0"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0"
+                }
+              }
+            },
+            "request-progress": {
+              "version": "0.3.1",
+              "from": "request-progress@0.3.1",
+              "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+              "dependencies": {
+                "throttleit": {
+                  "version": "0.0.2",
+                  "from": "throttleit@>=0.0.2 <0.1.0"
+                }
+              }
             },
             "which": {
-              "version": "1.0.5",
-              "from": "which@~1.0.5"
+              "version": "1.0.9",
+              "from": "which@>=1.0.5 <1.1.0",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
             }
           }
         }

--- a/frontend-maven-plugin/src/it/example project/package.json
+++ b/frontend-maven-plugin/src/it/example project/package.json
@@ -1,11 +1,11 @@
 {
   "name": "example",
   "version": "0.0.1",
-  "devDependencies": {
+  "dependencies": {
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.9",
     "grunt-karma": "~0.7.0",
-    "karma": "~0.11.2",
+    "karma": "~0.12.0",
     "grunt-contrib-jshint": "~0.6.4",
     "karma-jasmine": "~0.1.5",
     "karma-phantomjs-launcher": "~0.1.1",

--- a/frontend-maven-plugin/src/it/example project/pom.xml
+++ b/frontend-maven-plugin/src/it/example project/pom.xml
@@ -23,8 +23,8 @@
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v0.10.30</nodeVersion>
-                            <npmVersion>1.4.21</npmVersion>
+                            <nodeVersion>v0.12.2</nodeVersion>
+                            <npmVersion>2.7.6</npmVersion>
                         </configuration>
                     </execution>
 


### PR DESCRIPTION
Problem: the integration test fails because the
example project doesn't build.

Solution: Upgrade Node and npm to the latest
versions, tweak package.json.

We also move packages from devDependencies
back to dependencies, so we can lock down
the versions with npm-shrinkwrap.json.

A new shrinkwrap file was created, with updated
dependencies.