### PR TITLE
Run karma in the process-test-classes phase by default.

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
@@ -13,7 +13,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.slf4j.LoggerFactory;
 
 
-@Mojo(name="karma",  defaultPhase = LifecyclePhase.TEST)
+@Mojo(name="karma",  defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES)
 public final class KarmaRunMojo extends AbstractMojo {
 
     /**


### PR DESCRIPTION
This is the last phase before test and allows karma to be run BEFORE maven-surefire-plugin in a war project.

That way, test results of karma (using a junit-reporter) can automatically be picked up by CI servers listening explicitly for the result of surefire (Jenkins and Hudson).

Otherwise, karma would run after surefire, and when Jenkins reads test result, it would not get karma result.