### PR TITLE
fix the skipping of the install-node-and-yarn execution in pom

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
@@ -56,7 +56,7 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
     /**
      * Skips execution of this mojo.
      */
-    @Parameter(property = "skip.installyarn", defaultValue = "false")
+    @Parameter(property = "skip.installyarn", alias = "skip.installyarn", defaultValue = "false")
     private Boolean skip;
 
     @Component(role = SettingsDecrypter.class)


### PR DESCRIPTION
The issue fixed by this changeset is described in https://github.com/eirslett/frontend-maven-plugin/issues/506.
In summary, the execution of the install-node-and-yarn mojo cannot be skipped through the config in the pom.xml file.
