### PR TITLE
Clarify README to state download roots must point to the same repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Node/npm will only be "installed" locally to your project. It will not be instal
 </execution>
 ```
 
-You can also specify separate download roots for npm and node as they are now stored in separate repos.
+You can also specify separate download roots for npm and node as long as they are stored in the same repo.
 ```xml
 <execution>
     ...


### PR DESCRIPTION
Regarding download roots, the install instructions state that node and npm may have different roots "as they are now stored in separate repos".  However, the example implies the repo must be the same for both roots.
This change rewords that sentence to better convey that, while the download roots may be different, the downloads must come from the same repo.