### PR TITLE
Fixed unhandled NullReferenceException in specific case

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
@@ -47,7 +47,7 @@ public abstract class AbstractFrontendMojo extends AbstractMojo {
    */
   private boolean isTestingPhase() {
     String phase = execution.getLifecyclePhase();
-    return phase.equals("test") || phase.equals("integration-test");
+    return phase!=null && (phase.equals("test") || phase.equals("integration-test"));
   }
 
   protected abstract void execute(FrontendPluginFactory factory) throws FrontendException;


### PR DESCRIPTION
There is NullReferenceException when executing plugin goal directly or as 'default-cli' in 'noTests' mode  because in such case lifecycle phase is undefined.