### PR TITLE
Check write permissions on node destination folder

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArchiveExtractor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArchiveExtractor.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.AccessDeniedException;
 
 class ArchiveExtractionException extends Exception {
     ArchiveExtractionException(String message, Throwable cause) {
@@ -39,6 +40,10 @@ final class DefaultArchiveExtractor implements ArchiveExtractor {
                 } else {
                     if (!destPath.getParentFile().exists()) {
                         destPath.getParentFile().mkdirs();
+                    }
+                    if(!destPath.getParentFile().canWrite()) {
+                        throw new AccessDeniedException(
+                                String.format("Could not get write permissions for '%s'", destinationDirectory));
                     }
                     destPath.createNewFile();
                     boolean isExecutable = (tarEntry.getMode() & 0100) > 0;

--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.1</version>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>1.7</source>
+                        <target>1.7</target>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
* Raises a more detailed Exception if the plugin fails to extract the
  node archive because it can't access the destination directory.
  (Fixes #469)

Note: AccessDeniedException() was added since 1.7
