### PR TITLE
node v4.0.0 download path fix

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
@@ -67,13 +67,13 @@ class Platform {
     public String getNodeDownloadFilename(String nodeVersion) {
         if(isWindows()) {
             if(architecture == Architecture.x64){
-                if (nodeVersion == "v4.0.0") {
+                if (nodeVersion.equals("v4.0.0")) {
                     return nodeVersion+"/win-x64/node.exe";    
                 } else {
                     return nodeVersion+"/x64/node.exe";
                 }
             } else {
-                if (nodeVersion == "v4.0.0") {
+                if (nodeVersion.equals("v4.0.0")) {
                     return nodeVersion+"/win-x86/node.exe";    
                 } else {
                     return nodeVersion + "/node.exe";

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
@@ -66,14 +66,15 @@ class Platform {
 
     public String getNodeDownloadFilename(String nodeVersion) {
         if(isWindows()) {
+			int versionCompare = nodeVersion.compareTo("v4.0.0");
             if(architecture == Architecture.x64){
-                if ("v4.0.0".equals(nodeVersion)) {
+				if (versionCompare >= 0) {
                     return nodeVersion+"/win-x64/node.exe";    
                 } else {
                     return nodeVersion+"/x64/node.exe";
                 }
             } else {
-                if ("v4.0.0".equals(nodeVersion)) {
+                if (versionCompare < 0) {
                     return nodeVersion+"/win-x86/node.exe";    
                 } else {
                     return nodeVersion + "/node.exe";

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
@@ -74,7 +74,7 @@ class Platform {
                     return nodeVersion+"/x64/node.exe";
                 }
             } else {
-                if (versionCompare < 0) {
+                if (versionCompare >= 0) {
                     return nodeVersion+"/win-x86/node.exe";    
                 } else {
                     return nodeVersion + "/node.exe";

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
@@ -67,13 +67,13 @@ class Platform {
     public String getNodeDownloadFilename(String nodeVersion) {
         if(isWindows()) {
             if(architecture == Architecture.x64){
-                if (nodeVersion.equals("v4.0.0")) {
+                if ("v4.0.0".equals(nodeVersion)) {
                     return nodeVersion+"/win-x64/node.exe";    
                 } else {
                     return nodeVersion+"/x64/node.exe";
                 }
             } else {
-                if (nodeVersion.equals("v4.0.0")) {
+                if ("v4.0.0".equals(nodeVersion)) {
                     return nodeVersion+"/win-x86/node.exe";    
                 } else {
                     return nodeVersion + "/node.exe";

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
@@ -66,18 +66,17 @@ class Platform {
 
     public String getNodeDownloadFilename(String nodeVersion) {
         if(isWindows()) {
-            int versionCompare = nodeVersion.compareTo("v4.0.0");
             if(architecture == Architecture.x64){
-                if (versionCompare >= 0) {
-                    return nodeVersion+"/win-x64/node.exe";    
+                if (nodeVersion.startsWith("v0.")) {
+                    return nodeVersion+"/x64/node.exe";    
                 } else {
-                    return nodeVersion+"/x64/node.exe";
+                    return nodeVersion+"/win-x64/node.exe";
                 }
             } else {
-                if (versionCompare >= 0) {
-                    return nodeVersion+"/win-x86/node.exe";    
+                if (nodeVersion.startsWith("v0.")) {
+                	return nodeVersion + "/node.exe";
                 } else {
-                    return nodeVersion + "/node.exe";
+                    return nodeVersion+"/win-x86/node.exe";
                 }
             }
         } else {

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
@@ -66,9 +66,9 @@ class Platform {
 
     public String getNodeDownloadFilename(String nodeVersion) {
         if(isWindows()) {
-			int versionCompare = nodeVersion.compareTo("v4.0.0");
+            int versionCompare = nodeVersion.compareTo("v4.0.0");
             if(architecture == Architecture.x64){
-				if (versionCompare >= 0) {
+                if (versionCompare >= 0) {
                     return nodeVersion+"/win-x64/node.exe";    
                 } else {
                     return nodeVersion+"/x64/node.exe";


### PR DESCRIPTION
Fixed PR #284 and added comparation of the versions. For all versions >= v4.0.0 there will be new path.
I've tested it, but still not sure, I'm new to Java, so please check if it's alright.
Thanks.