### PR TITLE
Fix execution of Yarn 1.X & switch Travis to use OpenJDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 matrix:
   include:
     - os: linux
-      jdk: oraclejdk7
+      jdk: openjdk8
     - os: osx
       #osx_image: beta-xcode6.1
 # Run Integration tests

--- a/frontend-maven-plugin/src/it/yarn-1.X-integration/package.json
+++ b/frontend-maven-plugin/src/it/yarn-1.X-integration/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "example",
+  "version": "0.0.1",
+  "dependencies": {
+    "less": "~2.5.1"
+  }
+}

--- a/frontend-maven-plugin/src/it/yarn-1.X-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/yarn-1.X-integration/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.eirslett</groupId>
+    <artifactId>example</artifactId>
+    <version>0</version>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
+                <version>@project.version@</version>
+
+                <configuration>
+                    <installDirectory>target</installDirectory>
+                </configuration>
+
+                <executions>
+
+                    <execution>
+                        <id>install node and npm</id>
+                        <goals>
+                            <goal>install-node-and-yarn</goal>
+                        </goals>
+                        <configuration>
+                            <nodeVersion>v6.9.1</nodeVersion>
+                            <yarnVersion>v1.0.1</yarnVersion>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>yarn install</id>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>install</arguments>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/frontend-maven-plugin/src/it/yarn-1.X-integration/verify.groovy
+++ b/frontend-maven-plugin/src/it/yarn-1.X-integration/verify.groovy
@@ -1,0 +1,7 @@
+assert new File(basedir, 'target/node').exists() : "Node was not installed in the custom install directory";
+assert new File(basedir, 'node_modules').exists() : "Node modules were not installed in the base directory";
+assert new File(basedir, 'node_modules/less/package.json').exists() : "Less dependency has not been installed successfully";
+
+String buildLog = new File(basedir, 'build.log').text
+assert buildLog.contains('BUILD SUCCESS') : 'build was not successful'
+assert buildLog.replace(File.separatorChar, '/' as char).matches('(?s).+Unpacking .+\\Q/local-repo/com/github/eirslett/yarn/1.0.1/yarn-1.0.1.tar.gz\\E into .+/target/node/yarn.+') : 'incorrect local repository location'


### PR DESCRIPTION
**Summary**
#647

**Tests and Documentation**
Added a 1.X yarn test suite.  Didn't see a 1.6 section in the CHANGELOG, I can add if needed.