### PR TITLE
Changed testFailureIgnore property to be consistent with surefire.

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ By default, no colors will be shown in the log.
 ```
 __Skipping tests:__ If you run maven with the `-DskipTests` flag, karma tests will be skipped.
 
-__Ignoring failed tests:__ If you want to ignore test failures run maven with the `-DtestFailureIgnore` flag, karma test results will not stop the build but test results will remain
+__Ignoring failed tests:__ If you want to ignore test failures run maven with the `-Dmaven.test.failure.ignore` flag, karma test results will not stop the build but test results will remain
 in test output files. Suitable for continuous integration tool builds.
 
 __Why karma.conf.ci.js?__ When using Karma, you should have two separate

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
@@ -37,7 +37,7 @@ public final class KarmaRunMojo extends AbstractMojo {
     /**
      * Whether you should continue build when some test will fail (default is false)
      */
-    @Parameter(property = "testFailureIgnore", required = false, defaultValue = "false")
+    @Parameter(property = "maven.test.failure.ignore", required = false, defaultValue = "false")
     private Boolean testFailureIgnore;
 
     /**


### PR DESCRIPTION
Currently, the parameter to ignore test failures (testFailureIgnore) is mapped to the property 'testFailureIgnore'. This is inconsistent with maven surefire, which uses the property "maven.test.failure.ignore".

By using using this property as well, we will automatically get the same handling in Jenkins as with regular Java builds, i.e. the build will be marked as unstable instead of failed when test failures occur.

This PR introduces a slight usage change, because servers explicitly using "-DtestFailureIgnore" might behave differently (configuration in the POM is unaffected)