### PR TITLE
Implement getAbsoluteTaskLocation to work similar to the standard NPM

### DIFF
--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>frontend-plugins</artifactId>
         <groupId>com.github.eirslett</groupId>
-        <version>0.0.28-SNAPSHOT</version>
+        <version>0.0.28-UP</version>
     </parent>
 
     <artifactId>frontend-maven-plugin</artifactId>

--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>frontend-plugins</artifactId>
         <groupId>com.github.eirslett</groupId>
-        <version>0.0.28-SNAPSHOT</version>
+        <version>0.0.28-UP</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeTaskExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeTaskExecutor.java
@@ -67,7 +67,15 @@ abstract class NodeTaskExecutor {
     private String getAbsoluteTaskLocation() {
         String location = normalize(taskLocation);
         if (Utils.isRelative(taskLocation)) {
-            location = new File(config.getWorkingDirectory(), location).getAbsolutePath();
+            File executorDirectory = config.getWorkingDirectory();
+            File executor = new File(executorDirectory, location);
+            while (!executor.exists()) {
+                logger.debug("Executor not found (checking parent): " + executor.getAbsolutePath());
+                executorDirectory = executorDirectory.getParentFile();
+                executor = new File(executorDirectory, location);
+            }
+            logger.debug("Executor used: " + executor.getAbsolutePath());
+            location = executor.getAbsolutePath();
         }
         return location;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.github.eirslett</groupId>
     <artifactId>frontend-plugins</artifactId>
-    <version>0.0.28-SNAPSHOT</version>
+    <version>0.0.28-UP</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
task locator: Traverse up the parent directory until we find the
taskLocation. (Does not go global finally, if not found)

This supports multi module projects to consolidate node_modules on the
parent module:

parent -> frontend plugin install
module -> frontend plugin grunt / karma etc.