### PR TITLE
closes #534: Do not fail the Maven build for a failed test

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
@@ -2,10 +2,10 @@ package com.github.eirslett.maven.plugins.frontend.mojo;
 
 import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
 import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
+
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.slf4j.LoggerFactory;
 
 
 @Mojo(name="karma",  defaultPhase = LifecyclePhase.TEST)
@@ -16,12 +16,6 @@ public final class KarmaRunMojo extends AbstractFrontendMojo {
      */
     @Parameter(defaultValue = "karma.conf.js", property = "karmaConfPath")
     private String karmaConfPath;
-
-    /**
-     * Whether you should continue build when some test will fail (default is false)
-     */
-    @Parameter(property = "maven.test.failure.ignore", required = false, defaultValue = "false")
-    private Boolean testFailureIgnore;
 
     /**
      * Skips execution of this mojo.
@@ -36,17 +30,6 @@ public final class KarmaRunMojo extends AbstractFrontendMojo {
 
     @Override
     public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
-        try {
-            factory.getKarmaRunner().execute("start " + karmaConfPath, environmentVariables);
-        }
-        catch (TaskRunnerException e) {
-            if (testFailureIgnore) {
-                LoggerFactory.getLogger(KarmaRunMojo.class)
-                        .warn("There are ignored test failures/errors for: " + workingDirectory);
-            }
-            else {
-                throw e;
-            }
-        }
+        factory.getKarmaRunner().execute("start " + karmaConfPath, environmentVariables);
     }
 }


### PR DESCRIPTION
Added general support for `testFailureIgnore` (`maven.test.failure.ignore`) flag as in Surefire plugin (this closes #534). Currently only Karma mojo respects this flag, making it impossible to apply it to Protractor or any other tests.
In case this flag is set to `true`, a failure during `test` or `integration-test` phase will not fail the entire build, but just log the error.

**Property name** (to add to the `<configuration>` block): `testFailureIgnore`
**User property** (to add as command line argument, or the `<properties>` block): `maven.test.failure.ignore`

The change is minimal, and the flag itself, the behavior, and the implementation are all consistent with [Surefire plugin](https://github.com/apache/maven-surefire/blob/303cc8acdaf677bee9751da94de16e07083febb7/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/SurefireHelper.java):

**EDIT**
Seems like a similar pull request already exists: https://github.com/eirslett/frontend-maven-plugin/pull/553