### PR TITLE
Fixes #384 by adding a new configuration parameter to NpmMojo

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,26 @@ You can also specify separate download roots for npm and node as they are now st
 </plugin>
 ```
 
-__Proxy settings:__ If you need to download Node/npm through a proxy: [configure your Maven proxy settings](http://maven.apache.org/guides/mini/guide-proxies.html) in ~/.m2/settings.xml. This plugin will use the same proxy settings as Maven.
+### Proxy settings
 
+If you have [configured proxy settings for Maven](http://maven.apache.org/guides/mini/guide-proxies.html)
+in your settings.xml file, the plugin will automatically use the proxy for downloading node and npm, as well
+as [passing the proxy to npm commands](https://docs.npmjs.com/misc/config#proxy).
+
+__Non Proxy Hosts:__ npm does not currently support non proxy hosts - if you are using a proxy and npm install is 
+is not downloading from your repository, it may be because it cannot be accessed through your proxy. 
+If that is the case, you can stop the npm execution from inheriting the Maven proxy settings like this:
+```xml
+<execution>
+    <id>npm install</id>
+    <goals>
+        <goal>npm</goal>
+    </goals>
+    <configuration>
+        <npmInheritsProxyConfigFromMaven>false</npmInheritsProxyConfigFromMaven>
+    </configuration>
+</execution>
+```
 
 ### Running npm
 All npm modules will be installed in the `node_modules` folder in your working directory.

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
@@ -8,6 +8,8 @@ import org.apache.maven.settings.crypto.DefaultSettingsDecryptionRequest;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.apache.maven.settings.crypto.SettingsDecryptionResult;
 import org.codehaus.plexus.util.Scanner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
 import java.io.File;
@@ -16,6 +18,9 @@ import java.util.Collections;
 import java.util.List;
 
 class MojoUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MojoUtils.class);
+
     static <E extends Throwable> MojoFailureException toMojoFailureException(E e) {
         return new MojoFailureException(e.getMessage() + ": " + e.getCause().getMessage(), e);
     }
@@ -39,6 +44,7 @@ class MojoUtils {
                 }
             }
 
+            LOGGER.info("Found proxies: {}", proxies);
             return new ProxyConfig(proxies);
         }
     }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProxyConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProxyConfig.java
@@ -16,7 +16,6 @@ public class ProxyConfig {
 
     public ProxyConfig(List<Proxy> proxies) {
         this.proxies = proxies;
-        LOGGER.info("Found proxies: {}", proxies);
     }
 
     public boolean isEmpty() {


### PR DESCRIPTION
Fix for #384

When npmInheritsProxyConfigFromMaven is set to true, proxy settings for npm will not be automatically inherited from Maven.

Sorry @eirslett, I had to make a new pull request as I'm a rebase n00b and messed up squashing the commits.

This is the previous pull request if you want to look at the chat history:
https://github.com/eirslett/frontend-maven-plugin/pull/385