### PR TITLE
Working with Maven 3.2.x and IDE console logging

### DIFF
--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -11,9 +11,6 @@
     <packaging>maven-plugin</packaging>
 
     <name>Maven Frontend Plugin</name>
-    <prerequisites>
-        <maven>3.1.0</maven>
-    </prerequisites>
 
     <description>
         This Maven plugin lets you install Node/NPM locally

--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -38,7 +38,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.5</version>
+            <version>1.7.16</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.6.6</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Everything works fine in my project, except we are using maven 3.2.5, so I had to remove the prerequisite tag. Probably is better to use *maven-enforcer-plugin* if the version constraint is really needed.

Also, I just added the  *slf4j-simple* dependency in order to get the logging working properly on my IntelliJ IDEA

```
[INFO] --- frontend-maven-plugin:0.0.29-SNAPSHOT:install-node-and-npm (install node and npm) @ example ---
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```