### PR TITLE
Add plexus-utils and use CommandLineUtils to parse arguments

### DIFF
--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -40,5 +40,11 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.5</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.0.17</version>
+        </dependency>
     </dependencies>
 </project>

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeTaskExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeTaskExecutor.java
@@ -1,5 +1,6 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
+import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,7 +14,7 @@ import static com.github.eirslett.maven.plugins.frontend.lib.Utils.*;
 abstract class NodeTaskExecutor {
     private static final String DS = "//";
     private static final String AT = "@";
-    
+
     private final Logger logger;
     private final String taskName;
     private final String taskLocation;
@@ -45,18 +46,19 @@ abstract class NodeTaskExecutor {
         }
     }
 
-    private List<String> getArguments(String args) {
-        List<String> arguments = new ArrayList<String>();
-        if (args != null && !args.equals("null") && !args.isEmpty()) {
-            arguments.addAll(Arrays.asList(args.split("\\s+")));
-        }
-
-        for (String argument : additionalArguments) {
-            if (!arguments.contains(argument)) {
-                arguments.add(argument);
+    private List<String> getArguments(String args) throws TaskRunnerException {
+        try {
+            List<String> arguments = new ArrayList<String>(Arrays.asList(CommandLineUtils.translateCommandline(args)));
+            for(String argument: additionalArguments){
+                if(!arguments.contains(argument)){
+                    arguments.add(argument);
+                }
             }
+            return arguments;
         }
-        return arguments;
+        catch (Exception e) {
+            throw new TaskRunnerException("bad command args", e);
+        }
     }
 
     private static String taskToString(String taskName, List<String> arguments) {


### PR DESCRIPTION
Thanks for your continued work on this plugin!

This should solve the issue I'm having with spaces, but if you want to avoid adding a dependency you may want to look into CommandLineUtils.translateCommandline() to see how they handle it in plexus-utils.
