### PR TITLE
Point to node_modules/.bin/ for grunt

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GruntRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GruntRunner.java
@@ -4,7 +4,7 @@ public interface GruntRunner extends NodeTaskRunner {}
 
 final class DefaultGruntRunner extends NodeTaskExecutor implements GruntRunner {
 
-    private static final String TASK_LOCATION = "node_modules/grunt-cli/bin/grunt";
+    private static final String TASK_LOCATION = "node_modules/.bin/grunt";
 
     DefaultGruntRunner(NodeExecutorConfig config) {
         super(config, TASK_LOCATION);


### PR DESCRIPTION
**Summary**

Binaries are stored there, it gives more flexibility to the user, it's not obliged to have grunt-cli as first level dependency

**Tests and Documentation**

Now using node_modules/.bin/grunt instead of node_modules/grunt-cli/bin/grunt
If it is accepted, it can be done with the rest of the binaries too.