### PR TITLE
Suggestion: helper scripts are not really necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,9 +262,21 @@ to avoid doing unnecessary work. During an incremental build the `npm` goal will
 has been changed. The `grunt` and `gulp` goals have new `srcdir` and `triggerfiles` optional configuration options; if
 these are set they check for changes in your source files before being run. See the wiki for more information.
 
-# Helper scripts
+# Setting up path
 During development, it's convenient to have the "npm", "bower", "grunt", "gulp" and "karma" commands
-available on the command line. If you want that, use [those helper scripts](https://github.com/eirslett/frontend-maven-plugin/tree/master/frontend-maven-plugin/src/it/example%20project/helper-scripts)!
+available on the command line. If you want that, you can add `./node` and `./node_modules/.bin` to your PATH variable:
+
+* Linux / OS X
+
+  ```sh
+  PATH=./node:./node_modules/.bin:$PATH
+  ```
+
+* Windows
+
+  ```cmd
+  set PATH=".\node;.\node_modules\.bin;%PATH%"
+  ```
 
 ## To build this project:
 `mvn clean install`

--- a/frontend-maven-plugin/src/it/example project/helper-scripts/README.md
+++ b/frontend-maven-plugin/src/it/example project/helper-scripts/README.md
@@ -1,1 +1,0 @@
-Here are some helper scripts. Put them in your working directory (the same directory as your package.json file)

--- a/frontend-maven-plugin/src/it/example project/helper-scripts/bower
+++ b/frontend-maven-plugin/src/it/example project/helper-scripts/bower
@@ -1,2 +1,0 @@
-#!/bin/sh
-"node/node" "node_modules/bower/bin/bower" "$@"

--- a/frontend-maven-plugin/src/it/example project/helper-scripts/bower.cmd
+++ b/frontend-maven-plugin/src/it/example project/helper-scripts/bower.cmd
@@ -1,3 +1,0 @@
-@echo off
-%~dp0node/node node_modules/bower/bin/bower %*
-@echo on

--- a/frontend-maven-plugin/src/it/example project/helper-scripts/grunt
+++ b/frontend-maven-plugin/src/it/example project/helper-scripts/grunt
@@ -1,2 +1,0 @@
-#!/bin/sh
-"node/node" "node_modules/grunt-cli/bin/grunt" "$@"

--- a/frontend-maven-plugin/src/it/example project/helper-scripts/grunt.cmd
+++ b/frontend-maven-plugin/src/it/example project/helper-scripts/grunt.cmd
@@ -1,3 +1,0 @@
-@echo off
-%~dp0node/node node_modules/grunt-cli/bin/grunt %*
-@echo on

--- a/frontend-maven-plugin/src/it/example project/helper-scripts/gulp
+++ b/frontend-maven-plugin/src/it/example project/helper-scripts/gulp
@@ -1,2 +1,0 @@
-#!/bin/sh
-"node/node" "node_modules/gulp/bin/gulp.js" "$@"

--- a/frontend-maven-plugin/src/it/example project/helper-scripts/gulp.cmd
+++ b/frontend-maven-plugin/src/it/example project/helper-scripts/gulp.cmd
@@ -1,3 +1,0 @@
-@echo off
-%~dp0node/node node_modules/gulp/bin/gulp.js %*
-@echo on

--- a/frontend-maven-plugin/src/it/example project/helper-scripts/karma
+++ b/frontend-maven-plugin/src/it/example project/helper-scripts/karma
@@ -1,2 +1,0 @@
-#!/bin/sh
-"node/node" "node_modules/karma/bin/karma" "$@"

--- a/frontend-maven-plugin/src/it/example project/helper-scripts/karma.cmd
+++ b/frontend-maven-plugin/src/it/example project/helper-scripts/karma.cmd
@@ -1,3 +1,0 @@
-@echo off
-%~dp0node/node node_modules/karma/bin/karma %*
-@echo on

--- a/frontend-maven-plugin/src/it/example project/helper-scripts/npm
+++ b/frontend-maven-plugin/src/it/example project/helper-scripts/npm
@@ -1,2 +1,0 @@
-#!/bin/sh
-"node/node" "node/node_modules/npm/bin/npm-cli.js" "$@"

--- a/frontend-maven-plugin/src/it/example project/helper-scripts/npm.cmd
+++ b/frontend-maven-plugin/src/it/example project/helper-scripts/npm.cmd
@@ -1,3 +1,0 @@
-@echo off
-%~dp0node/node node/node_modules/npm/bin/npm-cli.js %*
-@echo on


### PR DESCRIPTION
Since you already have scripts for node and npm in the `/node` directory and npm symlinks in scripts for the other tools into `/node_modules/.bin` you really don't need the helper scripts.  All you need to do is add those two directories to your path.  So, just a suggestion to remove the helper scripts and include instructions for adding those directories to the path instead.