### PR TITLE
Updated README with example for maven 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,26 +39,7 @@ Include the plugin as a dependency in your Maven project.
     </plugin>
 ...
 ```
-## Maven 2
-```xml
-<plugins>
-    <plugin>
-        <groupId>com.github.eirslett</groupId>
-        <artifactId>frontend-maven-plugin</artifactId>
-        <!-- Use the latest possible version:
-        https://repo1.maven.org/maven2/com/github/eirslett/frontend-maven-plugin/ -->
-        <version>0.0.22</version> <!-- last version supported by maven 2 -->
-        <dependencies>
-            <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-utils</artifactId>
-                <version>2.1</version>
-            </dependency>
-        </dependencies>
-        ...
-    </plugin>
-...
-```
+For *Maven 2* support take a look at the [wiki](https://github.com/eirslett/frontend-maven-plugin/wiki#maven-2).
 
 # Usage
 Have a look at the example project, to see how it should be set up!

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ running common javascript tasks such as minification, obfuscation, compression, 
 
 # Installing
 Include the plugin as a dependency in your Maven project.
+## Maven 3
 ```xml
 <plugins>
     <plugin>
@@ -34,6 +35,26 @@ Include the plugin as a dependency in your Maven project.
         <!-- Use the latest released version:
         https://repo1.maven.org/maven2/com/github/eirslett/frontend-maven-plugin/ -->
         <version>0.0.27</version>
+        ...
+    </plugin>
+...
+```
+## Maven 2
+```xml
+<plugins>
+    <plugin>
+        <groupId>com.github.eirslett</groupId>
+        <artifactId>frontend-maven-plugin</artifactId>
+        <!-- Use the latest possible version:
+        https://repo1.maven.org/maven2/com/github/eirslett/frontend-maven-plugin/ -->
+        <version>0.0.22</version> <!-- last version supported by maven 2 -->
+        <dependencies>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>2.1</version>
+            </dependency>
+        </dependencies>
         ...
     </plugin>
 ...

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Include the plugin as a dependency in your Maven project.
     </plugin>
 ...
 ```
+
 For *Maven 2* support take a look at the [wiki](https://github.com/eirslett/frontend-maven-plugin/wiki#maven-2).
 
 # Usage


### PR DESCRIPTION
With Version 0.0.17 org.codehaus.plexus.util.Scanner was introduced in MojoUtils.java, which is a dependency of maven 3 but not maven 2. 
The turn to make the plugin maven 3 only was done in version 0.0.23.
So we need to make the difference clear for people still depending on maven 2.