### PR TITLE
add support for caching downloaded files

### DIFF
--- a/frontend-maven-plugin/src/it/example project/package.json
+++ b/frontend-maven-plugin/src/it/example project/package.json
@@ -2,24 +2,26 @@
   "name": "example",
   "version": "0.0.1",
   "dependencies": {
-    "bower": "~1.3.12",
-    "grunt": "~0.4.1",
-    "grunt-cli": "~0.1.9",
-    "grunt-contrib-jshint": "~0.6.4",
-    "grunt-karma": "~0.7.0",
+    "bower": "~1.7.2",
+    "grunt": "~0.4.5",
+    "grunt-cli": "~0.1.13",
+    "grunt-contrib-jshint": "~0.11.3",
+    "grunt-karma": "~0.12.1",
     "gulp": "^3.9.0",
-    "jspm": "~0.15.6",
-    "karma": "~0.12.0",
-    "karma-jasmine": "~0.1.5",
-    "karma-phantomjs-launcher": "~0.1.1"
+    "jspm": "~0.16.19",
+    "karma": "~0.13.18",
+    "karma-jasmine": "~0.3.6",
+    "karma-phantomjs-launcher": "~0.2.3",
+    "jasmine-core": "^2.4.1",
+    "phantomjs": "^1.9.19"
   },
   "jspm": {
     "dependencies": {
       "jquery": "github:jquery/jquery@^2.1.3"
     },
     "devDependencies": {
-      "traceur": "github:jmcriffey/bower-traceur@0.0.88",
-      "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.88"
+      "traceur": "github:jmcriffey/bower-traceur@0.0.95",
+      "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.95"
     }
   },
   "scripts": {

--- a/frontend-maven-plugin/src/it/example project/pom.xml
+++ b/frontend-maven-plugin/src/it/example project/pom.xml
@@ -23,8 +23,8 @@
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v0.12.2</nodeVersion>
-                            <npmVersion>2.7.6</npmVersion>
+                            <nodeVersion>v5.3.0</nodeVersion>
+                            <npmVersion>3.3.12</npmVersion>
                         </configuration>
                     </execution>
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
@@ -8,6 +8,8 @@ import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystemSession;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
@@ -43,6 +45,18 @@ public abstract class AbstractFrontendMojo extends AbstractMojo {
    @Parameter
    protected Map<String, String> environmentVariables;
 
+  @Parameter(
+      defaultValue = "${project}",
+      readonly = true
+  )
+  private MavenProject project;
+
+  @Parameter(
+      defaultValue = "${repositorySystemSession}",
+      readonly = true
+  )
+  private RepositorySystemSession repositorySystemSession;
+
   /**
    * Determines if this execution should be skipped.
    */
@@ -72,7 +86,11 @@ public abstract class AbstractFrontendMojo extends AbstractMojo {
         installDirectory = workingDirectory;
       }
       try {
-        execute(new FrontendPluginFactory(workingDirectory, installDirectory));
+        execute(new FrontendPluginFactory(
+            workingDirectory,
+            installDirectory,
+            new RepositoryCacheResolver(repositorySystemSession)
+        ));
       } catch (TaskRunnerException e) {
         throw new MojoFailureException("Failed to run task", e);
       } catch (FrontendException e) {

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/RepositoryCacheResolver.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/RepositoryCacheResolver.java
@@ -1,0 +1,53 @@
+package com.github.eirslett.maven.plugins.frontend.mojo;
+
+import com.github.eirslett.maven.plugins.frontend.lib.CacheDescriptor;
+import com.github.eirslett.maven.plugins.frontend.lib.CacheResolver;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.LocalRepositoryManager;
+
+import java.io.File;
+
+public class RepositoryCacheResolver implements CacheResolver {
+
+  private static final String GROUP_ID = "com.github.eirslett";
+  private final RepositorySystemSession repositorySystemSession;
+
+  public RepositoryCacheResolver(RepositorySystemSession repositorySystemSession) {
+    this.repositorySystemSession = repositorySystemSession;
+  }
+
+  @Override
+  public File resolve(CacheDescriptor cacheDescriptor) {
+    LocalRepositoryManager manager = repositorySystemSession.getLocalRepositoryManager();
+    File localArtifact = new File(
+        manager.getRepository().getBasedir(),
+        manager.getPathForLocalArtifact(createArtifact(cacheDescriptor))
+    );
+    return localArtifact;
+  }
+
+  private DefaultArtifact createArtifact(CacheDescriptor cacheDescriptor) {
+    String version = cacheDescriptor.getVersion().replaceAll("^v", "");
+
+    DefaultArtifact artifact;
+
+    if (cacheDescriptor.getClassifier() == null) {
+      artifact = new DefaultArtifact(
+          GROUP_ID,
+          cacheDescriptor.getName(),
+          cacheDescriptor.getExtension(),
+          version
+      );
+    } else {
+      artifact = new DefaultArtifact(
+          GROUP_ID,
+          cacheDescriptor.getName(),
+          cacheDescriptor.getClassifier(),
+          cacheDescriptor.getExtension(),
+          version
+      );
+    }
+    return artifact;
+  }
+}

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/CacheDescriptor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/CacheDescriptor.java
@@ -1,0 +1,36 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+public class CacheDescriptor {
+
+  private final String name;
+  private final String version;
+  private final String classifier;
+  private final String extension;
+
+  public CacheDescriptor(String name, String version, String extension) {
+    this(name, version, null, extension);
+  }
+
+  public CacheDescriptor(String name, String version, String classifier, String extension) {
+    this.name = name;
+    this.version = version;
+    this.classifier = classifier;
+    this.extension = extension;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public String getClassifier() {
+    return classifier;
+  }
+
+  public String getExtension() {
+    return extension;
+  }
+}

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/CacheResolver.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/CacheResolver.java
@@ -1,0 +1,7 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import java.io.File;
+
+public interface CacheResolver {
+  File resolve(CacheDescriptor cacheDescriptor);
+}

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/DirectoryCacheResolver.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/DirectoryCacheResolver.java
@@ -1,0 +1,30 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import java.io.File;
+
+public class DirectoryCacheResolver implements CacheResolver {
+
+  private final File cacheDirectory;
+
+  public DirectoryCacheResolver(File cacheDirectory) {
+    this.cacheDirectory = cacheDirectory;
+  }
+
+  @Override
+  public File resolve(CacheDescriptor cacheDescriptor) {
+    if (!cacheDirectory.exists()) {
+      cacheDirectory.mkdirs();
+    }
+
+    StringBuilder filename = new StringBuilder()
+        .append(cacheDescriptor.getName())
+        .append("-")
+        .append(cacheDescriptor.getVersion());
+    if (cacheDescriptor.getClassifier() != null) {
+      filename.append("-").append(cacheDescriptor.getClassifier());
+    }
+    filename.append(".").append(cacheDescriptor.getExtension());
+    return new File(cacheDirectory, filename.toString());
+  }
+
+}

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -3,14 +3,22 @@ package com.github.eirslett.maven.plugins.frontend.lib;
 import java.io.File;
 
 public final class FrontendPluginFactory {
+    
     private static final Platform defaultPlatform = Platform.guess();
+    private static final String DEFAULT_CACHE_PATH = "cache";
 
     private final File workingDirectory;
     private final File installDirectory;
+    private final CacheResolver cacheResolver;
 
     public FrontendPluginFactory(File workingDirectory, File installDirectory){
+        this(workingDirectory, installDirectory, getDefaultCacheResolver(installDirectory));
+    }
+
+    public FrontendPluginFactory(File workingDirectory, File installDirectory, CacheResolver cacheResolver){
         this.workingDirectory = workingDirectory;
         this.installDirectory = installDirectory;
+        this.cacheResolver = cacheResolver;
     }
 
     public NodeAndNPMInstaller getNodeAndNPMInstaller(ProxyConfig proxy){
@@ -57,6 +65,10 @@ public final class FrontendPluginFactory {
     }
 
     private InstallConfig getInstallConfig() {
-        return new DefaultInstallConfig(installDirectory, workingDirectory, defaultPlatform);
+        return new DefaultInstallConfig(installDirectory, workingDirectory, cacheResolver, defaultPlatform);
+    }
+
+    private static final CacheResolver getDefaultCacheResolver(File root) {
+        return new DirectoryCacheResolver(new File(root, DEFAULT_CACHE_PATH));
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/InstallConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/InstallConfig.java
@@ -5,6 +5,7 @@ import java.io.File;
 public interface InstallConfig {
   File getInstallDirectory();
   File getWorkingDirectory();
+  CacheResolver getCacheResolver();
   Platform getPlatform();
 }
 
@@ -12,13 +13,16 @@ final class DefaultInstallConfig implements InstallConfig {
 
   private final File installDirectory;
   private final File workingDirectory;
+  private final CacheResolver cacheResolver;
   private final Platform platform;
-
+  
   public DefaultInstallConfig(File installDirectory,
                               File workingDirectory,
+                              CacheResolver cacheResolver,
                               Platform platform) {
     this.installDirectory = installDirectory;
     this.workingDirectory = workingDirectory;
+    this.cacheResolver = cacheResolver;
     this.platform = platform;
   }
 
@@ -31,9 +35,14 @@ final class DefaultInstallConfig implements InstallConfig {
   public File getWorkingDirectory() {
     return this.workingDirectory;
   }
+  
+  public CacheResolver getCacheResolver() {
+    return cacheResolver;
+  }
 
   @Override
   public Platform getPlatform() {
     return this.platform;
   }
+
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
@@ -60,7 +60,7 @@ class Platform {
         if(isWindows()){
             return "node.exe";
         } else {
-            return "node-" + nodeVersion + "-" + getCodename() + "-" + architecture.toString();
+            return "node-" + nodeVersion + "-" + this.getNodeClassifier();
         }
     }
 
@@ -82,5 +82,9 @@ class Platform {
         } else {
             return nodeVersion + "/" + getLongNodeFilename(nodeVersion) + ".tar.gz";
         }
+    }
+
+    public String getNodeClassifier() {
+        return this.getCodename() + "-" + this.architecture.name();
     }
 }


### PR DESCRIPTION
I've been using the `installDirectory` parameter to avoid downloading node and npm everytime a build runs on my CI server by configuring all my builds to use a common install directory that is outside of the working directory.  This has been working fine but now I want to upgrade to newer versions of node and npm.  If I upgrade then the build will run and wipe out the old version from the install directory and install the new version which is great except for the fact that I still have builds of the older code running as well.  So basically it just keeps flipping back and forth between versions.  So far two builds with different versions haven't run at the same time but I'm sure that will happen soon and who knows what the result will be.

This pull requests adds a new optional parameter `cacheDirectory` which if specified will be used to store the downloaded files by name and version.  This way I can have multiple builds using the same cache directory so they don't need to download them everytime and if the version changes they don't cause each other problems.

I also cleaned up the logging a little bit and updated the example project to use newer versions of everything.