### PR TITLE
Authenticated download

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -76,8 +76,8 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
         ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session, decrypter);
         String nodeDownloadRoot = getNodeDownloadRoot();
         String npmDownloadRoot = getNpmDownloadRoot();
-        if(serverId != null && !"".equals(serverId)) {
-            Server server = MojoUtils.decryptServer(serverId, session, decrypter);
+        Server server = MojoUtils.decryptServer(serverId, session, decrypter);
+        if (null != server) {
             factory.getNodeAndNPMInstaller(proxyConfig).install(nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot, server.getUsername(), server.getPassword());
         } else {
             factory.getNodeAndNPMInstaller(proxyConfig).install(nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot, null, null);

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -78,9 +78,21 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
         String npmDownloadRoot = getNpmDownloadRoot();
         Server server = MojoUtils.decryptServer(serverId, session, decrypter);
         if (null != server) {
-            factory.getNodeAndNPMInstaller(proxyConfig).install(nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot, server.getUsername(), server.getPassword());
+            factory.getNodeAndNPMInstaller(proxyConfig)
+                .setNodeVersion(nodeVersion)
+                .setNodeDownloadRoot(nodeDownloadRoot)
+                .setNpmVersion(npmVersion)
+                .setNpmDownloadRoot(npmDownloadRoot)
+                .setUserName(server.getUsername())
+                .setPassword(server.getPassword())
+                .install();
         } else {
-            factory.getNodeAndNPMInstaller(proxyConfig).install(nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot, null, null);
+            factory.getNodeAndNPMInstaller(proxyConfig)
+                .setNodeVersion(nodeVersion)
+                .setNodeDownloadRoot(nodeDownloadRoot)
+                .setNpmVersion(npmVersion)
+                .setNpmDownloadRoot(npmDownloadRoot)
+                .install();
         }
     }
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -10,6 +10,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.apache.maven.settings.Server;
 
 @Mojo(name="install-node-and-npm", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
@@ -47,6 +48,12 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
     @Parameter(property = "npmVersion", required = true)
     private String npmVersion;
 
+    /**
+     * Server Id for download username and password
+     */
+    @Parameter(property = "serverId", defaultValue = "")
+    private String serverId;
+
     @Parameter(property = "session", defaultValue = "${session}", readonly = true)
     private MavenSession session;
 
@@ -69,7 +76,12 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
         ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session, decrypter);
         String nodeDownloadRoot = getNodeDownloadRoot();
         String npmDownloadRoot = getNpmDownloadRoot();
-        factory.getNodeAndNPMInstaller(proxyConfig).install(nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot);
+        if(serverId != null && !"".equals(serverId)) {
+            Server server = MojoUtils.decryptServer(serverId, session, decrypter);
+            factory.getNodeAndNPMInstaller(proxyConfig).install(nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot, server.getUsername(), server.getPassword());
+        } else {
+            factory.getNodeAndNPMInstaller(proxyConfig).install(nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot, null, null);
+        }
     }
 
     private String getNodeDownloadRoot() {

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
@@ -9,6 +9,7 @@ import org.apache.maven.settings.crypto.DefaultSettingsDecryptionRequest;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.apache.maven.settings.crypto.SettingsDecryptionResult;
 import org.codehaus.plexus.util.Scanner;
+import org.codehaus.plexus.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonatype.plexus.build.incremental.BuildContext;
@@ -57,12 +58,16 @@ class MojoUtils {
     }
 
     static Server decryptServer(String serverId, MavenSession mavenSession, SettingsDecrypter decrypter) {
+        if (StringUtils.isEmpty(serverId)) {
+            return null;
+        }
         Server server = mavenSession.getSettings().getServer(serverId);
         if (server != null) {
             final DefaultSettingsDecryptionRequest decryptionRequest = new DefaultSettingsDecryptionRequest(server);
             SettingsDecryptionResult decryptedResult = decrypter.decrypt(decryptionRequest);
             return decryptedResult.getServer();
         } else {
+            LOGGER.warn("Could not find server '" + serverId + "' in settings.xml");
             return null;
         }
     }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
@@ -4,6 +4,7 @@ import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.settings.Proxy;
+import org.apache.maven.settings.Server;
 import org.apache.maven.settings.crypto.DefaultSettingsDecryptionRequest;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.apache.maven.settings.crypto.SettingsDecryptionResult;
@@ -53,6 +54,17 @@ class MojoUtils {
         final DefaultSettingsDecryptionRequest decryptionRequest = new DefaultSettingsDecryptionRequest(proxy);
         SettingsDecryptionResult decryptedResult = decrypter.decrypt(decryptionRequest);
         return decryptedResult.getProxy();
+    }
+
+    static Server decryptServer(String serverId, MavenSession mavenSession, SettingsDecrypter decrypter) {
+        Server server = mavenSession.getSettings().getServer(serverId);
+        if (server != null) {
+            final DefaultSettingsDecryptionRequest decryptionRequest = new DefaultSettingsDecryptionRequest(server);
+            SettingsDecryptionResult decryptedResult = decrypter.decrypt(decryptionRequest);
+            return decryptedResult.getServer();
+        } else {
+            return null;
+        }
     }
 
     static boolean shouldExecute(BuildContext buildContext, List<File> triggerfiles, File srcdir) {

--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -36,6 +36,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.0.22</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.5</version>

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FileDownloader.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FileDownloader.java
@@ -25,6 +25,7 @@ import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.codehaus.plexus.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,7 +89,7 @@ final class DefaultFileDownloader implements FileDownloader {
             return executeViaProxy(proxy, requestUrl);
         } else {
             LOGGER.info("No proxy was configured, downloading directly");
-            if (userName != null && !"".equals(userName) && password != null && !"".equals(password)) {
+            if (StringUtils.isNotEmpty(userName) && StringUtils.isNotEmpty(password)) {
                 LOGGER.info("Using credentials (" + userName + ") from settings.xml");
                 // Auth target host
                 URL aURL = new URL(requestUrl);

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -22,7 +22,7 @@ public final class FrontendPluginFactory {
     }
 
     public NodeAndNPMInstaller getNodeAndNPMInstaller(ProxyConfig proxy){
-        return new DefaultNodeAndNPMInstaller(
+        return new NodeAndNPMInstaller(
                 getInstallConfig(),
                 new DefaultArchiveExtractor(),
                 new DefaultFileDownloader(proxy));

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeAndNPMInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeAndNPMInstaller.java
@@ -11,295 +11,298 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 
-public interface NodeAndNPMInstaller {
-
-    String DEFAULT_NODEJS_DOWNLOAD_ROOT = "https://nodejs.org/dist/";
-    String DEFAULT_NPM_DOWNLOAD_ROOT = "http://registry.npmjs.org/npm/-/";
-
-    void install(String nodeVersion, String npmVersion, String nodeDownloadRoot, String npmDownloadRoot, String userName, String password) throws InstallationException;
-}
-
-final class DefaultNodeAndNPMInstaller implements NodeAndNPMInstaller {
+public class NodeAndNPMInstaller {
 
     private static final String INSTALL_PATH = "node";
+    private static final String VERSION = "version";
+
+    public static final String DEFAULT_NODEJS_DOWNLOAD_ROOT = "https://nodejs.org/dist/";
+    public static final String DEFAULT_NPM_DOWNLOAD_ROOT = "http://registry.npmjs.org/npm/-/";
+
+    private String nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot, userName, password;
 
     private final Logger logger;
     private final InstallConfig config;
     private final ArchiveExtractor archiveExtractor;
     private final FileDownloader fileDownloader;
 
-    DefaultNodeAndNPMInstaller(InstallConfig config, ArchiveExtractor archiveExtractor, FileDownloader fileDownloader) {
+    NodeAndNPMInstaller(InstallConfig config, ArchiveExtractor archiveExtractor, FileDownloader fileDownloader) {
         this.logger = LoggerFactory.getLogger(getClass());
         this.config = config;
         this.archiveExtractor = archiveExtractor;
         this.fileDownloader = fileDownloader;
     }
 
-    @Override
-    public void install(String nodeVersion, String npmVersion, String nodeDownloadRoot, String npmDownloadRoot, String userName, String password) throws InstallationException {
+    public NodeAndNPMInstaller setNodeVersion (String nodeVersion) {
+        this.nodeVersion = nodeVersion;
+        return this;
+    }
+
+    public NodeAndNPMInstaller setNodeDownloadRoot (String nodeDownloadRoot) {
+        this.nodeDownloadRoot = nodeDownloadRoot;
+        return this;
+    }
+
+    public NodeAndNPMInstaller setNpmVersion (String npmVersion) {
+        this.npmVersion = npmVersion;
+        return this;
+    }
+
+    public NodeAndNPMInstaller setNpmDownloadRoot (String npmDownloadRoot) {
+        this.npmDownloadRoot = npmDownloadRoot;
+        return this;
+    }
+
+    public NodeAndNPMInstaller setUserName (String userName) {
+        this.userName = userName;
+        return this;
+    }
+
+    public NodeAndNPMInstaller setPassword (String password) {
+        this.password = password;
+        return this;
+    }
+
+    public void install() throws InstallationException {
         if(nodeDownloadRoot == null || nodeDownloadRoot.isEmpty()){
             nodeDownloadRoot = DEFAULT_NODEJS_DOWNLOAD_ROOT;
         }
         if(npmDownloadRoot == null || npmDownloadRoot.isEmpty()){
             npmDownloadRoot = DEFAULT_NPM_DOWNLOAD_ROOT;
         }
-        new NodeAndNPMInstallAction(nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot, userName, password).install();
+        if(!nodeIsAlreadyInstalled()){
+            logger.info("Installing node version {}", nodeVersion);
+            if (!nodeVersion.startsWith("v")) {
+                logger.warn("Node version does not start with naming convention 'v'.");
+            }
+            if(config.getPlatform().isWindows()){
+                installNodeForWindows();
+            } else {
+                installNodeDefault();
+            }
+        }
+        if(!npmIsAlreadyInstalled()) {
+            installNpm();
+        }
     }
 
-    private final class NodeAndNPMInstallAction {
-        private static final String VERSION = "version";
+    private boolean nodeIsAlreadyInstalled() {
+        try {
+            NodeExecutorConfig executorConfig = new InstallNodeExecutorConfig(config);
+            File nodeFile = executorConfig.getNodePath();
+            if(nodeFile.exists()){
+                final String version = new NodeExecutor(executorConfig, Arrays.asList("--version"), null).executeAndGetResult();
 
-        private final String nodeVersion;
-        private final String npmVersion;
-        private final String nodeDownloadRoot;
-        private final String npmDownloadRoot;
-        private final String userName;
-        private final String password;
-
-        public NodeAndNPMInstallAction(String nodeVersion, String npmVersion, String nodeDownloadRoot, String npmDownloadRoot, String userName, String password) {
-            this.nodeVersion = nodeVersion;
-            this.npmVersion = npmVersion;
-            this.nodeDownloadRoot = nodeDownloadRoot;
-            this.npmDownloadRoot = npmDownloadRoot;
-            this.userName = userName;
-            this.password = password;
-        }
-
-        public void install() throws InstallationException {
-            if(!nodeIsAlreadyInstalled()){
-                logger.info("Installing node version {}", nodeVersion);
-                if (!nodeVersion.startsWith("v")) {
-                    logger.warn("Node version does not start with naming convention 'v'.");
-                }
-                if(config.getPlatform().isWindows()){
-                    installNodeForWindows();
+                if(version.equals(nodeVersion)){
+                    logger.info("Node {} is already installed.", version);
+                    return true;
                 } else {
-                    installNodeDefault();
-                }
-            }
-            if(!npmIsAlreadyInstalled()) {
-                installNpm();
-            }
-        }
-
-        private boolean nodeIsAlreadyInstalled() {
-            try {
-                NodeExecutorConfig executorConfig = new InstallNodeExecutorConfig(config);
-                File nodeFile = executorConfig.getNodePath();
-                if(nodeFile.exists()){
-                    final String version = new NodeExecutor(executorConfig, Arrays.asList("--version"), null).executeAndGetResult();
-
-                    if(version.equals(nodeVersion)){
-                        logger.info("Node {} is already installed.", version);
-                        return true;
-                    } else {
-                        logger.info("Node {} was installed, but we need version {}", version, nodeVersion);
-                        return false;
-                    }
-                } else {
+                    logger.info("Node {} was installed, but we need version {}", version, nodeVersion);
                     return false;
                 }
-            } catch (ProcessExecutionException e) {
+            } else {
                 return false;
             }
+        } catch (ProcessExecutionException e) {
+            return false;
         }
+    }
 
-        private boolean npmIsAlreadyInstalled(){
-            try {
-                final File npmPackageJson = new File(config.getInstallDirectory() + Utils.normalize("/node/node_modules/npm/package.json"));
-                if(npmPackageJson.exists()){
-                    HashMap<String,Object> data = new ObjectMapper().readValue(npmPackageJson, HashMap.class);
-                    if(data.containsKey(VERSION)){
-                        final String foundNpmVersion = data.get(VERSION).toString();
-                        if(foundNpmVersion.equals(npmVersion)) {
-                            logger.info("NPM {} is already installed.", foundNpmVersion);
-                            return true;
-                        } else {
-                            logger.info("NPM {} was installed, but we need version {}", foundNpmVersion, npmVersion);
-                            return false;
-                        }
+    private boolean npmIsAlreadyInstalled(){
+        try {
+            final File npmPackageJson = new File(config.getInstallDirectory() + Utils.normalize("/node/node_modules/npm/package.json"));
+            if(npmPackageJson.exists()){
+                HashMap<String,Object> data = new ObjectMapper().readValue(npmPackageJson, HashMap.class);
+                if(data.containsKey(VERSION)){
+                    final String foundNpmVersion = data.get(VERSION).toString();
+                    if(foundNpmVersion.equals(npmVersion)) {
+                        logger.info("NPM {} is already installed.", foundNpmVersion);
+                        return true;
                     } else {
-                        logger.info("Could not read NPM version from package.json");
+                        logger.info("NPM {} was installed, but we need version {}", foundNpmVersion, npmVersion);
                         return false;
                     }
                 } else {
+                    logger.info("Could not read NPM version from package.json");
                     return false;
                 }
-            } catch (IOException ex){
-                throw new RuntimeException("Could not read package.json", ex);
+            } else {
+                return false;
             }
+        } catch (IOException ex){
+            throw new RuntimeException("Could not read package.json", ex);
         }
+    }
 
-        private void installNpm() throws InstallationException {
+    private void installNpm() throws InstallationException {
+        try {
+            logger.info("Installing npm version {}", npmVersion);
+            final String downloadUrl = npmDownloadRoot +"npm-"+npmVersion+".tgz";
+
+            CacheDescriptor cacheDescriptor = new CacheDescriptor("npm", npmVersion, "tar.gz");
+
+            File archive = config.getCacheResolver().resolve(cacheDescriptor);
+
+            downloadFileIfMissing(downloadUrl, archive, userName, password);
+
+            File installDirectory = getInstallDirectory();
+            File nodeModulesDirectory = new File(installDirectory, "node_modules");
+
+            // We need to delete the existing npm directory first so we clean out any old files, and
+            // so we can rename the package directory below.
+            File oldNpmDirectory = new File(installDirectory, "npm");
+            File npmDirectory = new File(nodeModulesDirectory, "npm");
             try {
-                logger.info("Installing npm version {}", npmVersion);
-                final String downloadUrl = npmDownloadRoot +"npm-"+npmVersion+".tgz";
-
-                CacheDescriptor cacheDescriptor = new CacheDescriptor("npm", npmVersion, "tar.gz");
-
-                File archive = config.getCacheResolver().resolve(cacheDescriptor);
-
-                downloadFileIfMissing(downloadUrl, archive, userName, password);
-
-                File installDirectory = getInstallDirectory();
-                File nodeModulesDirectory = new File(installDirectory, "node_modules");
-
-                // We need to delete the existing npm directory first so we clean out any old files, and
-                // so we can rename the package directory below.
-                File oldNpmDirectory = new File(installDirectory, "npm");
-                File npmDirectory = new File(nodeModulesDirectory, "npm");
-                try {
-                    if (oldNpmDirectory.isDirectory()) {
-                        FileUtils.deleteDirectory(oldNpmDirectory);
-                    }
-                    FileUtils.deleteDirectory(npmDirectory);
-                } catch (IOException e) {
-                    logger.warn("Failed to delete existing NPM installation.");
+                if (oldNpmDirectory.isDirectory()) {
+                    FileUtils.deleteDirectory(oldNpmDirectory);
                 }
-
-                extractFile(archive, nodeModulesDirectory);
-
-                // handles difference between old and new download root (nodejs.org/dist/npm and registry.npmjs.org)
-                // see https://github.com/eirslett/frontend-maven-plugin/issues/65#issuecomment-52024254
-                File packageDirectory = new File(nodeModulesDirectory, "package");
-                if (packageDirectory.exists() && !npmDirectory.exists()) {
-                    if (! packageDirectory.renameTo(npmDirectory)) {
-                        logger.warn("Cannot rename NPM directory, making a copy.");
-                        FileUtils.copyDirectory(packageDirectory, npmDirectory);
-                    }
-                }
-
-                // create a copy of the npm scripts next to the node executable
-                for (String script : Arrays.asList("npm", "npm.cmd")) {
-                    File scriptFile = new File(npmDirectory, "bin"+File.separator+script);
-                    if (scriptFile.exists()) {
-                        File copy = new File(installDirectory, script);
-                        FileUtils.copyFile(scriptFile, copy);
-                        copy.setExecutable(true);
-                    }
-                }
-
-                logger.info("Installed npm locally.");
-            } catch (DownloadException e) {
-                throw new InstallationException("Could not download npm", e);
-            } catch (ArchiveExtractionException e) {
-                throw new InstallationException("Could not extract the npm archive", e);
+                FileUtils.deleteDirectory(npmDirectory);
             } catch (IOException e) {
-                throw new InstallationException("Could not copy npm", e);
+                logger.warn("Failed to delete existing NPM installation.");
             }
-        }
 
-        private void installNodeDefault() throws InstallationException {
-            try {
-                final String longNodeFilename = config.getPlatform().getLongNodeFilename(nodeVersion);
-                String downloadUrl = nodeDownloadRoot + config.getPlatform().getNodeDownloadFilename(nodeVersion);
-                String classifier = config.getPlatform().getNodeClassifier();
+            extractFile(archive, nodeModulesDirectory);
 
-                File tmpDirectory = getTempDirectory();
-
-                CacheDescriptor cacheDescriptor = new CacheDescriptor("node", nodeVersion, classifier, "tar.gz");
-
-                File archive = config.getCacheResolver().resolve(cacheDescriptor);
-
-                downloadFileIfMissing(downloadUrl, archive, userName, password);
-
-                extractFile(archive, tmpDirectory);
-
-                // Search for the node binary
-                File nodeBinary = new File(tmpDirectory,longNodeFilename + File.separator + "bin" + File.separator + "node");
-                if(!nodeBinary.exists()){
-                    throw new FileNotFoundException("Could not find the downloaded Node.js binary in "+nodeBinary);
-                } else {
-                    File destinationDirectory = getInstallDirectory();
-
-                    File destination = new File(destinationDirectory, "node");
-                    logger.info("Copying node binary from {} to {}", nodeBinary, destination);
-                    if(!nodeBinary.renameTo(destination)){
-                        throw new InstallationException("Could not install Node: Was not allowed to rename "+nodeBinary+" to "+destination);
-                    }
-
-                    if(!destination.setExecutable(true, false)){
-                      throw new InstallationException("Could not install Node: Was not allowed to make "+destination+" executable.");
-                    }
-
-                    deleteTempDirectory(tmpDirectory);
-
-                    logger.info("Installed node locally.");
+            // handles difference between old and new download root (nodejs.org/dist/npm and registry.npmjs.org)
+            // see https://github.com/eirslett/frontend-maven-plugin/issues/65#issuecomment-52024254
+            File packageDirectory = new File(nodeModulesDirectory, "package");
+            if (packageDirectory.exists() && !npmDirectory.exists()) {
+                if (! packageDirectory.renameTo(npmDirectory)) {
+                    logger.warn("Cannot rename NPM directory, making a copy.");
+                    FileUtils.copyDirectory(packageDirectory, npmDirectory);
                 }
-            } catch (IOException e) {
-                throw new InstallationException("Could not install Node", e);
-            } catch (DownloadException e) {
-                throw new InstallationException("Could not download Node.js", e);
-            } catch (ArchiveExtractionException e) {
-                throw new InstallationException("Could not extract the Node archive", e);
             }
-        }
 
-        private void installNodeForWindows() throws InstallationException {
-            final String downloadUrl = nodeDownloadRoot + config.getPlatform().getNodeDownloadFilename(nodeVersion);
-            try {
+            // create a copy of the npm scripts next to the node executable
+            for (String script : Arrays.asList("npm", "npm.cmd")) {
+                File scriptFile = new File(npmDirectory, "bin"+File.separator+script);
+                if (scriptFile.exists()) {
+                    File copy = new File(installDirectory, script);
+                    FileUtils.copyFile(scriptFile, copy);
+                    copy.setExecutable(true);
+                }
+            }
+
+            logger.info("Installed npm locally.");
+        } catch (DownloadException e) {
+            throw new InstallationException("Could not download npm", e);
+        } catch (ArchiveExtractionException e) {
+            throw new InstallationException("Could not extract the npm archive", e);
+        } catch (IOException e) {
+            throw new InstallationException("Could not copy npm", e);
+        }
+    }
+
+    private void installNodeDefault() throws InstallationException {
+        try {
+            final String longNodeFilename = config.getPlatform().getLongNodeFilename(nodeVersion);
+            String downloadUrl = nodeDownloadRoot + config.getPlatform().getNodeDownloadFilename(nodeVersion);
+            String classifier = config.getPlatform().getNodeClassifier();
+
+            File tmpDirectory = getTempDirectory();
+
+            CacheDescriptor cacheDescriptor = new CacheDescriptor("node", nodeVersion, classifier, "tar.gz");
+
+            File archive = config.getCacheResolver().resolve(cacheDescriptor);
+
+            downloadFileIfMissing(downloadUrl, archive, userName, password);
+
+            extractFile(archive, tmpDirectory);
+
+            // Search for the node binary
+            File nodeBinary = new File(tmpDirectory,longNodeFilename + File.separator + "bin" + File.separator + "node");
+            if(!nodeBinary.exists()){
+                throw new FileNotFoundException("Could not find the downloaded Node.js binary in "+nodeBinary);
+            } else {
                 File destinationDirectory = getInstallDirectory();
 
-                File destination = new File(destinationDirectory, "node.exe");
+                File destination = new File(destinationDirectory, "node");
+                logger.info("Copying node binary from {} to {}", nodeBinary, destination);
+                if(!nodeBinary.renameTo(destination)){
+                    throw new InstallationException("Could not install Node: Was not allowed to rename "+nodeBinary+" to "+destination);
+                }
 
-                String classifier = config.getPlatform().getNodeClassifier();
+                if(!destination.setExecutable(true, false)){
+                  throw new InstallationException("Could not install Node: Was not allowed to make "+destination+" executable.");
+                }
 
-                CacheDescriptor cacheDescriptor = new CacheDescriptor("node", nodeVersion, classifier, "exe");
-
-                File binary = config.getCacheResolver().resolve(cacheDescriptor);
-
-                downloadFileIfMissing(downloadUrl, binary, userName, password);
-
-                logger.info("Copying node binary from {} to {}", binary, destination);
-                FileUtils.copyFile(binary, destination);
+                deleteTempDirectory(tmpDirectory);
 
                 logger.info("Installed node locally.");
-            } catch (DownloadException e) {
-                throw new InstallationException("Could not download Node.js from: " + downloadUrl, e);
-            } catch (IOException e) {
-                throw new InstallationException("Could not install Node.js", e);
             }
+        } catch (IOException e) {
+            throw new InstallationException("Could not install Node", e);
+        } catch (DownloadException e) {
+            throw new InstallationException("Could not download Node.js", e);
+        } catch (ArchiveExtractionException e) {
+            throw new InstallationException("Could not extract the Node archive", e);
         }
+    }
 
-        private File getTempDirectory() {
-            File tmpDirectory = new File(getInstallDirectory(), "tmp");
-            if (!tmpDirectory.exists()) {
-                logger.debug("Creating temporary directory {}", tmpDirectory);
-                tmpDirectory.mkdirs();
-            }
-            return tmpDirectory;
-        }
+    private void installNodeForWindows() throws InstallationException {
+        final String downloadUrl = nodeDownloadRoot + config.getPlatform().getNodeDownloadFilename(nodeVersion);
+        try {
+            File destinationDirectory = getInstallDirectory();
 
-        private File getInstallDirectory() {
-            File installDirectory = new File(config.getInstallDirectory(), INSTALL_PATH);
-            if (!installDirectory.exists()) {
-                logger.debug("Creating install directory {}", installDirectory);
-                installDirectory.mkdirs();
-            }
-            return installDirectory;
-        }
+            File destination = new File(destinationDirectory, "node.exe");
 
-        private void deleteTempDirectory(File tmpDirectory) throws IOException {
-            if (tmpDirectory != null && tmpDirectory.exists()) {
-                logger.debug("Deleting temporary directory {}", tmpDirectory);
-                FileUtils.deleteDirectory(tmpDirectory);
-            }
-        }
+            String classifier = config.getPlatform().getNodeClassifier();
 
-        private void extractFile(File archive, File destinationDirectory) throws ArchiveExtractionException {
-            logger.info("Unpacking {} into {}", archive, destinationDirectory);
-            archiveExtractor.extract(archive.getPath(), destinationDirectory.getPath());
-        }
+            CacheDescriptor cacheDescriptor = new CacheDescriptor("node", nodeVersion, classifier, "exe");
 
-        private void downloadFileIfMissing(String downloadUrl, File destination, String userName, String password) throws DownloadException {
-            if (!destination.exists()) {
-                downloadFile(downloadUrl, destination, userName, password);
-            }
-        }
+            File binary = config.getCacheResolver().resolve(cacheDescriptor);
 
-        private void downloadFile(String downloadUrl, File destination, String userName, String password) throws DownloadException {
-            logger.info("Downloading {} to {}", downloadUrl, destination);
-            fileDownloader.download(downloadUrl, destination.getPath(), userName, password);
+            downloadFileIfMissing(downloadUrl, binary, userName, password);
+
+            logger.info("Copying node binary from {} to {}", binary, destination);
+            FileUtils.copyFile(binary, destination);
+
+            logger.info("Installed node locally.");
+        } catch (DownloadException e) {
+            throw new InstallationException("Could not download Node.js from: " + downloadUrl, e);
+        } catch (IOException e) {
+            throw new InstallationException("Could not install Node.js", e);
         }
+    }
+
+    private File getTempDirectory() {
+        File tmpDirectory = new File(getInstallDirectory(), "tmp");
+        if (!tmpDirectory.exists()) {
+            logger.debug("Creating temporary directory {}", tmpDirectory);
+            tmpDirectory.mkdirs();
+        }
+        return tmpDirectory;
+    }
+
+    private File getInstallDirectory() {
+        File installDirectory = new File(config.getInstallDirectory(), INSTALL_PATH);
+        if (!installDirectory.exists()) {
+            logger.debug("Creating install directory {}", installDirectory);
+            installDirectory.mkdirs();
+        }
+        return installDirectory;
+    }
+
+    private void deleteTempDirectory(File tmpDirectory) throws IOException {
+        if (tmpDirectory != null && tmpDirectory.exists()) {
+            logger.debug("Deleting temporary directory {}", tmpDirectory);
+            FileUtils.deleteDirectory(tmpDirectory);
+        }
+    }
+
+    private void extractFile(File archive, File destinationDirectory) throws ArchiveExtractionException {
+        logger.info("Unpacking {} into {}", archive, destinationDirectory);
+        archiveExtractor.extract(archive.getPath(), destinationDirectory.getPath());
+    }
+
+    private void downloadFileIfMissing(String downloadUrl, File destination, String userName, String password) throws DownloadException {
+        if (!destination.exists()) {
+            downloadFile(downloadUrl, destination, userName, password);
+        }
+    }
+
+    private void downloadFile(String downloadUrl, File destination, String userName, String password) throws DownloadException {
+        logger.info("Downloading {} to {}", downloadUrl, destination);
+        fileDownloader.download(downloadUrl, destination.getPath(), userName, password);
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeAndNPMInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeAndNPMInstaller.java
@@ -16,7 +16,7 @@ public interface NodeAndNPMInstaller {
     String DEFAULT_NODEJS_DOWNLOAD_ROOT = "https://nodejs.org/dist/";
     String DEFAULT_NPM_DOWNLOAD_ROOT = "http://registry.npmjs.org/npm/-/";
 
-    void install(String nodeVersion, String npmVersion, String nodeDownloadRoot, String npmDownloadRoot) throws InstallationException;
+    void install(String nodeVersion, String npmVersion, String nodeDownloadRoot, String npmDownloadRoot, String userName, String password) throws InstallationException;
 }
 
 final class DefaultNodeAndNPMInstaller implements NodeAndNPMInstaller {
@@ -36,14 +36,14 @@ final class DefaultNodeAndNPMInstaller implements NodeAndNPMInstaller {
     }
 
     @Override
-    public void install(String nodeVersion, String npmVersion, String nodeDownloadRoot, String npmDownloadRoot) throws InstallationException {
+    public void install(String nodeVersion, String npmVersion, String nodeDownloadRoot, String npmDownloadRoot, String userName, String password) throws InstallationException {
         if(nodeDownloadRoot == null || nodeDownloadRoot.isEmpty()){
             nodeDownloadRoot = DEFAULT_NODEJS_DOWNLOAD_ROOT;
         }
         if(npmDownloadRoot == null || npmDownloadRoot.isEmpty()){
             npmDownloadRoot = DEFAULT_NPM_DOWNLOAD_ROOT;
         }
-        new NodeAndNPMInstallAction(nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot).install();
+        new NodeAndNPMInstallAction(nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot, userName, password).install();
     }
 
     private final class NodeAndNPMInstallAction {
@@ -53,12 +53,16 @@ final class DefaultNodeAndNPMInstaller implements NodeAndNPMInstaller {
         private final String npmVersion;
         private final String nodeDownloadRoot;
         private final String npmDownloadRoot;
+        private final String userName;
+        private final String password;
 
-        public NodeAndNPMInstallAction(String nodeVersion, String npmVersion, String nodeDownloadRoot, String npmDownloadRoot) {
+        public NodeAndNPMInstallAction(String nodeVersion, String npmVersion, String nodeDownloadRoot, String npmDownloadRoot, String userName, String password) {
             this.nodeVersion = nodeVersion;
             this.npmVersion = npmVersion;
             this.nodeDownloadRoot = nodeDownloadRoot;
             this.npmDownloadRoot = npmDownloadRoot;
+            this.userName = userName;
+            this.password = password;
         }
 
         public void install() throws InstallationException {
@@ -135,7 +139,7 @@ final class DefaultNodeAndNPMInstaller implements NodeAndNPMInstaller {
 
                 File archive = config.getCacheResolver().resolve(cacheDescriptor);
 
-                downloadFileIfMissing(downloadUrl, archive);
+                downloadFileIfMissing(downloadUrl, archive, userName, password);
 
                 File installDirectory = getInstallDirectory();
                 File nodeModulesDirectory = new File(installDirectory, "node_modules");
@@ -197,7 +201,7 @@ final class DefaultNodeAndNPMInstaller implements NodeAndNPMInstaller {
 
                 File archive = config.getCacheResolver().resolve(cacheDescriptor);
 
-                downloadFileIfMissing(downloadUrl, archive);
+                downloadFileIfMissing(downloadUrl, archive, userName, password);
 
                 extractFile(archive, tmpDirectory);
 
@@ -244,7 +248,7 @@ final class DefaultNodeAndNPMInstaller implements NodeAndNPMInstaller {
 
                 File binary = config.getCacheResolver().resolve(cacheDescriptor);
 
-                downloadFileIfMissing(downloadUrl, binary);
+                downloadFileIfMissing(downloadUrl, binary, userName, password);
 
                 logger.info("Copying node binary from {} to {}", binary, destination);
                 FileUtils.copyFile(binary, destination);
@@ -287,15 +291,15 @@ final class DefaultNodeAndNPMInstaller implements NodeAndNPMInstaller {
             archiveExtractor.extract(archive.getPath(), destinationDirectory.getPath());
         }
 
-        private void downloadFileIfMissing(String downloadUrl, File destination) throws DownloadException {
+        private void downloadFileIfMissing(String downloadUrl, File destination, String userName, String password) throws DownloadException {
             if (!destination.exists()) {
-                downloadFile(downloadUrl, destination);
+                downloadFile(downloadUrl, destination, userName, password);
             }
         }
 
-        private void downloadFile(String downloadUrl, File destination) throws DownloadException {
+        private void downloadFile(String downloadUrl, File destination, String userName, String password) throws DownloadException {
             logger.info("Downloading {} to {}", downloadUrl, destination);
-            fileDownloader.download(downloadUrl, destination.getPath());
+            fileDownloader.download(downloadUrl, destination.getPath(), userName, password);
         }
     }
 }


### PR DESCRIPTION
This PR is for issue 388. I haven't committed IT project changes since they are specific to my internal corporate environment. To summarize, I made the following changes to get the IT projects succeeding locally

1. Defined a `<server>` element in `frontend-maven-plugin/src/it/settings.xml`
2. Updated `frontend-maven-plugin/src/it/*/pom.xml` with following
- set `npmInteritsProxyConfigFromMaven` to `false`
- declare `nodeDownloadRoot` and `npmDownloadRoot` to point at internal URL and `serverId` to provide credentials from internal URL from `<server> element defined in #1

2/3 IT projects succeeded, the 3rd (`example project`) failed when PhantomJS script tried to perform a download from an external URL

```
[INFO] [INFO] PhantomJS not found on PATH
[INFO] [INFO] Downloading https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-windows.zip
[INFO] [INFO] Saving to C:\Users\hbl4218\AppData\Local\Temp\phantomjs\phantomjs-1.9.8-windows.zip
[INFO] [INFO] Receiving...
[INFO] [INFO]
[INFO] [ERROR] Error making request.
[INFO] [ERROR] Error: connect ECONNREFUSED 104.192.143.2:443
[INFO] [ERROR]     at Object.exports._errnoException (util.js:855:11)
[INFO] [ERROR]     at exports._exceptionWithHostPort (util.js:878:20)
[INFO] [ERROR]     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1063:14)
```
I don't consider this failure to be consequential this PR because frontend-maven-plugin was able to download Node and NPM over an authenticated connection to our internal downloadRoot URL, that installation of NPM correctly used the ~/.npmrc to use our internal Artifactory cache of the public registry.