### PR TITLE
update lifecycle-mapping-metadata.xml for yarn

### DIFF
--- a/frontend-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/frontend-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -5,6 +5,7 @@
 			<pluginExecutionFilter>
 				<goals>
 					<goal>install-node-and-npm</goal>
+					<goal>install-node-and-yarn</goal>
 				</goals>
 			</pluginExecutionFilter>
 			<action>
@@ -18,6 +19,7 @@
             <pluginExecutionFilter>
                 <goals>
                     <goal>npm</goal>
+                    <goal>yarn</goal>
                     <goal>gulp</goal>
                     <goal>grunt</goal>
                     <goal>bower</goal>


### PR DESCRIPTION
Yarn support was added in #490, but lifecycle-mapping-metadata.xml wasn't updated to reflect the new goals.
This change adds lifecycle mappings for the new `yarn` and `install-node-and-yarn` goals.
Fixes #531