### PR TITLE
Enable SSL client certificate authentication for node download url

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FileDownloader.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FileDownloader.java
@@ -114,6 +114,7 @@ final class DefaultFileDownloader implements FileDownloader {
     private CloseableHttpClient buildHttpClient(CredentialsProvider credentialsProvider) {
     	return HttpClients.custom()
     			.disableContentCompression()
+    			.useSystemProperties()
     			.setDefaultCredentialsProvider(credentialsProvider)
     			.build();
     }


### PR DESCRIPTION
Adds useSystemProperties to the httpclient builder in order to respect -Djavax.net.ssl.* properties. This would allow SSL client certificate authentication and custom truststores with self signed certificates to be used when downloading node and npm from a mirror that requires authentication.

A litle bit of background information:
We want to use this plugin in builds on our corporate jenkins. This jenkins has no direkt internet connection nor a connection via proxy. Instead we want to use a site repository on our nexus that mirrors nodejs.org/dist. Unfortunately the nexus requires client certificate authentication ;-)