### PR TITLE
install directory should default to working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Node/npm will only be "installed" locally to your project. It will not be instal
         <npmVersion>1.3.8</npmVersion>
         <!-- optional: where to download node and npm from. Defaults to http://nodejs.org/dist/ -->
         <downloadRoot>http://myproxy.example.org/nodejs/dist/</downloadRoot>
+        <!-- optional: where to install node and npm. Defaults to the working directory -->
+        <installDirectory>target</installDirectory>
     </configuration>
 </execution>
 ```

--- a/frontend-maven-plugin/src/it/custom-install-directory/package.json
+++ b/frontend-maven-plugin/src/it/custom-install-directory/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "example",
+  "version": "0.0.1",
+  "dependencies": {
+    "less": "~2.5.1"
+  }
+}

--- a/frontend-maven-plugin/src/it/custom-install-directory/pom.xml
+++ b/frontend-maven-plugin/src/it/custom-install-directory/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.eirslett</groupId>
+    <artifactId>example</artifactId>
+    <version>0</version>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
+                <version>@project.version@</version>
+
+                <configuration>
+                    <installDirectory>target</installDirectory>
+                </configuration>
+
+                <executions>
+
+                    <execution>
+                        <id>install node and npm</id>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
+                        <configuration>
+                            <nodeVersion>v0.12.2</nodeVersion>
+                            <npmVersion>2.7.6</npmVersion>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>npm install</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <!-- Optional configuration which provides for running any npm command -->
+                        <configuration>
+                            <arguments>install</arguments>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/frontend-maven-plugin/src/it/custom-install-directory/verify.groovy
+++ b/frontend-maven-plugin/src/it/custom-install-directory/verify.groovy
@@ -1,0 +1,2 @@
+assert new File(basedir, 'target/node').exists() : "Node was not installed in the custom install directory";
+assert new File(basedir, 'node_modules').exists() : "Node modules were not installed in the base directory";

--- a/frontend-maven-plugin/src/it/custom-working-directory/pom.xml
+++ b/frontend-maven-plugin/src/it/custom-working-directory/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.eirslett</groupId>
+    <artifactId>example</artifactId>
+    <version>0</version>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
+                <version>@project.version@</version>
+
+                <configuration>
+                    <workingDirectory>src/main/frontend</workingDirectory>
+                </configuration>
+
+                <executions>
+
+                    <execution>
+                        <id>install node and npm</id>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
+                        <configuration>
+                            <nodeVersion>v0.12.2</nodeVersion>
+                            <npmVersion>2.7.6</npmVersion>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>npm install</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <!-- Optional configuration which provides for running any npm command -->
+                        <configuration>
+                            <arguments>install</arguments>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/frontend-maven-plugin/src/it/custom-working-directory/src/main/frontend/package.json
+++ b/frontend-maven-plugin/src/it/custom-working-directory/src/main/frontend/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "example",
+  "version": "0.0.1",
+  "dependencies": {
+    "less": "~2.5.1"
+  }
+}

--- a/frontend-maven-plugin/src/it/custom-working-directory/verify.groovy
+++ b/frontend-maven-plugin/src/it/custom-working-directory/verify.groovy
@@ -1,0 +1,2 @@
+assert new File(basedir, 'src/main/frontend/node').exists() : "Node was not installed in the custom working directory";
+assert new File(basedir, 'src/main/frontend/node_modules').exists() : "Node modules were not installed in the custom working directory";

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
@@ -32,7 +32,7 @@ public abstract class AbstractFrontendMojo extends AbstractMojo {
   /**
    * The base directory for installing node and npm.
    */
-  @Parameter(defaultValue = "${basedir}", property = "installDirectory", required = false)
+  @Parameter(property = "installDirectory", required = false)
   protected File installDirectory;
 
   /**
@@ -60,6 +60,9 @@ public abstract class AbstractFrontendMojo extends AbstractMojo {
   @Override
   public void execute() throws MojoFailureException {
     if (!(skipTestPhase() || skipExecution())) {
+      if (installDirectory == null) {
+        installDirectory = workingDirectory;
+      }
       try {
         execute(new FrontendPluginFactory(workingDirectory, installDirectory));
       } catch (TaskRunnerException e) {


### PR DESCRIPTION
The install directory will now default to the working directory if it hasn't been specified.  I've also updated the README file to mention the `installDirectory` parameter.