### PR TITLE
Incorrect CacheDescriptor.extension

### DIFF
--- a/frontend-maven-plugin/src/it/yarn-integration/verify.groovy
+++ b/frontend-maven-plugin/src/it/yarn-integration/verify.groovy
@@ -2,7 +2,6 @@ assert new File(basedir, 'target/node').exists() : "Node was not installed in th
 assert new File(basedir, 'node_modules').exists() : "Node modules were not installed in the base directory";
 assert new File(basedir, 'node_modules/less/package.json').exists() : "Less dependency has not been installed successfully";
 
-import org.codehaus.plexus.util.FileUtils;
-
-String buildLog = FileUtils.fileRead(new File(basedir, 'build.log'));
+String buildLog = new File(basedir, 'build.log').text
 assert buildLog.contains('BUILD SUCCESS') : 'build was not successful'
+assert buildLog.replace(File.separatorChar, '/' as char).matches('(?s).+Unpacking .+\\Q/local-repo/com/github/eirslett/yarn/0.16.1/yarn-0.16.1.tar.gz\\E into .+/target/node/yarn.+') : 'incorrect local repository location'

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnInstaller.java
@@ -96,11 +96,12 @@ public class YarnInstaller {
         try {
             logger.info("Installing Yarn version {}", yarnVersion);
             String downloadUrl = yarnDownloadRoot + yarnVersion;
-            String fileending = "/yarn-" + yarnVersion + ".tar.gz";
+            String extension = "tar.gz";
+            String fileending = "/yarn-" + yarnVersion + "." + extension;
 
             downloadUrl += fileending;
 
-            CacheDescriptor cacheDescriptor = new CacheDescriptor("yarn", yarnVersion, "tar.gz");
+            CacheDescriptor cacheDescriptor = new CacheDescriptor("yarn", yarnVersion, extension);
 
             File archive = config.getCacheResolver().resolve(cacheDescriptor);
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnInstaller.java
@@ -100,7 +100,7 @@ public class YarnInstaller {
 
             downloadUrl += fileending;
 
-            CacheDescriptor cacheDescriptor = new CacheDescriptor("yarn", yarnVersion, fileending);
+            CacheDescriptor cacheDescriptor = new CacheDescriptor("yarn", yarnVersion, "tar.gz");
 
             File archive = config.getCacheResolver().resolve(cacheDescriptor);
 


### PR DESCRIPTION
**Summary**

#499 introduced `YarnInstaller` by analogy with `NodeInstaller` and `NPMInstaller`. However unlike those, which create a `CacheDescriptor.extension` like `zip` or `tar.gz`, this one was creating an extension like `/yarn-v0.23.0.tar.gz`. The result can be seen in build output like this:

    [INFO] Downloading https://github.com/yarnpkg/yarn/releases/download/v0.23.0/yarn-v0.23.0.tar.gz to …/.m2/repository/com/github/eirslett/yarn/0.23.0/yarn-0.23.0./yarn-v0.23.0.tar.gz

which of course violates Maven’s expectations of repository layout. Compare to the reasonable output for node:

    [INFO] Downloading https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-x64.tar.gz to …/.m2/repository/com/github/eirslett/node/4.0.0/node-4.0.0-linux-x64.tar.gz

where you have a relative path like `$groupId_with_slashes/$artifactId/$version/$artifact-$version[-$classifier].$extension`.

**Tests and Documentation**

After building and running it, I see

    [INFO] Downloading https://github.com/yarnpkg/yarn/releases/download/v0.23.0/yarn-v0.23.0.tar.gz to …/.m2/repository/com/github/eirslett/yarn/0.23.0/yarn-0.23.0.tar.gz

as I expected. Also confirmed in integration test.

For my coworkers: @reviewbybees