### PR TITLE
Prepend node and npm directories to PATH

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProcessExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProcessExecutor.java
@@ -87,11 +87,12 @@ final class ProcessExecutor {
         }
 
         StringBuilder pathBuilder = new StringBuilder();
-        if (pathVarValue != null) {
-            pathBuilder.append(pathVarValue).append(File.pathSeparator);
-        }
+
         pathBuilder.append(workingDirectory + File.separator + "node").append(File.pathSeparator);
         pathBuilder.append(workingDirectory + File.separator + "node" + File.separator + "npm" + File.separator + "bin");
+        if (pathVarValue != null) {
+            pathBuilder.append(File.pathSeparator).append(pathVarValue);
+        }
         environment.put(pathVarName, pathBuilder.toString());
 
         return pbuilder;


### PR DESCRIPTION
Appending these folders to PATH give them the lowest possible priority, thus if any other version of node/npm is found in PATH these will be used instead when called from a build script. This can lead to errors due to (e.g.) incompatible versions or permission problems.

By prepending the directories to PATH instead the bundled versions will take precedence over any other version already present on the system. This will ensure that any call to node or npm from the frontend-maven-plugin will use the bundled version, thus eliminating the problems mentioned above.