### PR TITLE
copy NPM directory if rename was not successful

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeAndNPMInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeAndNPMInstaller.java
@@ -167,13 +167,18 @@ final class DefaultNodeAndNPMInstaller implements NodeAndNPMInstaller {
                 // see https://github.com/eirslett/frontend-maven-plugin/issues/65#issuecomment-52024254
                 File packageDirectory = new File(workingDirectory, "./node/package");
                 if (packageDirectory.exists() && !npmDirectory.exists()) {
-                    packageDirectory.renameTo(npmDirectory);
+                    if (! packageDirectory.renameTo(npmDirectory)) {
+                        logger.warn("Cannot rename NPM directory, making a copy.");
+                        FileUtils.copyDirectory(packageDirectory, npmDirectory);
+                    }
                 }
                 logger.info("Installed NPM locally.");
             } catch (DownloadException e) {
                 throw new InstallationException("Could not download npm", e);
             } catch (ArchiveExtractionException e) {
                 throw new InstallationException("Could not extract the npm archive", e);
+            } catch (IOException e) {
+                throw new InstallationException("Could not copy npm", e);
             }
         }
 


### PR DESCRIPTION
This PR solves problem mentioned in [issue 169](https://github.com/eirslett/frontend-maven-plugin/issues/169) and [issue 147](https://github.com/eirslett/frontend-maven-plugin/issues/147). Sometimes on Windows computer NPM directory rename fails. This change copies NPM directory if rename was not successful.