### PR TITLE
reference scripts registered on node_modules/.bin

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/BowerRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/BowerRunner.java
@@ -7,7 +7,7 @@ public interface BowerRunner extends NodeTaskRunner {}
 
 final class DefaultBowerRunner extends NodeTaskExecutor implements BowerRunner {
 
-    private static final String TASK_LOCATION = "node_modules/bower/bin/bower";
+    private static final String TASK_LOCATION = "node_modules/.bin/bower";
 
     DefaultBowerRunner(NodeExecutorConfig config, ProxyConfig proxyConfig) {
         super(config, TASK_LOCATION, buildArguments(proxyConfig));

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/EmberRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/EmberRunner.java
@@ -4,7 +4,7 @@ public interface EmberRunner extends NodeTaskRunner {}
 
 final class DefaultEmberRunner extends NodeTaskExecutor implements EmberRunner {
 
-    private static final String TASK_LOCATION = "node_modules/ember-cli/bin/ember";
+    private static final String TASK_LOCATION = "node_modules/.bin/ember";
 
     DefaultEmberRunner(NodeExecutorConfig config) {
         super(config, TASK_LOCATION);

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GruntRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GruntRunner.java
@@ -4,7 +4,7 @@ public interface GruntRunner extends NodeTaskRunner {}
 
 final class DefaultGruntRunner extends NodeTaskExecutor implements GruntRunner {
 
-    private static final String TASK_LOCATION = "node_modules/grunt-cli/bin/grunt";
+    private static final String TASK_LOCATION = "node_modules/.bin/grunt";
 
     DefaultGruntRunner(NodeExecutorConfig config) {
         super(config, TASK_LOCATION);

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GulpRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GulpRunner.java
@@ -3,7 +3,7 @@ package com.github.eirslett.maven.plugins.frontend.lib;
 public interface GulpRunner  extends NodeTaskRunner {}
 
 final class DefaultGulpRunner extends NodeTaskExecutor implements GulpRunner {
-    private static final String TASK_LOCATION = "node_modules/gulp/bin/gulp.js";
+    private static final String TASK_LOCATION = "node_modules/.bin/gulp";
 
     DefaultGulpRunner(NodeExecutorConfig config) {
         super(config, TASK_LOCATION);

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/JspmRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/JspmRunner.java
@@ -4,7 +4,7 @@ public interface JspmRunner extends NodeTaskRunner {}
 
 final class DefaultJspmRunner extends NodeTaskExecutor implements JspmRunner {
 
-    static final String TASK_LOCATION = "node_modules/jspm/jspm.js";
+    static final String TASK_LOCATION = "node_modules/.bin/jspm";
 
     DefaultJspmRunner(NodeExecutorConfig config) {
         super(config, TASK_LOCATION);

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/KarmaRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/KarmaRunner.java
@@ -4,7 +4,7 @@ public interface KarmaRunner extends NodeTaskRunner {}
 
 final class DefaultKarmaRunner extends NodeTaskExecutor implements KarmaRunner {
 
-    static final String TASK_LOCATION = "node_modules/karma/bin/karma";
+    static final String TASK_LOCATION = "node_modules/.bin/karma";
 
     DefaultKarmaRunner(NodeExecutorConfig config) {
         super(config, TASK_LOCATION);

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/WebpackRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/WebpackRunner.java
@@ -4,7 +4,7 @@ public interface WebpackRunner extends NodeTaskRunner {}
 
 final class DefaultWebpackRunner extends NodeTaskExecutor implements WebpackRunner {
 
-    private static final String TASK_LOCATION = "node_modules/webpack/bin/webpack.js";
+    private static final String TASK_LOCATION = "node_modules/.bin/webpack.js";
 
     DefaultWebpackRunner(NodeExecutorConfig config) {
         super(config, TASK_LOCATION);


### PR DESCRIPTION
It helps in a lot of cases. For example, Grunt 1.0 contains grunt-cli, so we don't need to install grunt-cli alongside. In this case, refering node_modules/.bin/grunt will work no matter you are using grunt < 1.0 + grunt-cli, or just using grunt >= 1.0
