### PR TITLE
Make using the maven caching optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ You can also specify separate download roots for npm and node as they are now st
 </plugin>
 ```
 
+By default node/npm will be cached to to the Maven local repository. To disable this and use the `workingDirectory/cache` add
+
+    <configuration>
+        <useMavenCache>false</useMavenCache>
+
+
 ### Proxy settings
 
 If you have [configured proxy settings for Maven](http://maven.apache.org/guides/mini/guide-proxies.html)

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
@@ -38,6 +38,12 @@ public abstract class AbstractFrontendMojo extends AbstractMojo {
   @Parameter(property = "installDirectory", required = false)
   protected File installDirectory;
 
+  /**
+   * Use maven cache location.
+   */
+  @Parameter(property = "useMavenCache", required = false, defaultValue = "true")
+  protected Boolean useMavenCache;
+
 
   /**
    * Additional environment variables to pass to the build.
@@ -89,7 +95,8 @@ public abstract class AbstractFrontendMojo extends AbstractMojo {
         execute(new FrontendPluginFactory(
             workingDirectory,
             installDirectory,
-            new RepositoryCacheResolver(repositorySystemSession)
+            ( useMavenCache ? new RepositoryCacheResolver(repositorySystemSession) :
+              FrontendPluginFactory.getDefaultCacheResolver (workingDirectory))
         ));
       } catch (TaskRunnerException e) {
         throw new MojoFailureException("Failed to run task", e);

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -68,7 +68,7 @@ public final class FrontendPluginFactory {
         return new DefaultInstallConfig(installDirectory, workingDirectory, cacheResolver, defaultPlatform);
     }
 
-    private static final CacheResolver getDefaultCacheResolver(File root) {
+    public static final CacheResolver getDefaultCacheResolver(File root) {
         return new DirectoryCacheResolver(new File(root, DEFAULT_CACHE_PATH));
     }
 }


### PR DESCRIPTION
While #330 is very useful, in certain constrained build environments caching files in the .m2 leads to verification errors when matching to deployed files. 

It would be useful to allow this new functionality to be optional. 
