### PR TITLE
Improved proxy support

### DIFF
--- a/frontend-maven-plugin/src/it/settings.xml
+++ b/frontend-maven-plugin/src/it/settings.xml
@@ -8,6 +8,24 @@
       <mirrorOf>*</mirrorOf>
     </mirror>
   </mirrors>
+    <proxies>
+        <proxy>
+            <id>http</id>
+            <active>false</active>
+            <protocol>http</protocol>
+            <host>127.0.0.1</host>
+            <port>3128</port>
+            <nonProxyHosts></nonProxyHosts>
+        </proxy>
+        <proxy>
+            <id>https</id>
+            <active>false</active>
+            <protocol>https</protocol>
+            <host>127.0.0.1</host>
+            <port>3128</port>
+            <nonProxyHosts></nonProxyHosts>
+        </proxy>
+    </proxies>
     <profiles>
         <profile>
             <id>it-repo</id>

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
@@ -11,6 +11,8 @@ import org.codehaus.plexus.util.Scanner;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 class MojoUtils {
@@ -21,20 +23,33 @@ class MojoUtils {
     static ProxyConfig getProxyConfig(MavenSession mavenSession, SettingsDecrypter decrypter) {
         if (mavenSession == null ||
                 mavenSession.getSettings() == null ||
-                mavenSession.getSettings().getActiveProxy() == null ||
-                !mavenSession.getSettings().getActiveProxy().isActive()) {
-            return null;
+                mavenSession.getSettings().getProxies() == null ||
+                mavenSession.getSettings().getProxies().isEmpty()) {
+            return new ProxyConfig(Collections.<ProxyConfig.Proxy>emptyList());
         } else {
-            Proxy mavenProxy = mavenSession.getSettings().getActiveProxy();
-            final DefaultSettingsDecryptionRequest decryptionRequest = new DefaultSettingsDecryptionRequest(mavenProxy);
-            SettingsDecryptionResult decryptedResult = decrypter.decrypt(decryptionRequest);
-            mavenProxy = decryptedResult.getProxy();
-            return new ProxyConfig(mavenProxy.getId(), mavenProxy.getProtocol(), mavenProxy.getHost(),
-                    mavenProxy.getPort(), mavenProxy.getUsername(), mavenProxy.getPassword());
+            final List<Proxy> mavenProxies = mavenSession.getSettings().getProxies();
+
+            final List<ProxyConfig.Proxy> proxies = new ArrayList<ProxyConfig.Proxy>(mavenProxies.size());
+
+            for (Proxy mavenProxy : mavenProxies) {
+                if (mavenProxy.isActive()) {
+                    mavenProxy = decryptProxy(mavenProxy, decrypter);
+                    proxies.add(new ProxyConfig.Proxy(mavenProxy.getId(), mavenProxy.getProtocol(), mavenProxy.getHost(),
+                            mavenProxy.getPort(), mavenProxy.getUsername(), mavenProxy.getPassword(), mavenProxy.getNonProxyHosts()));
+                }
+            }
+
+            return new ProxyConfig(proxies);
         }
     }
 
-  static boolean shouldExecute(BuildContext buildContext, List<File> triggerfiles, File srcdir) {
+    private static Proxy decryptProxy(Proxy proxy, SettingsDecrypter decrypter) {
+        final DefaultSettingsDecryptionRequest decryptionRequest = new DefaultSettingsDecryptionRequest(proxy);
+        SettingsDecryptionResult decryptedResult = decrypter.decrypt(decryptionRequest);
+        return decryptedResult.getProxy();
+    }
+
+    static boolean shouldExecute(BuildContext buildContext, List<File> triggerfiles, File srcdir) {
 
     // If there is no buildContext, or this is not an incremental build, always execute.
     if (buildContext == null || !buildContext.isIncremental()) {

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
@@ -1,5 +1,7 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
+import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig.Proxy;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,18 +12,23 @@ public interface NpmRunner {
 final class DefaultNpmRunner extends NodeTaskExecutor implements NpmRunner {
     static final String TASK_NAME = "npm";
 
-    public DefaultNpmRunner(NodeExecutorConfig config, ProxyConfig proxy) {
-        super(config, TASK_NAME, config.getNpmPath().getAbsolutePath(), buildArguments(proxy));
+    public DefaultNpmRunner(NodeExecutorConfig config, ProxyConfig proxyConfig) {
+        super(config, TASK_NAME, config.getNpmPath().getAbsolutePath(), buildArguments(proxyConfig));
     }
 
-    private static List<String> buildArguments(ProxyConfig proxy) {
+    private static List<String> buildArguments(ProxyConfig proxyConfig) {
         List<String> arguments = new ArrayList<String>();
         arguments.add("--color=false");
-        if (proxy != null) {
-            if(proxy.isSecure()){
-                arguments.add("--https-proxy=" + proxy.getUri().toString());
-            } else {
-                arguments.add("--proxy=" + proxy.getUri().toString());
+
+        if (!proxyConfig.isEmpty()) {
+            Proxy secureProxy = proxyConfig.getSecureProxy();
+            if (secureProxy != null){
+                arguments.add("--https-proxy=" + secureProxy.getUri().toString());
+            }
+
+            Proxy insecureProxy = proxyConfig.getInsecureProxy();
+            if (insecureProxy != null) {
+                arguments.add("--proxy=" + insecureProxy.getUri().toString());
             }
         }
         return arguments;


### PR DESCRIPTION
Current proxy support is somewhat naive, retrieving only the first active proxy available in the Maven settings. This PR contains an improvement that retrieves all (active) proxies and uses the first matching based on the protocol used (so when downloading a file from http, the http proxy is used) for downloading node and npm.
When executing npm, both npm arguments --proxy and --https-proxy are set when corresponding proxies are specified.