### PR TITLE
allow 'npmRegistryURL' to be set as part of the pom configuration

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -27,12 +27,6 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
     private String npmDownloadRoot;
 
     /**
-     * Registry override, passed as the registry option during npm install if set.
-     */
-    @Parameter(property = "npmRegistryURL", required = false, defaultValue = "")
-    private String npmRegistryURL;
-
-    /**
      * Where to download Node.js and NPM binaries from.
      *
      * @deprecated use {@link #nodeDownloadRoot} and {@link #npmDownloadRoot} instead, this configuration will be used only when no {@link #nodeDownloadRoot} or {@link #npmDownloadRoot} is specified.

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -28,8 +28,8 @@ public final class FrontendPluginFactory {
         return new DefaultJspmRunner(getExecutorConfig());
     }
 
-    public NpmRunner getNpmRunner(ProxyConfig proxy) {
-        return new DefaultNpmRunner(getExecutorConfig(), proxy);
+    public NpmRunner getNpmRunner(ProxyConfig proxy, String npmRegistryURL) {
+        return new DefaultNpmRunner(getExecutorConfig(), proxy, npmRegistryURL);
     }
 
     public GruntRunner getGruntRunner(){

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
@@ -10,14 +10,13 @@ public interface NpmRunner extends NodeTaskRunner {}
 final class DefaultNpmRunner extends NodeTaskExecutor implements NpmRunner {
     static final String TASK_NAME = "npm";
 
-    public DefaultNpmRunner(NodeExecutorConfig config, ProxyConfig proxyConfig) {
-        super(config, TASK_NAME, config.getNpmPath().getAbsolutePath(), buildArguments(proxyConfig));
+    public DefaultNpmRunner(NodeExecutorConfig config, ProxyConfig proxyConfig, String npmRegistryURL) {
+        super(config, TASK_NAME, config.getNpmPath().getAbsolutePath(), buildArguments(proxyConfig, npmRegistryURL));
     }
 
-    private static List<String> buildArguments(ProxyConfig proxyConfig) {
+    private static List<String> buildArguments(ProxyConfig proxyConfig, String npmRegistryURL) {
         List<String> arguments = new ArrayList<String>();
-
-        String npmRegistryURL = System.getProperty("npmRegistryURL");
+               
         if (npmRegistryURL != null)
         {
             arguments.add ("--registry=" + npmRegistryURL);
@@ -34,6 +33,7 @@ final class DefaultNpmRunner extends NodeTaskExecutor implements NpmRunner {
                 arguments.add("--proxy=" + insecureProxy.getUri().toString());
             }
         }
+        
         return arguments;
     }
 }


### PR DESCRIPTION
this PR is for #356, it allows the `npmRegistryURL` to be configured in the pom as well as being specified via a `-D` option.

