### PR TITLE
add failOnError and integration-test support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 .project
 .metadata
 .recommenders
+bin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Changelog
 
+### 1.4
+
+* Add maven.frontend.failOnError and maven.test.failure.ignore flags to best manage integration-test
+
 ### 1.3
 
 * Fix `yarn` for Windows

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Include the plugin as a dependency in your Maven project. Change `LATEST_VERSION
 
 ## Usage
 
-Have a look at the [example project](https://github.com/eirslett/frontend-maven-plugin/tree/master/frontend-maven-plugin/src/it/example%20project), 
+Have a look at the [example project](frontend-maven-plugin/src/it/example%20project),
 to see how it should be set up: https://github.com/eirslett/frontend-maven-plugin/blob/master/frontend-maven-plugin/src/it/example%20project/pom.xml
 
  - [Installing node and npm](#installing-node-and-npm)
@@ -71,6 +71,7 @@ to see how it should be set up: https://github.com/eirslett/frontend-maven-plugi
     - [Installation Directory](#installation-directory)
     - [Proxy Settings](#proxy-settings)
     - [Environment variables](#environment-variables)
+    - [Ignoring Failure](#ignoring-failure)
     - [Skipping Execution](#skipping-execution)
     
 **Recommendation:** _Try to run all your tasks via npm scripts instead of running bower, grunt, gulp etc. directly._
@@ -190,6 +191,7 @@ By default, colors will be shown in the log.
 
 **Notice:** _Remember to gitignore the `node_modules` folder, unless you actually want to commit it. Npm packages will 
 always be installed in `node_modules` next to your `package.json`, which is default npm behavior._
+
 
 ### Running yarn
 
@@ -445,6 +447,28 @@ tag of an execution like this:
 </configuration>
 ```
 
+#### Ignoring Failure
+
+**Ignoring failed tests:** If you want to ignore test failures in specific execution  you can set that using the property `maven.test.failure.ignore` in configuration tag of an execution like this:
+
+```xml
+<configuration>
+    <maven.test.failure.ignore>true</maven.test.failure.ignore>
+</configuration>
+```
+
+If you want to generally ignore tests run maven with the `-Dmaven.test.failure.ignore=true` flag, test/integration-test results will not stop the build.
+
+**Ignoring other failures:** If you need to ignore other failures you can set that using the property `maven.frontend.failOnError` in configuration tag of an execution like this:
+
+```xml
+<configuration>
+    <maven.frontend.failOnError>true</maven.frontend.failOnError>
+</configuration>
+```
+
+If you want to ignore all failures run maven with the `-Dmaven.frontend.failOnError=true` flag.
+
 #### Skipping Execution
 
 Each frontend build tool and package manager allows skipping execution.
@@ -476,7 +500,7 @@ these are set they check for changes in your source files before being run. See 
 ## Helper scripts
 
 During development, it's convenient to have the "npm", "bower", "grunt", "gulp" and "karma" commands
-available on the command line. If you want that, use [those helper scripts](https://github.com/eirslett/frontend-maven-plugin/tree/master/frontend-maven-plugin/src/it/example%20project/helper-scripts)!
+available on the command line. If you want that, use [those helper scripts](frontend-maven-plugin/src/it/example%20project/helper-scripts)!
 
 ## To build this project:
 

--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -121,6 +121,11 @@
                             <goal>run</goal>
                             <goal>verify</goal>
                         </goals>
+                        <configuration>
+				<goals>
+					<goal>verify</goal>
+				</goals>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -1,154 +1,157 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <artifactId>frontend-plugins</artifactId>
-        <groupId>com.github.eirslett</groupId>
-        <version>1.4-SNAPSHOT</version>
-    </parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>frontend-plugins</artifactId>
+    <groupId>com.github.eirslett</groupId>
+    <version>1.4-SNAPSHOT</version>
+  </parent>
 
-    <artifactId>frontend-maven-plugin</artifactId>
-    <packaging>maven-plugin</packaging>
+  <artifactId>frontend-maven-plugin</artifactId>
+  <packaging>maven-plugin</packaging>
 
-    <name>Maven Frontend Plugin</name>
-    <prerequisites>
-        <maven>3.1.0</maven>
-    </prerequisites>
+  <name>Maven Frontend Plugin</name>
+  <prerequisites>
+    <maven>3.1.0</maven>
+  </prerequisites>
 
-    <description>
+  <description>
         This Maven plugin lets you install Node/NPM locally
         for your project, install dependencies with NPM,
         install dependencies with bower or jspm, run Grunt or gulp tasks,
         and/or run Karma tests.
     </description>
 
-    <dependencies>
-        <dependency>
-            <groupId>com.github.eirslett</groupId>
-            <artifactId>frontend-plugin-core</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
+  <dependencies>
+    <dependency>
+      <groupId>com.github.eirslett</groupId>
+      <artifactId>frontend-plugin-core</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
 
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-core</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
-        </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>3.1.0</version>
+      <scope>provided</scope>
+    </dependency>
 
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-plugin-api</artifactId>
-            <version>3.1.0</version>
-        </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>3.1.0</version>
+    </dependency>
 
-        <dependency>
-            <groupId>org.apache.maven.plugin-tools</groupId>
-            <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.2</version>
-        </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.2</version>
+    </dependency>
 
-        <dependency>
-            <groupId>org.sonatype.plexus</groupId>
-            <artifactId>plexus-build-api</artifactId>
-            <version>0.0.7</version>
-        </dependency>
-    </dependencies>
+    <dependency>
+      <groupId>org.sonatype.plexus</groupId>
+      <artifactId>plexus-build-api</artifactId>
+      <version>0.0.7</version>
+    </dependency>
+  </dependencies>
 
-    <build>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.2</version>
+        <configuration>
+          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+        </configuration>
+        <executions>
+          <execution>
+            <id>mojo-descriptor</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+            <configuration>
+              <goalPrefix>frontend</goalPrefix>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- For the integration test -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>mrm-maven-plugin</artifactId>
+        <version>1.0-beta-2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>start</goal>
+              <goal>stop</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <propertyName>repository.proxy.url</propertyName>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <version>2.0.0</version>
+
+        <configuration>
+          <debug>true</debug>
+          <projectsDirectory>src/it</projectsDirectory>
+          <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+          <settingsFile>src/it/settings.xml</settingsFile>
+          <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+          <streamLogs>true</streamLogs>
+          <postBuildHookScript>verify</postBuildHookScript>
+          <filterProperties>
+            <repository.proxy.url>${repository.proxy.url}</repository.proxy.url>
+          </filterProperties>
+        </configuration>
+
+        <executions>
+          <execution>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>install</goal>
+              <goal>run</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <goals>
+                <goal>verify</goal>
+              </goals>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>Skip tests</id>
+      <activation>
+        <property>
+          <name>skipTests</name>
+        </property>
+      </activation>
+      <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
-                <configuration>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                        <configuration>
-                            <goalPrefix>frontend</goalPrefix>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <!-- For the integration test -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>mrm-maven-plugin</artifactId>
-                <version>1.0-beta-2</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>start</goal>
-                            <goal>stop</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                  <propertyName>repository.proxy.url</propertyName>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-invoker-plugin</artifactId>
-                <version>2.0.0</version>
-
-                <configuration>
-                    <debug>true</debug>
-                    <projectsDirectory>src/it</projectsDirectory>
-                    <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
-                    <settingsFile>src/it/settings.xml</settingsFile>
-                    <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
-                    <streamLogs>true</streamLogs>
-                    <postBuildHookScript>verify</postBuildHookScript>
-                    <filterProperties>
-                        <repository.proxy.url>${repository.proxy.url}</repository.proxy.url>
-                    </filterProperties>
-                </configuration>
-
-                <executions>
-                    <execution>
-                        <phase>integration-test</phase>
-                        <goals>
-                            <goal>install</goal>
-                            <goal>run</goal>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-				<goals>
-					<goal>verify</goal>
-				</goals>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-invoker-plugin</artifactId>
+            <configuration>
+              <skipInvocation>true</skipInvocation>
+            </configuration>
+          </plugin>
         </plugins>
-    </build>
-
-    <profiles>
-        <profile>
-            <id>Skip tests</id>
-            <activation>
-                <property><name>skipTests</name></property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-invoker-plugin</artifactId>
-                        <configuration>
-                            <skipInvocation>true</skipInvocation>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -122,11 +122,6 @@
               <goal>run</goal>
               <goal>verify</goal>
             </goals>
-            <configuration>
-              <goals>
-                <goal>verify</goal>
-              </goals>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/frontend-maven-plugin/src/it/example project/invoker.properties
+++ b/frontend-maven-plugin/src/it/example project/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean verify

--- a/frontend-maven-plugin/src/it/example project/package.json
+++ b/frontend-maven-plugin/src/it/example project/package.json
@@ -26,6 +26,9 @@
   },
   "scripts": {
     "prebuild": "npm install",
+	"pre-test": "echo pre-integration-test-success",
+	"test": "return 1",
+	"post-test": "echo post-integration-test-success",
     "build": "gulp"
   }
 }

--- a/frontend-maven-plugin/src/it/example project/package.json
+++ b/frontend-maven-plugin/src/it/example project/package.json
@@ -26,9 +26,9 @@
   },
   "scripts": {
     "prebuild": "npm install",
-	"pre-test": "echo pre-integration-test-success",
-	"test": "return 1",
-	"post-test": "echo post-integration-test-success",
+    "pre-test": "echo pre-integration-test-success",
+    "test": "return 1",
+    "post-test": "echo post-integration-test-success",
     "build": "gulp"
   }
 }

--- a/frontend-maven-plugin/src/it/example project/pom.xml
+++ b/frontend-maven-plugin/src/it/example project/pom.xml
@@ -103,6 +103,51 @@
                         </configuration>
                     </execution>
 
+				   <!-- Integration Tests -->
+                   <execution>
+                        <id>npm-pre-integration-test</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>run pre-test</arguments>
+                        </configuration>
+                        <phase>pre-integration-test</phase>
+                    </execution>
+                   <execution>
+                        <id>npm-integration-test-failSafeTest</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>run test</arguments>
+                            <testFailureIgnore>true</testFailureIgnore>
+                        </configuration>
+                        <phase>integration-test</phase>
+                    </execution>
+                   <execution>
+                        <id>npm-integration-test-failOnError</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>run test</arguments>
+                            <failOnError>false</failOnError>
+                        </configuration>
+                        <phase>integration-test</phase>
+                    </execution>
+                   <execution>
+                        <id>npm-post-integration-test</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>run post-test</arguments>
+                            <testFailureIgnore>true</testFailureIgnore>
+                        </configuration>
+                        <phase>post-integration-test</phase>
+                    </execution>
+
                 </executions>
             </plugin>
         </plugins>

--- a/frontend-maven-plugin/src/it/example project/pom.xml
+++ b/frontend-maven-plugin/src/it/example project/pom.xml
@@ -1,155 +1,156 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.eirslett</groupId>
-    <artifactId>example</artifactId>
-    <version>0</version>
-    <packaging>pom</packaging>
+  <groupId>com.github.eirslett</groupId>
+  <artifactId>example</artifactId>
+  <version>0</version>
+  <packaging>pom</packaging>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.github.eirslett</groupId>
-                <artifactId>frontend-maven-plugin</artifactId>
-                <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
-                <version>@project.version@</version>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.eirslett</groupId>
+        <artifactId>frontend-maven-plugin</artifactId>
+        <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
+        <version>@project.version@</version>
 
-                <executions>
+        <executions>
 
-                    <execution>
-                        <id>install node and npm</id>
-                        <goals>
-                            <goal>install-node-and-npm</goal>
-                        </goals>
-                        <configuration>
-                            <!-- See https://nodejs.org/en/download/ for latest node and npm (lts) versions -->
-                            <nodeVersion>v4.6.0</nodeVersion>
-                            <npmVersion>2.15.9</npmVersion>
-                        </configuration>
-                    </execution>
+          <execution>
+            <id>install node and npm</id>
+            <goals>
+              <goal>install-node-and-npm</goal>
+            </goals>
+            <configuration>
+              <!-- See https://nodejs.org/en/download/ for latest node and npm (lts) versions -->
+              <nodeVersion>v4.6.0</nodeVersion>
+              <npmVersion>2.15.9</npmVersion>
+            </configuration>
+          </execution>
 
-                    <execution>
-                        <id>npm install</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <!-- Optional configuration which provides for running any npm command -->
-                        <configuration>
-                            <arguments>install</arguments>
-                        </configuration>
-                    </execution>
+          <execution>
+            <id>npm install</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <!-- Optional configuration which provides for running any npm command -->
+            <configuration>
+              <arguments>install</arguments>
+            </configuration>
+          </execution>
 
-                    <execution>
-                        <id>npm run build</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>run build</arguments>
-                        </configuration>
-                    </execution>
-                    
-                    <execution>
-                        <id>bower install</id>
-                        <goals>
-                            <goal>bower</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>install</arguments>
-                        </configuration>
-                    </execution>
+          <execution>
+            <id>npm run build</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <configuration>
+              <arguments>run build</arguments>
+            </configuration>
+          </execution>
 
-                    <execution>
-                        <id>jspm install</id>
-                        <goals>
-                            <goal>jspm</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>--version</arguments>
-                        </configuration>
-                    </execution>
+          <execution>
+            <id>bower install</id>
+            <goals>
+              <goal>bower</goal>
+            </goals>
+            <configuration>
+              <arguments>install</arguments>
+            </configuration>
+          </execution>
 
-                    <execution>
-                        <id>grunt build</id>
-                        <goals>
-                            <goal>grunt</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>--no-color</arguments>
-                        </configuration>
-                    </execution>
+          <execution>
+            <id>jspm install</id>
+            <goals>
+              <goal>jspm</goal>
+            </goals>
+            <configuration>
+              <arguments>--version</arguments>
+            </configuration>
+          </execution>
 
-                    <execution>
-                        <id>gulp build</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>gulp</goal>
-                        </goals>
-                        <configuration>
-                            <environmentVariables>
-                                <NODE_ENV>production</NODE_ENV>
-                            </environmentVariables>
-                        </configuration>
-                    </execution>
+          <execution>
+            <id>grunt build</id>
+            <goals>
+              <goal>grunt</goal>
+            </goals>
+            <configuration>
+              <arguments>--no-color</arguments>
+            </configuration>
+          </execution>
 
-                    <execution>
-                        <id>javascript tests</id>
-                        <goals>
-                            <goal>karma</goal>
-                        </goals>
-                        <configuration>
-                            <karmaConfPath>src/test/javascript/karma.conf.ci.js</karmaConfPath>
-                        </configuration>
-                    </execution>
+          <execution>
+            <id>gulp build</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>gulp</goal>
+            </goals>
+            <configuration>
+              <environmentVariables>
+                <NODE_ENV>production</NODE_ENV>
+              </environmentVariables>
+            </configuration>
+          </execution>
 
-				   <!-- Integration Tests -->
-                   <execution>
-                        <id>npm-pre-integration-test</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>run pre-test</arguments>
-                        </configuration>
-                        <phase>pre-integration-test</phase>
-                    </execution>
-                   <execution>
-                        <id>npm-integration-test-failSafeTest</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>run test</arguments>
-                            <testFailureIgnore>true</testFailureIgnore>
-                        </configuration>
-                        <phase>integration-test</phase>
-                    </execution>
-                   <execution>
-                        <id>npm-integration-test-failOnError</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>run test</arguments>
-                            <failOnError>false</failOnError>
-                        </configuration>
-                        <phase>integration-test</phase>
-                    </execution>
-                   <execution>
-                        <id>npm-post-integration-test</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>run post-test</arguments>
-                            <testFailureIgnore>true</testFailureIgnore>
-                        </configuration>
-                        <phase>post-integration-test</phase>
-                    </execution>
+          <execution>
+            <id>javascript tests</id>
+            <goals>
+              <goal>karma</goal>
+            </goals>
+            <configuration>
+              <karmaConfPath>src/test/javascript/karma.conf.ci.js</karmaConfPath>
+            </configuration>
+          </execution>
 
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+          <!-- Integration Tests -->
+          <execution>
+            <id>npm-pre-integration-test</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <configuration>
+              <arguments>run pre-test</arguments>
+            </configuration>
+            <phase>pre-integration-test</phase>
+          </execution>
+          <execution>
+            <id>npm-integration-test-failSafeTest</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <configuration>
+              <arguments>run test</arguments>
+              <testFailureIgnore>true</testFailureIgnore>
+            </configuration>
+            <phase>integration-test</phase>
+          </execution>
+          <execution>
+            <id>npm-integration-test-failOnError</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <configuration>
+              <arguments>run test</arguments>
+              <failOnError>false</failOnError>
+            </configuration>
+            <phase>integration-test</phase>
+          </execution>
+          <execution>
+            <id>npm-post-integration-test</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <configuration>
+              <arguments>run post-test</arguments>
+              <testFailureIgnore>true</testFailureIgnore>
+            </configuration>
+            <phase>post-integration-test</phase>
+          </execution>
+
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/frontend-maven-plugin/src/it/example project/verify.groovy
+++ b/frontend-maven-plugin/src/it/example project/verify.groovy
@@ -6,4 +6,6 @@ assert buildLog.contains('gulp runs as expected') : 'gulp failed to run as expec
 assert buildLog.contains('Running against local jspm install.') : 'jspm failed to run as expected'
 assert buildLog.contains('5 files lint free.') : 'grunt failed to run as expected'
 assert buildLog.contains('Executed 1 of 1 SUCCESS') : 'karma failed to run as expected'
+assert buildLog.contains('post-integration-test-success') : 'failOnError does not works as expected'
+assert buildLog.contains('testFailureIgnore property is ignored in non test phases') : 'testFailureIgnore does not works as expected'
 assert buildLog.contains('BUILD SUCCESS') : 'build was not successful'

--- a/frontend-maven-plugin/src/it/yarn-integration/verify.groovy
+++ b/frontend-maven-plugin/src/it/yarn-integration/verify.groovy
@@ -5,5 +5,4 @@ assert new File(basedir, 'node_modules/less/package.json').exists() : "Less depe
 import org.codehaus.plexus.util.FileUtils;
 
 String buildLog = FileUtils.fileRead(new File(basedir, 'build.log'));
-
 assert buildLog.contains('BUILD SUCCESS') : 'build was not successful'

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
@@ -18,120 +18,111 @@ import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
 
 public abstract class AbstractFrontendMojo extends AbstractMojo {
 
-  @Component
-  protected MojoExecution execution;
+    @Component
+    protected MojoExecution execution;
 
-  /**
-   * Whether you should skip while running in the test phase (default is false)
-   */
-  @Parameter(property = "skipTests", required = false, defaultValue = "false")
-  protected Boolean skipTests;
+    /**
+     * Whether you should skip while running in the test phase (default is false)
+     */
+    @Parameter(property = "skipTests", required = false, defaultValue = "false")
+    protected Boolean skipTests;
 
-  /**
-   * Specifies if the build will fail if there are errors during a frontend execution or not.
-   *
-   * @parameter property="maven.frontend.failOnError" default-value="true"
-   * @since 1.4
-   */
-  @Parameter(property = "maven.frontend.failOnError", required = false, defaultValue = "true")
-  protected boolean failOnError;
+    /**
+     * Specifies if the build will fail if there are errors during a frontend execution or not.
+     *
+     * @parameter property="maven.frontend.failOnError" default-value="true"
+     * @since 1.4
+     */
+    @Parameter(property = "maven.frontend.failOnError", required = false, defaultValue = "true")
+    protected boolean failOnError;
 
-  /**
-   * Whether you should continue build when some test will fail (default is false)
-   */
-  @Parameter(property = "maven.test.failure.ignore", required = false, defaultValue = "false")
-  protected boolean testFailureIgnore;
+    /**
+     * Whether you should continue build when some test will fail (default is false)
+     */
+    @Parameter(property = "maven.test.failure.ignore", required = false, defaultValue = "false")
+    protected boolean testFailureIgnore;
 
-  /**
-   * The base directory for running all Node commands. (Usually the directory that contains package.json)
-   */
-  @Parameter(defaultValue = "${basedir}", property = "workingDirectory", required = false)
-  protected File workingDirectory;
+    /**
+     * The base directory for running all Node commands. (Usually the directory that contains package.json)
+     */
+    @Parameter(defaultValue = "${basedir}", property = "workingDirectory", required = false)
+    protected File workingDirectory;
 
-  /**
-   * The base directory for installing node and npm.
-   */
-  @Parameter(property = "installDirectory", required = false)
-  protected File installDirectory;
+    /**
+     * The base directory for installing node and npm.
+     */
+    @Parameter(property = "installDirectory", required = false)
+    protected File installDirectory;
 
+    /**
+     * Additional environment variables to pass to the build.
+     */
+    @Parameter
+    protected Map<String, String> environmentVariables;
 
-  /**
-   * Additional environment variables to pass to the build.
-   */
-   @Parameter
-   protected Map<String, String> environmentVariables;
+    @Parameter(defaultValue = "${project}", readonly = true)
+    private MavenProject project;
 
-  @Parameter(
-      defaultValue = "${project}",
-      readonly = true
-  )
-  private MavenProject project;
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
+    private RepositorySystemSession repositorySystemSession;
 
-  @Parameter(
-      defaultValue = "${repositorySystemSession}",
-      readonly = true
-  )
-  private RepositorySystemSession repositorySystemSession;
-
-  /**
-   * Determines if this execution should be skipped.
-   */
-  private boolean skipTestPhase() {
-    return skipTests && isTestingPhase();
-  }
-
-  /**
-   * Determines if the current execution is during a testing phase (e.g., "test" or "integration-test").
-   */
-  private boolean isTestingPhase() {
-    String phase = execution.getLifecyclePhase();
-    return phase!=null && (phase.equals("test") || phase.equals("integration-test"));
-  }
-
-  protected abstract void execute(FrontendPluginFactory factory) throws FrontendException;
-
-  /**
-   * Implemented by children to determine if this execution should be skipped.
-   */
-  protected abstract boolean skipExecution();
-
-  @Override
-  public void execute() throws MojoFailureException {
-	if (testFailureIgnore && !isTestingPhase()){
-		LoggerFactory.getLogger(AbstractFrontendMojo.class).warn("testFailureIgnore property is ignored in non test phases");
-	}
-    if (!(skipTestPhase() || skipExecution())) {
-      if (installDirectory == null) {
-        installDirectory = workingDirectory;
-      }
-      try {
-        execute(new FrontendPluginFactory(
-            workingDirectory,
-            installDirectory,
-            new RepositoryCacheResolver(repositorySystemSession)
-        ));
-      } catch (TaskRunnerException e) {
-        failOnError( "Failed to run task", e );
-      } catch (FrontendException e) {
-        throw MojoUtils.toMojoFailureException(e);
-      }
-    } else {
-      LoggerFactory.getLogger(AbstractFrontendMojo.class).info("Skipping test phase.");
+    /**
+     * Determines if this execution should be skipped.
+     */
+    private boolean skipTestPhase() {
+        return skipTests && isTestingPhase();
     }
-  }
 
-	protected void failOnError(String prefix, Exception e) throws MojoFailureException {
-		if (!failOnError || (testFailureIgnore && isTestingPhase()) ){
-			if ((testFailureIgnore && isTestingPhase())){
-	            LoggerFactory.getLogger(AbstractFrontendMojo.class)
-	            .warn("There are ignored test failures/errors for: " + workingDirectory);
-			}
-			LoggerFactory.getLogger(AbstractFrontendMojo.class).error(prefix + ": " + e.getMessage(), e);
-		}else {
-			if (e instanceof RuntimeException) {
-				throw (RuntimeException) e;
-			}
-			throw new MojoFailureException(prefix + ": " + e.getMessage(), e);
-		}
-	}
+    /**
+     * Determines if the current execution is during a testing phase (e.g., "test" or "integration-test").
+     */
+    private boolean isTestingPhase() {
+        String phase = execution.getLifecyclePhase();
+        return phase != null && (phase.equals("test") || phase.equals("integration-test"));
+    }
+
+    protected abstract void execute(FrontendPluginFactory factory) throws FrontendException;
+
+    /**
+     * Implemented by children to determine if this execution should be skipped.
+     */
+    protected abstract boolean skipExecution();
+
+    @Override
+    public void execute() throws MojoFailureException {
+        if (testFailureIgnore && !isTestingPhase()) {
+            LoggerFactory.getLogger(AbstractFrontendMojo.class)
+                         .warn("testFailureIgnore property is ignored in non test phases");
+        }
+        if (!(skipTestPhase() || skipExecution())) {
+            if (installDirectory == null) {
+                installDirectory = workingDirectory;
+            }
+            try {
+                execute(new FrontendPluginFactory(workingDirectory, installDirectory,
+                        new RepositoryCacheResolver(repositorySystemSession)));
+            } catch (TaskRunnerException e) {
+                failOnError("Failed to run task", e);
+            } catch (FrontendException e) {
+                throw MojoUtils.toMojoFailureException(e);
+            }
+        } else {
+            LoggerFactory.getLogger(AbstractFrontendMojo.class).info("Skipping test phase.");
+        }
+    }
+
+    protected void failOnError(String prefix, Exception e) throws MojoFailureException {
+        if (!failOnError || (testFailureIgnore && isTestingPhase())) {
+            if ((testFailureIgnore && isTestingPhase())) {
+                LoggerFactory.getLogger(AbstractFrontendMojo.class)
+                             .warn("There are ignored test failures/errors for: " + workingDirectory);
+            }
+            LoggerFactory.getLogger(AbstractFrontendMojo.class).error(prefix + ": " + e.getMessage(), e);
+        } else {
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            }
+            throw new MojoFailureException(prefix + ": " + e.getMessage(), e);
+        }
+    }
 }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
@@ -5,7 +5,6 @@ import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.slf4j.LoggerFactory;
 
 
 @Mojo(name="karma",  defaultPhase = LifecyclePhase.TEST)
@@ -16,12 +15,6 @@ public final class KarmaRunMojo extends AbstractFrontendMojo {
      */
     @Parameter(defaultValue = "karma.conf.js", property = "karmaConfPath")
     private String karmaConfPath;
-
-    /**
-     * Whether you should continue build when some test will fail (default is false)
-     */
-    @Parameter(property = "maven.test.failure.ignore", required = false, defaultValue = "false")
-    private Boolean testFailureIgnore;
 
     /**
      * Skips execution of this mojo.
@@ -36,17 +29,6 @@ public final class KarmaRunMojo extends AbstractFrontendMojo {
 
     @Override
     public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
-        try {
-            factory.getKarmaRunner().execute("start " + karmaConfPath, environmentVariables);
-        }
-        catch (TaskRunnerException e) {
-            if (testFailureIgnore) {
-                LoggerFactory.getLogger(KarmaRunMojo.class)
-                        .warn("There are ignored test failures/errors for: " + workingDirectory);
-            }
-            else {
-                throw e;
-            }
-        }
+	factory.getKarmaRunner().execute("start " + karmaConfPath, environmentVariables);
     }
 }


### PR DESCRIPTION
This reuses and fixes PR #553 , solving issue #552 ; see also #534 closed as duplicate.

Current behavior: an execution failure stops the Maven build. This is an issue for instance when the plugin is used to execute tests. Moreover, after an `integration-test` phase, it is often required to execute the `post-integration-test` phase for environment cleanup and tear down.

Expected behavior: 
- add a `failOnError` property
- if unset, then defaults to true except if if the current execution is a testing phase
- else, if `failOnError==true`, keep the current behavior (`BUILD FAILURE`)
- else, if `failOnError==false`, don't fail the Maven build (`BUILD ERROR`)

That is compliant with the common behavior encountered on the Maven plugins.

Tested on frontend-maven-plugin 1.4-SNAPSHOT