### PR TITLE
Allow any Mojo to be skipped during test phase.

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
@@ -39,7 +39,15 @@ public abstract class AbstractFrontendMojo extends AbstractMojo {
    * Determines if this execution should be skipped.
    */
   private boolean skipTestPhase() {
-    return skipTests && execution.getLifecyclePhase().equals("test");
+    return skipTests && isTestingPhase();
+  }
+
+  /**
+   * Determines if the current execution is during a testing phase (e.g., "test" or "integration-test").
+   */
+  private boolean isTestingPhase() {
+    String phase = execution.getLifecyclePhase();
+    return phase.equals("test") || phase.equals("integration-test");
   }
 
   protected abstract void execute(FrontendPluginFactory factory) throws FrontendException;

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/BowerMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/BowerMojo.java
@@ -22,7 +22,7 @@ public final class BowerMojo extends AbstractFrontendMojo {
     private Boolean skip;
 
     @Override
-    protected boolean isSkipped() {
+    protected boolean skipExecution() {
         return this.skip;
     }
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/EmberMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/EmberMojo.java
@@ -54,7 +54,7 @@ public final class EmberMojo extends AbstractFrontendMojo {
     private BuildContext buildContext;
 
     @Override
-    protected boolean isSkipped() {
+    protected boolean skipExecution() {
         return this.skip;
     }
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
@@ -54,7 +54,7 @@ public final class GruntMojo extends AbstractFrontendMojo {
     private BuildContext buildContext;
 
     @Override
-    protected boolean isSkipped() {
+    protected boolean skipExecution() {
         return this.skip;
     }
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
@@ -54,7 +54,7 @@ public final class GulpMojo extends AbstractFrontendMojo {
     private BuildContext buildContext;
 
     @Override
-    protected boolean isSkipped() {
+    protected boolean skipExecution() {
         return this.skip;
     }
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -60,7 +60,7 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
     private SettingsDecrypter decrypter;
 
     @Override
-    protected boolean isSkipped() {
+    protected boolean skipExecution() {
         return this.skip;
     }
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/JspmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/JspmMojo.java
@@ -27,7 +27,7 @@ public class JspmMojo extends AbstractFrontendMojo {
     private Boolean skip;
 
     @Override
-    protected boolean isSkipped() {
+    protected boolean skipExecution() {
         return this.skip;
     }
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
@@ -18,12 +18,6 @@ public final class KarmaRunMojo extends AbstractFrontendMojo {
     private String karmaConfPath;
 
     /**
-     * Whether you should skip running the tests (default is false)
-     */
-    @Parameter(property = "skipTests", required = false, defaultValue = "false")
-    private Boolean skipTests;
-
-    /**
      * Whether you should continue build when some test will fail (default is false)
      */
     @Parameter(property = "testFailureIgnore", required = false, defaultValue = "false")
@@ -36,19 +30,14 @@ public final class KarmaRunMojo extends AbstractFrontendMojo {
     private Boolean skip;
 
     @Override
-    protected boolean isSkipped() {
+    protected boolean skipExecution() {
         return this.skip;
     }
 
     @Override
     public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
         try {
-            if (skipTests) {
-                LoggerFactory.getLogger(KarmaRunMojo.class).info("Skipping karma tests.");
-            }
-            else {
-                factory.getKarmaRunner().execute("start " + karmaConfPath);
-            }
+            factory.getKarmaRunner().execute("start " + karmaConfPath);
         }
         catch (TaskRunnerException e) {
             if (testFailureIgnore) {

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -38,7 +38,7 @@ public final class NpmMojo extends AbstractFrontendMojo {
     private Boolean skip;
 
     @Override
-    protected boolean isSkipped() {
+    protected boolean skipExecution() {
         return this.skip;
     }
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/WebpackMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/WebpackMojo.java
@@ -54,7 +54,7 @@ public final class WebpackMojo extends AbstractFrontendMojo {
     private BuildContext buildContext;
 
     @Override
-    protected boolean isSkipped() {
+    protected boolean skipExecution() {
         return this.skip;
     }
 


### PR DESCRIPTION
This addresses #235. Instead of only skipping Karma tests with `-DskipTests` the `AbstractFrontendMojo` now checks to see if `skipTests` is set and if it is running in the `test` phase. If these conditions are met then the execution is skipped. Each additional mojo is still skippable via their respective `skip` configurations.