### PR TITLE
Maven prereq >= 3.1.0, added slf4j-simple to resolve missing StaticLoggerBinder error

### DIFF
--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -12,7 +12,7 @@
 
     <name>Maven Frontend Plugin</name>
     <prerequisites>
-        <maven>3.1.0</maven>
+        <maven>>=3.1.0</maven>
     </prerequisites>
 
     <description>

--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -40,5 +40,11 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.5</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.5</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Hi, nice plugin. The mojo appears to be compatible with the latest Maven version -- It doesn't appear necessary to restrict it to 3.1.0.  I also added a dependency on slf4j-simple to resolve the missing StaticLoggerBinder error.