### PR TITLE
Add ppc64le support

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
@@ -1,8 +1,13 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
-enum Architecture { x86, x64;
+enum Architecture { x86, x64, ppc64le;
     public static Architecture guess(){
-        return System.getProperty("os.arch").contains("64") ? x64 : x86;
+        String arch = System.getProperty("os.arch");
+        if (arch.equals("ppc64le")) {
+            return ppc64le;
+        } else {
+            return arch.contains("64") ? x64 : x86;
+        }
     }
 }
 


### PR DESCRIPTION
Use architecture specific archives on ppc64le (supported from v4.3.2 onwards)
incorporates @asanjar's snippet
Resolves #418 