### PR TITLE
Enable proxy overrides for install-node-and-npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 
 ## Changelog
 
+### 1.5
+* Add proxy override configuration for `install-node-and-npm`
+
 ### 1.4
 
 * Add maven.frontend.failOnError and maven.test.failure.ignore flags to best manage integration-test

--- a/README.md
+++ b/README.md
@@ -102,6 +102,42 @@ present).
         
         <!-- optional: where to download node and npm from. Defaults to https://nodejs.org/dist/ -->
         <downloadRoot>http://myproxy.example.org/nodejs/</downloadRoot>
+        
+        <!-- optional -->
+        <httpProxyOverride>
+            <!-- required -->
+            <host>myproxy.host</host>
+            
+            <!-- optional - defaults to 8080-->
+            <port>8081</port>
+            
+            <!-- optional -->
+            <userName>myUserName</userName>
+            
+            <!-- optional -->
+            <password>myPassword</password>
+            
+            <!-- optional -->
+            <nonProxy>myNonProxyHost.com</nonProxy>
+        </httpProxyOverride>
+        
+        <!-- optional -->
+        <httpsProxyOverride>
+            <!-- required -->
+            <host>myproxy.host</host>
+            
+            <!-- optional - defaults to 8080-->
+            <port>8081</port>
+            
+            <!-- optional -->
+            <userName>myUserName</userName>
+            
+            <!-- optional -->
+            <password>myPassword</password>
+            
+            <!-- optional -->
+            <nonProxy>myNonProxyHost.com</nonProxy>
+        </httpsProxyOverride>
     </configuration>
 </plugin>
 ```

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -88,7 +88,7 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
 
     @Override
     public void execute(FrontendPluginFactory factory) throws InstallationException {
-        ProxyConfig proxyConfig = MojoUtils.getProxyConfig(this.getHttpProxyOverride(), this.getHttpsProxyOverride(), session, decrypter);
+        ProxyConfig proxyConfig = MojoUtils.getProxyConfig(httpProxyOverride, httpsProxyOverride, session, decrypter);
         String nodeDownloadRoot = getNodeDownloadRoot();
         String npmDownloadRoot = getNpmDownloadRoot();
         Server server = MojoUtils.decryptServer(serverId, session, decrypter);

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -64,6 +64,20 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
     @Parameter(property = "skip.installnodenpm", defaultValue = "${skip.installnodenpm}")
     private boolean skip;
 
+    /**
+     * allows setting of http proxy overrides so that settings.xml does not need to be modified
+     * @since 1.5
+     */
+    @Parameter
+    private ProxyOverrideConfig httpProxyOverride;
+
+    /**
+     * allows setting of https proxy overrides so that settings.xml does not need to be modified
+     * @since 1.5
+     */
+    @Parameter
+    private ProxyOverrideConfig httpsProxyOverride;
+
     @Component(role = SettingsDecrypter.class)
     private SettingsDecrypter decrypter;
 
@@ -74,7 +88,7 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
 
     @Override
     public void execute(FrontendPluginFactory factory) throws InstallationException {
-        ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session, decrypter);
+        ProxyConfig proxyConfig = MojoUtils.getProxyConfig(this.getHttpProxyOverride(), this.getHttpsProxyOverride(), session, decrypter);
         String nodeDownloadRoot = getNodeDownloadRoot();
         String npmDownloadRoot = getNpmDownloadRoot();
         Server server = MojoUtils.decryptServer(serverId, session, decrypter);
@@ -119,5 +133,13 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
             return downloadRoot;
         }
         return npmDownloadRoot;
+    }
+
+    public ProxyOverrideConfig getHttpProxyOverride() {
+        return httpProxyOverride;
+    }
+
+    public ProxyOverrideConfig getHttpsProxyOverride() {
+        return httpsProxyOverride;
     }
 }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -134,12 +134,4 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
         }
         return npmDownloadRoot;
     }
-
-    public ProxyOverrideConfig getHttpProxyOverride() {
-        return httpProxyOverride;
-    }
-
-    public ProxyOverrideConfig getHttpsProxyOverride() {
-        return httpsProxyOverride;
-    }
 }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
@@ -98,4 +98,33 @@ class MojoUtils {
     String[] includedFiles = scanner.getIncludedFiles();
     return (includedFiles != null && includedFiles.length > 0);
   }
+
+    public static ProxyConfig getProxyConfig(final ProxyOverrideConfig httpProxyOverride, final ProxyOverrideConfig httpsProxyOverride, final MavenSession session, final SettingsDecrypter decrypter) {
+        if (httpProxyOverride == null && httpsProxyOverride == null) {
+            return getProxyConfig(session, decrypter);
+        } else {
+            final List<ProxyConfig.Proxy> proxies = new ArrayList<ProxyConfig.Proxy>();
+            if (httpProxyOverride != null) {
+                proxies.add(buildProxyFromOverride(httpProxyOverride, "http"));
+            }
+
+            if (httpsProxyOverride != null) {
+                proxies.add(buildProxyFromOverride(httpsProxyOverride, "https"));
+            }
+
+            return new ProxyConfig(proxies);
+        }
+    }
+
+    private static ProxyConfig.Proxy buildProxyFromOverride(final ProxyOverrideConfig config, final String protocol) {
+        return new ProxyConfig.Proxy(
+                "frontend-proxy-override-" + protocol,
+                protocol,
+                config.getHost(),
+                config.getPort(),
+                config.getUserName(),
+                config.getPassword(),
+                config.getNonProxy()
+        );
+    }
 }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/ProxyOverrideConfig.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/ProxyOverrideConfig.java
@@ -1,0 +1,56 @@
+package com.github.eirslett.maven.plugins.frontend.mojo;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+public class ProxyOverrideConfig {
+    @Parameter(required = true)
+    private String host;
+
+    @Parameter()
+    private Integer port = 8080;
+
+    @Parameter
+    private String userName;
+
+    @Parameter
+    private String password;
+
+    @Parameter
+    private String nonProxy;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(final String host) {
+        this.host = host;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(final Integer port) {
+        this.port = port;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(final String userName) {
+        this.userName = userName;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(final String password) {
+        this.password = password;
+    }
+
+    public String getNonProxy() {
+        return nonProxy;
+    }
+}


### PR DESCRIPTION
In enterprise systems it is sometimes not possible to change settings.xml in order to set proxy information. In this case it makes it difficult to download node/npm. This change allows a user to specify a download configuration for goal: install-node-and-npm.
