### PR TITLE
Fixed toMojoFailureException() when e.getCause() is null

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
@@ -24,7 +24,8 @@ class MojoUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(MojoUtils.class);
 
     static <E extends Throwable> MojoFailureException toMojoFailureException(E e) {
-        return new MojoFailureException(e.getMessage() + ": " + e.getCause().getMessage(), e);
+        String causeMessage = e.getCause() != null ? ": " + e.getCause().getMessage() : "";
+        return new MojoFailureException(e.getMessage() + causeMessage, e);
     }
 
     static ProxyConfig getProxyConfig(MavenSession mavenSession, SettingsDecrypter decrypter) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

See my comment on #532:

I just had the same problem as the OP. The problem for me was not the error message but the fact that it is not displayed. Instead, a NullPointerException is thrown:

```org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.4-SNAPSHOT:install-node-and-yarn (install node and yarn) on project teamapps-webserver: Execution install node and yarn of goal com.github.eirslett:frontend-maven-plugin:1.4-SNAPSHOT:install-node-and-yarn failed.
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:224)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:862)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:286)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:197)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
	at org.codehaus.classworlds.Launcher.main(Launcher.java:47)
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution install node and yarn of goal com.github.eirslett:frontend-maven-plugin:1.4-SNAPSHOT:install-node-and-yarn failed.
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:145)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
	... 21 more
Caused by: java.lang.NullPointerException
	at com.github.eirslett.maven.plugins.frontend.mojo.MojoUtils.toMojoFailureException(MojoUtils.java:27)
	at com.github.eirslett.maven.plugins.frontend.mojo.AbstractFrontendMojo.execute(AbstractFrontendMojo.java:97)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
	... 22 more
```

This was because in MojoUtils.java:27 e.getCause() returned null.

This apparently only happens on the first build (neither node nor node_modules are present).


**Tests and Documentation**

-
