### PR TITLE
Use proxies more correctly. Fixes #322

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProxyConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProxyConfig.java
@@ -30,11 +30,11 @@ public class ProxyConfig {
         }
         final URI uri = URI.create(requestUrl);
         for (Proxy proxy : proxies) {
-            if (proxy.protocol.equals(uri.getScheme()) && !proxy.isNonProxyHost(uri.getHost())) {
+            if (!proxy.isNonProxyHost(uri.getHost())) {
                 return proxy;
             }
         }
-        LOGGER.info("Could not find matching proxy for protocol {}", uri.getScheme());
+        LOGGER.info("Could not find matching proxy for host: {}" + uri.getHost());
         return null;
     }
 


### PR DESCRIPTION
ProxyConfig no longer checks the host scheme and compares it to the
configured proxy, it just uses the maven proxy now.