### PR TITLE
Update example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ to see how it should be set up: https://github.com/eirslett/frontend-maven-plugi
     
 **Recommendation:** _Try to run all your tasks via npm scripts instead of running bower, grunt, gulp etc. directly._
 
-#### Installing node and npm
+### Installing node and npm
 
 The versions of Node and npm are downloaded from https://nodejs.org/dist, extracted and put into a `node` folder created 
 in your [installation directory](#installation-directory) . Node/npm will only be "installed" locally to your project. 

--- a/frontend-maven-plugin/src/it/example project/package.json
+++ b/frontend-maven-plugin/src/it/example project/package.json
@@ -2,18 +2,18 @@
   "name": "example",
   "version": "0.0.1",
   "dependencies": {
-    "bower": "~1.7.2",
-    "grunt": "~0.4.5",
-    "grunt-cli": "~0.1.13",
-    "grunt-contrib-jshint": "~0.11.3",
-    "grunt-karma": "~0.12.1",
-    "gulp": "^3.9.0",
-    "jspm": "~0.16.19",
-    "karma": "~0.13.18",
-    "karma-jasmine": "~0.3.6",
-    "karma-phantomjs-launcher": "~0.2.3",
-    "jasmine-core": "^2.4.1",
-    "phantomjs": "^1.9.19"
+    "bower": "~1.7.9",
+    "grunt": "~1.0.1",
+    "grunt-cli": "~1.2.0",
+    "grunt-contrib-jshint": "~1.0.0",
+    "grunt-karma": "~2.0.0",
+    "gulp": "^3.9.1",
+    "jspm": "~0.16.46",
+    "karma": "~1.3.0",
+    "karma-jasmine": "~1.0.2",
+    "karma-phantomjs-launcher": "~1.0.2",
+    "jasmine-core": "^2.5.2",
+    "phantomjs": "^2.1.7"
   },
   "jspm": {
     "dependencies": {

--- a/frontend-maven-plugin/src/it/example project/pom.xml
+++ b/frontend-maven-plugin/src/it/example project/pom.xml
@@ -23,8 +23,9 @@
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v5.3.0</nodeVersion>
-                            <npmVersion>3.3.12</npmVersion>
+                            <!-- See https://nodejs.org/en/download/ for latest node and npm (lts) versions -->
+                            <nodeVersion>v4.6.0</nodeVersion>
+                            <npmVersion>2.15.9</npmVersion>
                         </configuration>
                     </execution>
 


### PR DESCRIPTION
updated package.json dependencies to latest versions. changed node and npm to latest lts version. 
This should help testing current version instead of old legacy ones and it removes warnings from build log.