### PR TITLE
Add ARM's 64bit server aarch64 support

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
@@ -1,10 +1,12 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
-enum Architecture { x86, x64, ppc64le;
+enum Architecture { x86, x64, ppc64le, arm64;
     public static Architecture guess(){
         String arch = System.getProperty("os.arch");
         if (arch.equals("ppc64le")) {
             return ppc64le;
+        } else if (arch.equals("aarch64")) {
+            return arm64;
         } else {
             return arch.contains("64") ? x64 : x86;
         }


### PR DESCRIPTION
Added aarch64 support similiar as pull427.
On X86, 'mvn clean test install' passed.
On aarch64, 'mvn clean install' failed on example build which requests for  "nodeVersion = v0.12.2". This is because aarch64 support was added since v4.0.0. For example which requests for "nodeVersion = v5.3.0" the build is passed.
```
[INFO] [DEBUG] -- end configuration --
[INFO] [INFO] Installing node version v5.3.0
[INFO] [DEBUG] Creating install directory /root/frontend-maven-plugin/frontend-maven-plugin/target/it/example project/node
[INFO] [DEBUG] Creating temporary directory /root/frontend-maven-plugin/frontend-maven-plugin/target/it/example project/node/tmp
[INFO] [INFO] Downloading https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-arm64.tar.gz to /root/frontend-maven-plugin/frontend-maven-plugin/target/local-repo/com/github/eirslett/node/5.3.0/node-5.3.0-linux-arm64.tar.gz
[INFO] [INFO] No proxies configured
[INFO] [INFO] No proxy was configured, downloading directly
[INFO] [INFO] Unpacking /root/frontend-maven-plugin/frontend-maven-plugin/target/local-repo/com/github/eirslett/node/5.3.0/node-5.3.0-linux-arm64.tar.gz into /root/frontend-maven-plugin/frontend-maven-plugin/target/it/example project/node/tmp
[INFO] [INFO] Copying node binary from /root/frontend-maven-plugin/frontend-maven-plugin/target/it/example project/node/tmp/node-v5.3.0-linux-arm64/bin/node to /root/frontend-maven-plugin/frontend-maven-plugin/target/it/example project/node/node
[INFO] [DEBUG] Deleting temporary directory /root/frontend-maven-plugin/frontend-maven-plugin/target/it/example project/node/tmp
[INFO] [INFO] Installed node locally.
[INFO] [INFO] Installing npm version 3.3.12
[INFO] [INFO] Downloading http://registry.npmjs.org/npm/-/npm-3.3.12.tgz to /root/frontend-maven-plugin/frontend-maven-plugin/target/local-repo/com/github/eirslett/npm/3.3.12/npm-3.3.12.tar.gz
[INFO] [INFO] No proxies configured
[INFO] [INFO] No proxy was configured, downloading directly
[INFO] [INFO] Unpacking /root/frontend-maven-plugin/frontend-maven-plugin/target/local-repo/com/github/eirslett/npm/3.3.12/npm-3.3.12.tar.gz into /root/frontend-maven-plugin/frontend-maven-plugin/target/it/example project/node/node_modules
[INFO] [INFO] Installed npm locally.
```