### PR TITLE
check if yarn is already installed is not correct

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnInstaller.java
@@ -75,7 +75,7 @@ public class YarnInstaller {
             File nodeFile = executorConfig.getYarnPath();
             if (nodeFile.exists()) {
                 final String version =
-                    new YarnExecutor(executorConfig, Arrays.asList("--version"), null).executeAndGetResult();
+                    new YarnExecutor(executorConfig, Arrays.asList("--version"), null).executeAndGetResult().trim();
 
                 if (version.equals(yarnVersion.replaceFirst("^v", ""))) {
                     logger.info("Yarn {} is already installed.", version);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

On Windows systems the command `yarn --version`, which is used to get the current installed yarn version, can contain a space at the end. For this reason the version check fail and yarn will be installed again, because it is thinking that the installed version is not the latest.