### PR TITLE
Update maven-invoker-plugin to latest version

### DIFF
--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -98,7 +98,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
-                <version>1.8</version>
+                <version>2.0.0</version>
 
                 <configuration>
                     <debug>true</debug>


### PR DESCRIPTION
On my windows machine with maven 3.3.3 the build of this project fails. Caused by this issue: https://issues.apache.org/jira/browse/MINVOKER-185 With this update everything works fine.