### PR TITLE
npmRegistryURL

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -27,6 +27,12 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
     private String npmDownloadRoot;
 
     /**
+     * Registry override, passed as the registry option during npm install if set.
+     */
+    @Parameter(property = "npmRegistryURL", required = false, defaultValue = "")
+    private String npmRegistryURL;
+
+    /**
      * Where to download Node.js and NPM binaries from.
      *
      * @deprecated use {@link #nodeDownloadRoot} and {@link #npmDownloadRoot} instead, this configuration will be used only when no {@link #nodeDownloadRoot} or {@link #npmDownloadRoot} is specified.

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
@@ -20,6 +20,12 @@ final class DefaultNpmRunner extends NodeTaskExecutor implements NpmRunner {
         List<String> arguments = new ArrayList<String>();
         arguments.add("--color=false");
 
+        String npmRegistryURL = System.getProperty("npmRegistryURL");
+        if (npmRegistryURL != null)
+        {
+            arguments.add ("--registry=" + npmRegistryURL);
+        }
+
         if (!proxyConfig.isEmpty()) {
             Proxy secureProxy = proxyConfig.getSecureProxy();
             if (secureProxy != null){


### PR DESCRIPTION
Extra property setting 'npmRegistryURL' added so that no changes are required to the pom.xml to specify a local/internal registry.

Required because internal build policy at Red Hat has to allow repeatable builds, which means we need to mirror the NPM registry,  and as we do not want to change code (pom.xml) and add a static internal redhat NPM registry, which will not be public, this way we can specify the registry during our build process and still leave the source to use the default when external.
