### PR TITLE
Added bower proxy ignore parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,18 @@ If that is the case, you can stop the npm execution from inheriting the Maven pr
 </configuration>
 ```
 
+If you have [configured proxy settings for Maven](http://maven.apache.org/guides/mini/guide-proxies.html)
+in your settings.xml file, the plugin will automatically [pass the proxy to bower commands](https://docs.npmjs.com/misc/config#proxy).
+If that is the case, you can stop the bower execution from inheriting the Maven proxy settings like this:
+
+```xml
+<configuration>
+    <bowerInheritsProxyConfigFromMaven>false</bowerInheritsProxyConfigFromMaven>
+</configuration>
+```
+
+
+
 #### Environment variables
 
 If you need to pass some variable to Node, you can set that using the property `environmentVariables` in configuration 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/BowerMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/BowerMojo.java
@@ -10,6 +10,8 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
 
+import java.util.Collections;
+
 @Mojo(name = "bower", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public final class BowerMojo extends AbstractFrontendMojo {
 
@@ -28,6 +30,9 @@ public final class BowerMojo extends AbstractFrontendMojo {
     @Parameter(property = "session", defaultValue = "${session}", readonly = true)
     private MavenSession session;
 
+    @Parameter(property = "frontend.bower.bowerInheritsProxyConfigFromMaven", required = false, defaultValue = "true")
+    private boolean bowerInheritsProxyConfigFromMaven;
+
     @Component(role = SettingsDecrypter.class)
     private SettingsDecrypter decrypter;
 
@@ -38,7 +43,17 @@ public final class BowerMojo extends AbstractFrontendMojo {
 
     @Override
     protected void execute(FrontendPluginFactory factory) throws TaskRunnerException {
-        ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session, decrypter);
+        ProxyConfig proxyConfig = getProxyConfig();
         factory.getBowerRunner(proxyConfig).execute(arguments, environmentVariables);
     }
+
+    private ProxyConfig getProxyConfig() {
+        if (bowerInheritsProxyConfigFromMaven) {
+            return MojoUtils.getProxyConfig(session, decrypter);
+        } else {
+            getLog().info("npm not inheriting proxy config from Maven");
+            return new ProxyConfig(Collections.<ProxyConfig.Proxy>emptyList());
+        }
+    }
+
 }


### PR DESCRIPTION
**Summary**

The aim of this modification is to allow user to NOT use maven proxy settings on bower commands.

**Tests and Documentation**

This modification is sort of a copy of the existing code for Node proxy ignoring method.
