### PR TITLE
Possibility define already installed yarn for plugin

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/YarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/YarnMojo.java
@@ -51,6 +51,12 @@ public final class YarnMojo extends AbstractFrontendMojo {
     @Parameter(property = "skip.yarn", defaultValue = "false")
     private Boolean skip;
 
+    /**
+     * The path of the yarn executable
+     */
+    @Parameter(property = "yarnExecutablePath", required = false)
+    protected File yarnExecutablePath;
+
     @Override
     protected boolean skipExecution() {
         return this.skip;
@@ -62,7 +68,7 @@ public final class YarnMojo extends AbstractFrontendMojo {
         if (this.buildContext == null || this.buildContext.hasDelta(packageJson)
             || !this.buildContext.isIncremental()) {
             ProxyConfig proxyConfig = getProxyConfig();
-            factory.getYarnRunner(proxyConfig, getRegistryUrl()).execute(this.arguments,
+            factory.getYarnRunner(proxyConfig, getRegistryUrl(), this.yarnExecutablePath).execute(this.arguments,
                 this.environmentVariables);
         } else {
             getLog().info("Skipping yarn install as package.json unchanged");

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/YarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/YarnMojo.java
@@ -54,8 +54,8 @@ public final class YarnMojo extends AbstractFrontendMojo {
     /**
      * The path of the yarn executable
      */
-    @Parameter(property = "yarnExecutablePath", required = false)
-    protected File yarnExecutablePath;
+    @Parameter(property = "yarnPath", required = false)
+    protected File yarnPath;
 
     @Override
     protected boolean skipExecution() {
@@ -68,7 +68,7 @@ public final class YarnMojo extends AbstractFrontendMojo {
         if (this.buildContext == null || this.buildContext.hasDelta(packageJson)
             || !this.buildContext.isIncremental()) {
             ProxyConfig proxyConfig = getProxyConfig();
-            factory.getYarnRunner(proxyConfig, getRegistryUrl(), this.yarnExecutablePath).execute(this.arguments,
+            factory.getYarnRunner(proxyConfig, getRegistryUrl(), this.yarnPath).execute(this.arguments,
                 this.environmentVariables);
         } else {
             getLog().info("Skipping yarn install as package.json unchanged");

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -45,8 +45,8 @@ public final class FrontendPluginFactory {
         return new DefaultNpmRunner(getExecutorConfig(), proxy, npmRegistryURL);
     }
 
-    public YarnRunner getYarnRunner(ProxyConfig proxy, String npmRegistryURL, File yarnExecutablePath) {
-        return new DefaultYarnRunner(new InstallYarnExecutorConfig(getInstallConfig(), yarnExecutablePath), proxy, npmRegistryURL);
+    public YarnRunner getYarnRunner(ProxyConfig proxy, String npmRegistryURL, File yarnPath) {
+        return new DefaultYarnRunner(new InstallYarnExecutorConfig(getInstallConfig(), yarnPath), proxy, npmRegistryURL);
     }
 
     public GruntRunner getGruntRunner(){

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -45,8 +45,8 @@ public final class FrontendPluginFactory {
         return new DefaultNpmRunner(getExecutorConfig(), proxy, npmRegistryURL);
     }
 
-    public YarnRunner getYarnRunner(ProxyConfig proxy, String npmRegistryURL) {
-        return new DefaultYarnRunner(new InstallYarnExecutorConfig(getInstallConfig()), proxy, npmRegistryURL);
+    public YarnRunner getYarnRunner(ProxyConfig proxy, String npmRegistryURL, File yarnExecutablePath) {
+        return new DefaultYarnRunner(new InstallYarnExecutorConfig(getInstallConfig(), yarnExecutablePath), proxy, npmRegistryURL);
     }
 
     public GruntRunner getGruntRunner(){

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnExecutorConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnExecutorConfig.java
@@ -22,7 +22,7 @@ final class InstallYarnExecutorConfig implements YarnExecutorConfig {
 
     private File nodePath;
 
-    private final File yarnExecutablePath;
+    private final File yarnPath;
 
     private final InstallConfig installConfig;
 
@@ -30,9 +30,9 @@ final class InstallYarnExecutorConfig implements YarnExecutorConfig {
         this(installConfig, null);
     }
 
-    public InstallYarnExecutorConfig(InstallConfig installConfig, File yarnExecutablePath) {
+    public InstallYarnExecutorConfig(InstallConfig installConfig, File yarnPath) {
         this.installConfig = installConfig;
-        this.yarnExecutablePath = yarnExecutablePath;
+        this.yarnPath = yarnPath;
         nodePath = new InstallNodeExecutorConfig(installConfig).getNodePath();
     }
 
@@ -43,8 +43,8 @@ final class InstallYarnExecutorConfig implements YarnExecutorConfig {
 
     @Override
     public File getYarnPath() {
-        if (yarnExecutablePath != null) {
-            return yarnExecutablePath;
+        if (yarnPath != null) {
+            return yarnPath ;
         }
         String yarnExecutable = getPlatform().isWindows() ? YARN_WINDOWS : YARN_DEFAULT;
         return new File(installConfig.getInstallDirectory() + yarnExecutable);

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnExecutorConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnExecutorConfig.java
@@ -22,10 +22,17 @@ final class InstallYarnExecutorConfig implements YarnExecutorConfig {
 
     private File nodePath;
 
+    private final File yarnExecutablePath;
+
     private final InstallConfig installConfig;
 
     public InstallYarnExecutorConfig(InstallConfig installConfig) {
+        this(installConfig, null);
+    }
+
+    public InstallYarnExecutorConfig(InstallConfig installConfig, File yarnExecutablePath) {
         this.installConfig = installConfig;
+        this.yarnExecutablePath = yarnExecutablePath;
         nodePath = new InstallNodeExecutorConfig(installConfig).getNodePath();
     }
 
@@ -36,6 +43,9 @@ final class InstallYarnExecutorConfig implements YarnExecutorConfig {
 
     @Override
     public File getYarnPath() {
+        if (yarnExecutablePath != null) {
+            return yarnExecutablePath;
+        }
         String yarnExecutable = getPlatform().isWindows() ? YARN_WINDOWS : YARN_DEFAULT;
         return new File(installConfig.getInstallDirectory() + yarnExecutable);
     }


### PR DESCRIPTION
**Summary**

We have pre-installed `yarn` in our environments where the folder structure not matching with that which is defined in the plugin at the moment. Would be nice to have some possibility to define a custom path of yarn executable. This change is implement this need.

Also would be nice to influence this path by environment variable somehow.
So basically all environment would know is there already installed instance of yarn.
Or the plugin also would check the `PATH` to see is already on it.