### PR TITLE
Passthrough additional environment variables

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
@@ -11,6 +11,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.Map;
 
 public abstract class AbstractFrontendMojo extends AbstractMojo {
 
@@ -34,6 +35,13 @@ public abstract class AbstractFrontendMojo extends AbstractMojo {
    */
   @Parameter(property = "installDirectory", required = false)
   protected File installDirectory;
+
+
+  /**
+   * Additional environment variables to pass to the build.
+   */
+   @Parameter
+   protected Map<String, String> environmentVariables;
 
   /**
    * Determines if this execution should be skipped.

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/BowerMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/BowerMojo.java
@@ -28,6 +28,6 @@ public final class BowerMojo extends AbstractFrontendMojo {
 
     @Override
     protected void execute(FrontendPluginFactory factory) throws TaskRunnerException {
-        factory.getBowerRunner().execute(arguments);
+        factory.getBowerRunner().execute(arguments, environmentVariables);
     }
 }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/EmberMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/EmberMojo.java
@@ -61,7 +61,7 @@ public final class EmberMojo extends AbstractFrontendMojo {
     @Override
     public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
         if (shouldExecute()) {
-            factory.getEmberRunner().execute(arguments);
+            factory.getEmberRunner().execute(arguments, environmentVariables);
 
             if (outputdir != null) {
                 getLog().info("Refreshing files after ember: " + outputdir);

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
@@ -61,7 +61,7 @@ public final class GruntMojo extends AbstractFrontendMojo {
     @Override
     public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
         if (shouldExecute()) {
-            factory.getGruntRunner().execute(arguments);
+            factory.getGruntRunner().execute(arguments, environmentVariables);
 
             if (outputdir != null) {
                 getLog().info("Refreshing files after grunt: " + outputdir);

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
@@ -61,7 +61,7 @@ public final class GulpMojo extends AbstractFrontendMojo {
     @Override
     public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
         if (shouldExecute()) {
-            factory.getGulpRunner().execute(arguments);
+            factory.getGulpRunner().execute(arguments, environmentVariables);
 
             if (outputdir != null) {
                 getLog().info("Refreshing files after gulp: " + outputdir);

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/JspmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/JspmMojo.java
@@ -33,7 +33,7 @@ public class JspmMojo extends AbstractFrontendMojo {
 
     @Override
     protected void execute(FrontendPluginFactory factory) throws TaskRunnerException {
-        factory.getJspmRunner().execute(arguments);
+        factory.getJspmRunner().execute(arguments, environmentVariables);
     }
 
 }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
@@ -37,7 +37,7 @@ public final class KarmaRunMojo extends AbstractFrontendMojo {
     @Override
     public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
         try {
-            factory.getKarmaRunner().execute("start " + karmaConfPath);
+            factory.getKarmaRunner().execute("start " + karmaConfPath, environmentVariables);
         }
         catch (TaskRunnerException e) {
             if (testFailureIgnore) {

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -47,7 +47,7 @@ public final class NpmMojo extends AbstractFrontendMojo {
         File packageJson = new File(workingDirectory, "package.json");
         if (buildContext == null || buildContext.hasDelta(packageJson) || !buildContext.isIncremental()) {
             ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session, decrypter);
-            factory.getNpmRunner(proxyConfig).execute(arguments);
+            factory.getNpmRunner(proxyConfig).execute(arguments, environmentVariables);
         } else {
             getLog().info("Skipping npm install as package.json unchanged");
         }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/WebpackMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/WebpackMojo.java
@@ -61,7 +61,7 @@ public final class WebpackMojo extends AbstractFrontendMojo {
     @Override
     public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
         if (shouldExecute()) {
-            factory.getWebpackRunner().execute(arguments);
+            factory.getWebpackRunner().execute(arguments, environmentVariables);
 
             if (outputdir != null) {
                 getLog().info("Refreshing files after webpack: " + outputdir);

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/BowerRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/BowerRunner.java
@@ -1,8 +1,6 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
-public interface BowerRunner {
-    void execute(String args) throws TaskRunnerException;
-}
+public interface BowerRunner extends NodeTaskRunner {}
 
 final class DefaultBowerRunner extends NodeTaskExecutor implements BowerRunner {
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/EmberRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/EmberRunner.java
@@ -1,8 +1,6 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
-public interface EmberRunner {
-    void execute(String args) throws TaskRunnerException;
-}
+public interface EmberRunner extends NodeTaskRunner {}
 
 final class DefaultEmberRunner extends NodeTaskExecutor implements EmberRunner {
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GruntRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GruntRunner.java
@@ -2,9 +2,7 @@ package com.github.eirslett.maven.plugins.frontend.lib;
 
 import java.util.Arrays;
 
-public interface GruntRunner {
-    void execute(String args) throws TaskRunnerException;
-}
+public interface GruntRunner extends NodeTaskRunner {}
 
 final class DefaultGruntRunner extends NodeTaskExecutor implements GruntRunner {
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GulpRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GulpRunner.java
@@ -2,9 +2,7 @@ package com.github.eirslett.maven.plugins.frontend.lib;
 
 import java.util.Arrays;
 
-public interface GulpRunner {
-    void execute(String args) throws TaskRunnerException;
-}
+public interface GulpRunner  extends NodeTaskRunner {}
 
 final class DefaultGulpRunner extends NodeTaskExecutor implements GulpRunner {
     private static final String TASK_LOCATION = "node_modules/gulp/bin/gulp.js";

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/JspmRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/JspmRunner.java
@@ -1,9 +1,6 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
-public interface JspmRunner {
-    void execute(String args) throws TaskRunnerException;
-}
-
+public interface JspmRunner extends NodeTaskRunner {}
 
 final class DefaultJspmRunner extends NodeTaskExecutor implements JspmRunner {
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/KarmaRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/KarmaRunner.java
@@ -2,9 +2,7 @@ package com.github.eirslett.maven.plugins.frontend.lib;
 
 import java.util.Arrays;
 
-public interface KarmaRunner {
-    void execute(String args) throws TaskRunnerException;
-}
+public interface KarmaRunner extends NodeTaskRunner {}
 
 final class DefaultKarmaRunner extends NodeTaskExecutor implements KarmaRunner {
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeAndNPMInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeAndNPMInstaller.java
@@ -77,7 +77,7 @@ final class DefaultNodeAndNPMInstaller implements NodeAndNPMInstaller {
                 NodeExecutorConfig executorConfig = new InstallNodeExecutorConfig(config);
                 File nodeFile = executorConfig.getNodePath();
                 if(nodeFile.exists()){
-                    final String version = new NodeExecutor(executorConfig, Arrays.asList("--version")).executeAndGetResult();
+                    final String version = new NodeExecutor(executorConfig, Arrays.asList("--version"), null).executeAndGetResult();
 
                     if(version.equals(nodeVersion)){
                         logger.info("Node " + version + " is already installed.");

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutor.java
@@ -4,11 +4,12 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 final class NodeExecutor {
     private final ProcessExecutor executor;
 
-    public NodeExecutor(NodeExecutorConfig config, List<String> arguments){
+    public NodeExecutor(NodeExecutorConfig config, List<String> arguments, Map<String, String> additionalEnvironment){
         final String node = config.getNodePath().getAbsolutePath();
         List<String> localPaths = new ArrayList<String>();
         localPaths.add(config.getNodePath().getParent());
@@ -17,7 +18,7 @@ final class NodeExecutor {
             localPaths,
             Utils.prepend(node, arguments),
             config.getPlatform(),
-            null);
+            additionalEnvironment);
     }
 
     public String executeAndGetResult() throws ProcessExecutionException {

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutor.java
@@ -16,7 +16,8 @@ final class NodeExecutor {
             config.getWorkingDirectory(),
             localPaths,
             Utils.prepend(node, arguments),
-            config.getPlatform());
+            config.getPlatform(),
+            null);
     }
 
     public String executeAndGetResult() throws ProcessExecutionException {

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeTaskExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeTaskExecutor.java
@@ -12,6 +12,7 @@ import java.util.List;
 import static com.github.eirslett.maven.plugins.frontend.lib.Utils.implode;
 import static com.github.eirslett.maven.plugins.frontend.lib.Utils.normalize;
 import static com.github.eirslett.maven.plugins.frontend.lib.Utils.prepend;
+import java.util.Map;
 
 abstract class NodeTaskExecutor {
     private static final String DS = "//";
@@ -48,13 +49,13 @@ abstract class NodeTaskExecutor {
     }
 
 
-    public final void execute(String args) throws TaskRunnerException {
+    public final void execute(String args, Map<String, String> environment) throws TaskRunnerException {
         final String absoluteTaskLocation = getAbsoluteTaskLocation();
         final List<String> arguments = getArguments(args);
         logger.info("Running " + taskToString(taskName, arguments) + " in " + config.getWorkingDirectory());
 
         try {
-            final int result = new NodeExecutor(config, prepend(absoluteTaskLocation, arguments)).executeAndRedirectOutput(logger);
+            final int result = new NodeExecutor(config, prepend(absoluteTaskLocation, arguments), environment).executeAndRedirectOutput(logger);
             if (result != 0) {
                 throw new TaskRunnerException(taskToString(taskName, arguments) + " failed. (error code " + result + ")");
             }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeTaskRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeTaskRunner.java
@@ -1,0 +1,7 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import java.util.Map;
+
+interface NodeTaskRunner {
+	void execute(String args, Map<String,String> environment) throws TaskRunnerException;
+}

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
@@ -5,9 +5,7 @@ import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 
-public interface NpmRunner {
-    void execute(String args) throws TaskRunnerException;
-}
+public interface NpmRunner extends NodeTaskRunner {}
 
 final class DefaultNpmRunner extends NodeTaskExecutor implements NpmRunner {
     static final String TASK_NAME = "npm";

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProcessExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProcessExecutor.java
@@ -25,12 +25,14 @@ final class ProcessExecutor {
     private final List<String> command;
     private final ProcessBuilder processBuilder;
     private final Platform platform;
+    private final Map<String, String> additionalEnvironment;
 
-    public ProcessExecutor(File workingDirectory, List<String> paths, List<String> command, Platform platform){
+    public ProcessExecutor(File workingDirectory, List<String> paths, List<String> command, Platform platform, Map<String, String> additionalEnvironment){
         this.workingDirectory = workingDirectory;
         this.localPaths = paths;
         this.command = command;
         this.platform = platform;
+        this.additionalEnvironment = additionalEnvironment;
 
         this.processBuilder = createProcessBuilder();
     }
@@ -97,6 +99,9 @@ final class ProcessExecutor {
         }
         environment.put(pathVarName, pathBuilder.toString());
 
+        if (additionalEnvironment != null) {
+            environment.putAll(additionalEnvironment);
+        }
         return pbuilder;
     }
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/WebpackRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/WebpackRunner.java
@@ -2,9 +2,7 @@ package com.github.eirslett.maven.plugins.frontend.lib;
 
 import java.util.ArrayList;
 
-public interface WebpackRunner {
-    void execute(String args) throws TaskRunnerException;
-}
+public interface WebpackRunner extends NodeTaskRunner {}
 
 final class DefaultWebpackRunner extends NodeTaskExecutor implements WebpackRunner {
 


### PR DESCRIPTION
This PR allows all Mojos to pass through additional environment variables to the build, accessible there through `process.env`.
This is a relatively quick and convenient way to transport (e.g.) Maven properties into the Node world, which is what I would be using it for.
```
<configuration>
    <environmentVariables>
        <OUTPUT_DIR>${project.build.directory}</OUTPUT_DIR>
    </environmentVariables> 
</configuration>
```
It would also fix #158.