### PR TITLE
Correct markup in PR 237

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can also specify separate download roots for npm and node as they are now st
     <configuration>
         <nodeVersion>v0.12.1</nodeVersion>
         <npmVersion>2.7.1</npmVersion>
-        <nodeDownloadRoot>http://nodejs.org/nodejs/dist/</nodeDownloadRoot
+        <nodeDownloadRoot>http://nodejs.org/nodejs/dist/</nodeDownloadRoot>
         <npmDownloadRoot>http://npm.org/npm/-/</npmDownloadRoot>
     </configuration>
 </execution>


### PR DESCRIPTION
Pull request 237 (Enhance example of different download roots) was missing the trailing angle bracket on `nodeDownloadRoot`.