### PR TITLE
Fix Yarn version comparison

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnInstaller.java
@@ -77,7 +77,7 @@ public class YarnInstaller {
                 final String version =
                     new YarnExecutor(executorConfig, Arrays.asList("--version"), null).executeAndGetResult();
 
-                if (version.equals(yarnVersion)) {
+                if (version.equals(yarnVersion.replaceFirst("^v", ""))) {
                     logger.info("Yarn {} is already installed.", version);
                     return true;
                 } else {


### PR DESCRIPTION
The command `yarn --version` doesn't return a version number prefixed with a **v**.
