### PR TITLE
595: Fixed issue with skip properties with jvm arguments

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/BowerMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/BowerMojo.java
@@ -24,8 +24,8 @@ public final class BowerMojo extends AbstractFrontendMojo {
     /**
      * Skips execution of this mojo.
      */
-    @Parameter(property = "skip.bower", defaultValue = "false")
-    private Boolean skip;
+    @Parameter(property = "skip.bower", defaultValue = "${skip.bower}")
+    private boolean skip;
 
     @Parameter(property = "session", defaultValue = "${session}", readonly = true)
     private MavenSession session;

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/EmberMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/EmberMojo.java
@@ -47,8 +47,8 @@ public final class EmberMojo extends AbstractFrontendMojo {
     /**
      * Skips execution of this mojo.
      */
-    @Parameter(property = "skip.ember", defaultValue = "false")
-    private Boolean skip;
+    @Parameter(property = "skip.ember", defaultValue = "${skip.ember}")
+    private boolean skip;
 
     @Component
     private BuildContext buildContext;

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
@@ -47,8 +47,8 @@ public final class GruntMojo extends AbstractFrontendMojo {
     /**
      * Skips execution of this mojo.
      */
-    @Parameter(property = "skip.grunt", defaultValue = "false")
-    private Boolean skip;
+    @Parameter(property = "skip.grunt", defaultValue = "${skip.grunt}")
+    private boolean skip;
 
     @Component
     private BuildContext buildContext;

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
@@ -47,8 +47,8 @@ public final class GulpMojo extends AbstractFrontendMojo {
     /**
      * Skips execution of this mojo.
      */
-    @Parameter(property = "skip.gulp", defaultValue = "false")
-    private Boolean skip;
+    @Parameter(property = "skip.gulp", defaultValue = "${skip.gulp}")
+    private boolean skip;
 
     @Component
     private BuildContext buildContext;

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -61,8 +61,8 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
     /**
      * Skips execution of this mojo.
      */
-    @Parameter(property = "skip.installnodenpm", defaultValue = "false")
-    private Boolean skip;
+    @Parameter(property = "skip.installnodenpm", defaultValue = "${skip.installnodenpm}")
+    private boolean skip;
 
     @Component(role = SettingsDecrypter.class)
     private SettingsDecrypter decrypter;

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
@@ -56,8 +56,8 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
     /**
      * Skips execution of this mojo.
      */
-    @Parameter(property = "skip.installyarn", alias = "skip.installyarn", defaultValue = "false")
-    private Boolean skip;
+    @Parameter(property = "skip.installyarn", alias = "skip.installyarn", defaultValue = "${skip.installyarn}")
+    private boolean skip;
 
     @Component(role = SettingsDecrypter.class)
     private SettingsDecrypter decrypter;

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/JspmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/JspmMojo.java
@@ -23,8 +23,8 @@ public class JspmMojo extends AbstractFrontendMojo {
     /**
      * Skips execution of this mojo.
      */
-    @Parameter(property = "skip.jspm", defaultValue = "false")
-    private Boolean skip;
+    @Parameter(property = "skip.jspm", defaultValue = "${skip.jspm}")
+    private boolean skip;
 
     @Override
     protected boolean skipExecution() {

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
@@ -19,8 +19,8 @@ public final class KarmaRunMojo extends AbstractFrontendMojo {
     /**
      * Skips execution of this mojo.
      */
-    @Parameter(property = "skip.karma", defaultValue = "false")
-    private Boolean skip;
+    @Parameter(property = "skip.karma", defaultValue = "${skip.karma}")
+    private boolean skip;
 
     @Override
     protected boolean skipExecution() {
@@ -29,6 +29,6 @@ public final class KarmaRunMojo extends AbstractFrontendMojo {
 
     @Override
     public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
-	factory.getKarmaRunner().execute("start " + karmaConfPath, environmentVariables);
+        factory.getKarmaRunner().execute("start " + karmaConfPath, environmentVariables);
     }
 }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -46,8 +46,8 @@ public final class NpmMojo extends AbstractFrontendMojo {
     /**
      * Skips execution of this mojo.
      */
-    @Parameter(property = "skip.npm", defaultValue = "false")
-    private Boolean skip;
+    @Parameter(property = "skip.npm", defaultValue = "${skip.npm}")
+    private boolean skip;
 
     @Override
     protected boolean skipExecution() {
@@ -75,7 +75,7 @@ public final class NpmMojo extends AbstractFrontendMojo {
     }
 
     private String getRegistryUrl() {
-	// check to see if overridden via `-D`, otherwise fallback to pom value
-	return System.getProperty(NPM_REGISTRY_URL, npmRegistryURL);
+        // check to see if overridden via `-D`, otherwise fallback to pom value
+        return System.getProperty(NPM_REGISTRY_URL, npmRegistryURL);
     }
 }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/WebpackMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/WebpackMojo.java
@@ -47,8 +47,8 @@ public final class WebpackMojo extends AbstractFrontendMojo {
     /**
      * Skips execution of this mojo.
      */
-    @Parameter(property = "skip.webpack", defaultValue = "false")
-    private Boolean skip;
+    @Parameter(property = "skip.webpack", defaultValue = "${skip.webpack}")
+    private boolean skip;
 
     @Component
     private BuildContext buildContext;

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/YarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/YarnMojo.java
@@ -48,8 +48,8 @@ public final class YarnMojo extends AbstractFrontendMojo {
     /**
      * Skips execution of this mojo.
      */
-    @Parameter(property = "skip.yarn", defaultValue = "false")
-    private Boolean skip;
+    @Parameter(property = "skip.yarn", defaultValue = "${skip.yarn}")
+    private boolean skip;
 
     @Override
     protected boolean skipExecution() {
@@ -74,7 +74,7 @@ public final class YarnMojo extends AbstractFrontendMojo {
             return MojoUtils.getProxyConfig(this.session, this.decrypter);
         } else {
             getLog().info("yarn not inheriting proxy config from Maven");
-            return new ProxyConfig(Collections.<ProxyConfig.Proxy> emptyList());
+            return new ProxyConfig(Collections.<ProxyConfig.Proxy>emptyList());
         }
     }
 


### PR DESCRIPTION
Fix for issue [https://github.com/eirslett/frontend-maven-plugin/issues/595](url).

**Summary**
All hardcoded "false" values replaced with EL code for each skip-property.
`@Parameter(property = "skip.npm", defaultValue = "${skip.npm}")`
This value will be read from jvm argumens like -Dskip.npm=true

Also changed type of skip - all big Boolean replaced with little boolean, because big Boolean can be null. In case when skip value set with null the `boolean skipExecution` method will throw NullPointerException (implicit unboxing) and build will be failed:
> Execution npm install of goal com.github.eirslett:frontend-maven-plugin:1.5-SNAPSHOT:npm failed.: NullPointerException