### PR TITLE
use HTTPS instead of HTTP to download NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ You can also specify separate download roots for npm and node as they are stored
     <configuration>
         <!-- optional: where to download node from. Defaults to https://nodejs.org/dist/ -->
         <nodeDownloadRoot>http://myproxy.example.org/nodejs/</nodeDownloadRoot>
-        <!-- optional: where to download npm from. Defaults to http://registry.npmjs.org/npm/-/ -->
+        <!-- optional: where to download npm from. Defaults to https://registry.npmjs.org/npm/-/ -->
         <npmDownloadRoot>https://myproxy.example.org/npm/</npmDownloadRoot>
     </configuration>
 </plugin>

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -17,13 +17,13 @@ import org.apache.maven.settings.Server;
 public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
 
     /**
-     * Where to download Node.js binary from. Defaults to http://nodejs.org/dist/
+     * Where to download Node.js binary from. Defaults to https://nodejs.org/dist/
      */
     @Parameter(property = "nodeDownloadRoot", required = false, defaultValue = NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)
     private String nodeDownloadRoot;
 
     /**
-     * Where to download NPM binary from. Defaults to http://registry.npmjs.org/npm/-/
+     * Where to download NPM binary from. Defaults to https://registry.npmjs.org/npm/-/
      */
     @Parameter(property = "npmDownloadRoot", required = false, defaultValue = NPMInstaller.DEFAULT_NPM_DOWNLOAD_ROOT)
     private String npmDownloadRoot;

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
@@ -18,7 +18,7 @@ import com.github.eirslett.maven.plugins.frontend.lib.YarnInstaller;
 public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
 
     /**
-     * Where to download Node.js binary from. Defaults to http://nodejs.org/dist/
+     * Where to download Node.js binary from. Defaults to https://nodejs.org/dist/
      */
     @Parameter(property = "nodeDownloadRoot", required = false,
         defaultValue = NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NPMInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NPMInstaller.java
@@ -14,7 +14,7 @@ public class NPMInstaller {
 
     private static final String VERSION = "version";
 
-    public static final String DEFAULT_NPM_DOWNLOAD_ROOT = "http://registry.npmjs.org/npm/-/";
+    public static final String DEFAULT_NPM_DOWNLOAD_ROOT = "https://registry.npmjs.org/npm/-/";
 
     private static final Object LOCK = new Object();
 


### PR DESCRIPTION
**Summary**

It is good security practice to download via HTTPS over HTTP where available, this change updates the default URL to download NPM to be HTTPS not HTTP.  Node is already downloaded over HTTPS.

**Tests and Documentation**

The README, and various comments, have been updated with the correct default URL (also there was one instance of a NodeJS download URL still mentioning HTTP)