### PR TITLE
ThreadSafe Node and NPM installation

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -12,7 +12,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.apache.maven.settings.Server;
 
-@Mojo(name="install-node-and-npm", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name="install-node-and-npm", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
 
     /**

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeAndNPMInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeAndNPMInstaller.java
@@ -21,6 +21,8 @@ public class NodeAndNPMInstaller {
 
     private String nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot, userName, password;
 
+    private static final Object lock = new Object();
+
     private final Logger logger;
     private final InstallConfig config;
     private final ArchiveExtractor archiveExtractor;
@@ -70,19 +72,21 @@ public class NodeAndNPMInstaller {
         if(npmDownloadRoot == null || npmDownloadRoot.isEmpty()){
             npmDownloadRoot = DEFAULT_NPM_DOWNLOAD_ROOT;
         }
-        if(!nodeIsAlreadyInstalled()){
-            logger.info("Installing node version {}", nodeVersion);
-            if (!nodeVersion.startsWith("v")) {
-                logger.warn("Node version does not start with naming convention 'v'.");
+        synchronized (lock) {
+            if (!nodeIsAlreadyInstalled()) {
+                logger.info("Installing node version {}", nodeVersion);
+                if (!nodeVersion.startsWith("v")) {
+                    logger.warn("Node version does not start with naming convention 'v'.");
+                }
+                if (config.getPlatform().isWindows()) {
+                    installNodeForWindows();
+                } else {
+                    installNodeDefault();
+                }
             }
-            if(config.getPlatform().isWindows()){
-                installNodeForWindows();
-            } else {
-                installNodeDefault();
+            if (!npmIsAlreadyInstalled()) {
+                installNpm();
             }
-        }
-        if(!npmIsAlreadyInstalled()) {
-            installNpm();
         }
     }
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeAndNPMInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeAndNPMInstaller.java
@@ -19,9 +19,9 @@ public class NodeAndNPMInstaller {
     public static final String DEFAULT_NODEJS_DOWNLOAD_ROOT = "https://nodejs.org/dist/";
     public static final String DEFAULT_NPM_DOWNLOAD_ROOT = "http://registry.npmjs.org/npm/-/";
 
-    private String nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot, userName, password;
+    private static final Object LOCK = new Object();
 
-    private static final Object lock = new Object();
+    private String nodeVersion, npmVersion, nodeDownloadRoot, npmDownloadRoot, userName, password;
 
     private final Logger logger;
     private final InstallConfig config;
@@ -66,13 +66,14 @@ public class NodeAndNPMInstaller {
     }
 
     public void install() throws InstallationException {
-        if(nodeDownloadRoot == null || nodeDownloadRoot.isEmpty()){
-            nodeDownloadRoot = DEFAULT_NODEJS_DOWNLOAD_ROOT;
-        }
-        if(npmDownloadRoot == null || npmDownloadRoot.isEmpty()){
-            npmDownloadRoot = DEFAULT_NPM_DOWNLOAD_ROOT;
-        }
-        synchronized (lock) {
+        // use static lock object for a synchronized block
+        synchronized (LOCK) {
+            if(nodeDownloadRoot == null || nodeDownloadRoot.isEmpty()){
+                nodeDownloadRoot = DEFAULT_NODEJS_DOWNLOAD_ROOT;
+            }
+            if(npmDownloadRoot == null || npmDownloadRoot.isEmpty()){
+                npmDownloadRoot = DEFAULT_NPM_DOWNLOAD_ROOT;
+            }
             if (!nodeIsAlreadyInstalled()) {
                 logger.info("Installing node version {}", nodeVersion);
                 if (!nodeVersion.startsWith("v")) {


### PR DESCRIPTION
allow use of -T (threaded builds) together with node/npm installation

This is a copy of pull request #327 without proxy changes. We run into some race conditions in our CI with multiple modules using the frontend-maven-plugin with the same node installDirectory. 