### PR TITLE
Allow Bower to use Maven proxy

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/BowerMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/BowerMojo.java
@@ -1,10 +1,14 @@
 package com.github.eirslett.maven.plugins.frontend.mojo;
 
 import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
+import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
 
 @Mojo(name = "bower", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public final class BowerMojo extends AbstractFrontendMojo {
@@ -21,6 +25,12 @@ public final class BowerMojo extends AbstractFrontendMojo {
     @Parameter(property = "skip.bower", defaultValue = "false")
     private Boolean skip;
 
+    @Parameter(property = "session", defaultValue = "${session}", readonly = true)
+    private MavenSession session;
+
+    @Component(role = SettingsDecrypter.class)
+    private SettingsDecrypter decrypter;
+
     @Override
     protected boolean skipExecution() {
         return this.skip;
@@ -28,6 +38,7 @@ public final class BowerMojo extends AbstractFrontendMojo {
 
     @Override
     protected void execute(FrontendPluginFactory factory) throws TaskRunnerException {
-        factory.getBowerRunner().execute(arguments);
+        ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session, decrypter);
+        factory.getBowerRunner(proxyConfig).execute(arguments);
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/BowerRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/BowerRunner.java
@@ -1,5 +1,8 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public interface BowerRunner {
     void execute(String args) throws TaskRunnerException;
 }
@@ -8,7 +11,24 @@ final class DefaultBowerRunner extends NodeTaskExecutor implements BowerRunner {
 
     private static final String TASK_LOCATION = "node_modules/bower/bin/bower";
 
-    DefaultBowerRunner(NodeExecutorConfig config) {
-        super(config, TASK_LOCATION);
+    DefaultBowerRunner(NodeExecutorConfig config, ProxyConfig proxyConfig) {
+        super(config, TASK_LOCATION, buildArguments(proxyConfig));
+    }
+
+    private static List<String> buildArguments(ProxyConfig proxyConfig) {
+        List<String> arguments = new ArrayList<String>();
+
+        if (!proxyConfig.isEmpty()) {
+            ProxyConfig.Proxy secureProxy = proxyConfig.getSecureProxy();
+            if (secureProxy != null){
+                arguments.add("--config.https-proxy=" + secureProxy.getUri().toString());
+            }
+
+            ProxyConfig.Proxy insecureProxy = proxyConfig.getInsecureProxy();
+            if (insecureProxy != null) {
+                arguments.add("--config.proxy=" + insecureProxy.getUri().toString());
+            }
+        }
+        return arguments;
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -20,8 +20,8 @@ public final class FrontendPluginFactory {
                 new DefaultFileDownloader(proxy));
     }
     
-    public BowerRunner getBowerRunner() {
-        return new DefaultBowerRunner(getExecutorConfig());
+    public BowerRunner getBowerRunner(ProxyConfig proxy) {
+        return new DefaultBowerRunner(getExecutorConfig(), proxy);
     }    
 
     public JspmRunner getJspmRunner() {


### PR DESCRIPTION
Using frontend-maven-plugin I found that Bower cannot download files when Maven works via proxy server. So I added to Bower Mojo ability to work via Maven proxy like it is done in NPM Mojo.
