### PR TITLE
Modified the NodeInstaller to use a custom method for copying files c…

### DIFF
--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -58,5 +58,140 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.5</version>
         </dependency>
+        <dependency>
+		    <groupId>junit</groupId>
+		    <artifactId>junit</artifactId>
+		    <version>4.12</version>
+		</dependency>
     </dependencies>
+    
+	<build>
+		<pluginManagement>
+		    <plugins>
+		    		<plugin>
+			    		<artifactId>maven-antrun-plugin</artifactId>
+			    		<version>1.8</version>
+					<executions>
+						<execution>
+							<phase>integration-test</phase>
+							<configuration>
+								<target>
+								
+								<mkdir dir="${project.build.directory}/copy-src/parent"/>
+								<mkdir dir="${project.build.directory}/copy-src/parent/child"/>
+								<mkdir dir="${project.build.directory}/copy-src/parent/child/grandchild"/>
+								
+								<!--  THE FOLLOWING WILL CREATE EMPTY FILES WITH PERMISSIONS (WITH READ PERMISSIONS AS THE BASE) -->
+								
+								<!-- Create a set of files with rwx permission combinations under the parent directory -->
+								<touch file="${project.build.directory}/copy-src/parent/readonly"/>
+								<touch file="${project.build.directory}/copy-src/parent/readwrite"/>
+								<touch file="${project.build.directory}/copy-src/parent/readexecute"/>
+								<touch file="${project.build.directory}/copy-src/parent/readwriteexecute"/>
+								
+								<!-- Create a set of files with rwx permission combinations under the child directory -->
+								<touch file="${project.build.directory}/copy-src/parent/child/readonly"/>
+								<touch file="${project.build.directory}/copy-src/parent/child/readwrite"/>
+								<touch file="${project.build.directory}/copy-src/parent/child/readexecute"/>
+								<touch file="${project.build.directory}/copy-src/parent/child/readwriteexecute"/>
+								
+								<!-- Create a set of files with rwx permission combinations under the grandchild directory -->
+								<touch file="${project.build.directory}/copy-src/parent/child/grandchild/readonly"/>
+								<touch file="${project.build.directory}/copy-src/parent/child/grandchild/readwrite"/>
+								<touch file="${project.build.directory}/copy-src/parent/child/grandchild/readexecute"/>
+								<touch file="${project.build.directory}/copy-src/parent/child/grandchild/readwriteexecute"/>
+								
+								<!-- set file permissions to match file name in parent directory -->
+								<chmod file="${project.build.directory}/copy-src/parent/readonly" perm="400"/>
+								<chmod file="${project.build.directory}/copy-src/parent/readwrite" perm="600"/>
+								<chmod file="${project.build.directory}/copy-src/parent/readexecute" perm="500"/>
+								<chmod file="${project.build.directory}/copy-src/parent/readwriteexecute" perm="700"/>
+								
+								<!-- set file permissions to match file name in child directory -->
+								<chmod file="${project.build.directory}/copy-src/parent/child/readonly" perm="400"/>
+								<chmod file="${project.build.directory}/copy-src/parent/child/readwrite" perm="600"/>
+								<chmod file="${project.build.directory}/copy-src/parent/child/readexecute" perm="500"/>
+								<chmod file="${project.build.directory}/copy-src/parent/child/readwriteexecute" perm="700"/>
+								
+								<!-- set file permissions to match file name in grandchild directory -->
+								<chmod file="${project.build.directory}/copy-src/parent/child/grandchild/readonly" perm="400"/>
+								<chmod file="${project.build.directory}/copy-src/parent/child/grandchild/readwrite" perm="600"/>
+								<chmod file="${project.build.directory}/copy-src/parent/child/grandchild/readexecute" perm="500"/>
+								<chmod file="${project.build.directory}/copy-src/parent/child/grandchild/readwriteexecute" perm="700"/>
+								
+								
+								</target>
+							</configuration>
+							<goals>
+								<goal>run</goal>
+							</goals>
+						</execution>
+			        </executions>
+				</plugin>
+		      <plugin>
+		         <groupId>org.apache.maven.plugins</groupId>
+		         <artifactId>maven-failsafe-plugin</artifactId>
+		         <version>2.20.1</version>
+		         <executions>
+			        <execution>
+			          <id>integration-test</id>
+			          <goals>
+			            <goal>integration-test</goal>
+			          </goals>
+			         <configuration>
+			           <systemPropertyVariables>
+			             <propertyName>srcDirectory</propertyName>
+			             <srcDirectory>${project.build.directory}/copy-src/</srcDirectory>
+			             <propertyName>destDirectory</propertyName>
+			             <destDirectory>${project.build.directory}/copy-dest/</destDirectory>
+			           </systemPropertyVariables>
+			         </configuration>
+			        </execution>
+			        </executions>
+		      </plugin>
+		    </plugins>
+	    </pluginManagement>
+	</build>
+	
+	<profiles>
+		  <profile>
+		  <id>Linux</id>
+		  <activation>
+			<os>
+			  <family>unix</family>
+			</os>
+		  </activation>
+		  <build>
+		  <plugins>
+			  <plugin>
+			  <artifactId>maven-antrun-plugin</artifactId>
+			  </plugin>
+			  <plugin>
+		         <groupId>org.apache.maven.plugins</groupId>
+		         <artifactId>maven-failsafe-plugin</artifactId>
+		      </plugin>
+			</plugins>
+			</build>
+		  </profile>
+		  <profile>
+		  <id>MAC</id>
+		  <activation>
+			<os>
+			  <family>mac</family>
+			</os>
+		  </activation>
+		  <build>
+		  <plugins>
+			  <plugin>
+			  <artifactId>maven-antrun-plugin</artifactId>
+			  </plugin>
+			  <plugin>
+		         <groupId>org.apache.maven.plugins</groupId>
+		         <artifactId>maven-failsafe-plugin</artifactId>
+		      </plugin>
+			</plugins>
+			</build>
+		  </profile>
+	</profiles>
+  
 </project>

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArchiveExtractor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArchiveExtractor.java
@@ -141,11 +141,9 @@ final class DefaultArchiveExtractor implements ArchiveExtractor {
     }
     
     void setFilePermissions(TarArchiveEntry tarEntry, File destPath){
-	    LOG.debug("tarEntry is " + tarEntry.getName() + " mode is " + tarEntry.getMode());
 	    
 	    boolean isExecutable = (tarEntry.getMode() & EXECUTE_FILE_MASK) > 0;
 
-	    LOG.debug("Setting Execute permission on: " + destPath + " to " + isExecutable);
 	    destPath.setExecutable(isExecutable);
 	}
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
@@ -3,6 +3,9 @@ package com.github.eirslett.maven.plugins.frontend.lib;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 
 import org.apache.commons.io.FileUtils;
@@ -166,7 +169,7 @@ public class NodeInstaller {
                         longNodeFilename + File.separator + "lib" + File.separator + "node_modules");
                     File nodeModulesDirectory = new File(destinationDirectory, "node_modules");
                     File npmDirectory = new File(nodeModulesDirectory, "npm");
-                    FileUtils.copyDirectory(tmpNodeModulesDir, nodeModulesDirectory);
+                    copyDirectoryContents(tmpNodeModulesDir, nodeModulesDirectory);
                     this.logger.info("Extracting NPM");
                     // create a copy of the npm scripts next to the node executable
                     for (String script : Arrays.asList("npm", "npm.cmd")) {
@@ -228,7 +231,7 @@ public class NodeInstaller {
                     File tmpNodeModulesDir =
                         new File(tmpDirectory, longNodeFilename + File.separator + "node_modules");
                     File nodeModulesDirectory = new File(destinationDirectory, "node_modules");
-                    FileUtils.copyDirectory(tmpNodeModulesDir, nodeModulesDirectory);
+                    copyDirectoryContents(tmpNodeModulesDir, nodeModulesDirectory);
                 }
                 deleteTempDirectory(tmpDirectory);
 
@@ -262,7 +265,7 @@ public class NodeInstaller {
             downloadFileIfMissing(downloadUrl, binary, this.userName, this.password);
 
             this.logger.info("Copying node binary from {} to {}", binary, destination);
-            FileUtils.copyFile(binary, destination);
+            Files.copy(Paths.get(binary.getAbsolutePath()), Paths.get(destination.getAbsolutePath()), StandardCopyOption.COPY_ATTRIBUTES);
 
             this.logger.info("Installed node locally.");
         } catch (DownloadException e) {
@@ -313,5 +316,37 @@ public class NodeInstaller {
         throws DownloadException {
         this.logger.info("Downloading {} to {}", downloadUrl, destination);
         this.fileDownloader.download(downloadUrl, destination.getPath(), userName, password);
+    }
+    
+    /**
+     * This method is a convenience for copying all contents from 1 directory to another while preserving file permissions
+     * @param sourceDirectory - The directory to copy all contents from
+     * @param destDirectory - The new directory to copy all contents to
+     */
+    private void copyDirectoryContents(File sourceDirectory, File destDirectory) {
+    		if(sourceDirectory.isDirectory()) {
+	    		//Get all files and directory names from the current source directory
+			for(File child : sourceDirectory.listFiles()) {
+				//If the File is a Directory then we need to create it and any parent directories that may not exist
+				//At the same time we need to go ahead and recursively call our current method to go into all child directories to copy
+				//all of their contents as well
+				if(child.isDirectory()) {
+					File newDirectory = new File(destDirectory.getAbsolutePath() + File.separator + child.getName());
+					this.logger.debug("Creating directory :" + newDirectory.getAbsolutePath());
+					newDirectory.mkdirs();
+					copyDirectoryContents(child, newDirectory);
+				}
+				else {
+					//If this is a plain file then we need to copy it and preserve permissions
+					File dest = new File(destDirectory.getPath() + File.separator + child.getName());
+					try {
+						this.logger.debug("Creating file :" + dest.getAbsolutePath());
+						Files.copy(Paths.get(child.getAbsolutePath()), Paths.get(dest.getAbsolutePath()), StandardCopyOption.COPY_ATTRIBUTES);
+					} catch (IOException e) {
+						e.printStackTrace();
+					}
+				}
+			}
+	    }
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
@@ -169,7 +169,7 @@ public class NodeInstaller {
                         longNodeFilename + File.separator + "lib" + File.separator + "node_modules");
                     File nodeModulesDirectory = new File(destinationDirectory, "node_modules");
                     File npmDirectory = new File(nodeModulesDirectory, "npm");
-                    copyDirectoryContents(tmpNodeModulesDir, nodeModulesDirectory);
+                    Utils.copyDirectoryContents(tmpNodeModulesDir, nodeModulesDirectory);
                     this.logger.info("Extracting NPM");
                     // create a copy of the npm scripts next to the node executable
                     for (String script : Arrays.asList("npm", "npm.cmd")) {
@@ -231,7 +231,7 @@ public class NodeInstaller {
                     File tmpNodeModulesDir =
                         new File(tmpDirectory, longNodeFilename + File.separator + "node_modules");
                     File nodeModulesDirectory = new File(destinationDirectory, "node_modules");
-                    copyDirectoryContents(tmpNodeModulesDir, nodeModulesDirectory);
+                    Utils.copyDirectoryContents(tmpNodeModulesDir, nodeModulesDirectory);
                 }
                 deleteTempDirectory(tmpDirectory);
 
@@ -317,36 +317,5 @@ public class NodeInstaller {
         this.logger.info("Downloading {} to {}", downloadUrl, destination);
         this.fileDownloader.download(downloadUrl, destination.getPath(), userName, password);
     }
-    
-    /**
-     * This method is a convenience for copying all contents from 1 directory to another while preserving file permissions
-     * @param sourceDirectory - The directory to copy all contents from
-     * @param destDirectory - The new directory to copy all contents to
-     */
-    private void copyDirectoryContents(File sourceDirectory, File destDirectory) {
-    		if(sourceDirectory.isDirectory()) {
-	    		//Get all files and directory names from the current source directory
-			for(File child : sourceDirectory.listFiles()) {
-				//If the File is a Directory then we need to create it and any parent directories that may not exist
-				//At the same time we need to go ahead and recursively call our current method to go into all child directories to copy
-				//all of their contents as well
-				if(child.isDirectory()) {
-					File newDirectory = new File(destDirectory.getAbsolutePath() + File.separator + child.getName());
-					this.logger.debug("Creating directory :" + newDirectory.getAbsolutePath());
-					newDirectory.mkdirs();
-					copyDirectoryContents(child, newDirectory);
-				}
-				else {
-					//If this is a plain file then we need to copy it and preserve permissions
-					File dest = new File(destDirectory.getPath() + File.separator + child.getName());
-					try {
-						this.logger.debug("Creating file :" + dest.getAbsolutePath());
-						Files.copy(Paths.get(child.getAbsolutePath()), Paths.get(dest.getAbsolutePath()), StandardCopyOption.COPY_ATTRIBUTES);
-					} catch (IOException e) {
-						e.printStackTrace();
-					}
-				}
-			}
-	    }
-    }
+
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Utils.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Utils.java
@@ -1,11 +1,20 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 final class Utils {
+	private static final Logger logger = LoggerFactory.getLogger(Utils.class);
+	
     public static List<String> merge(List<String> first, List<String> second) {
         ArrayList<String> result = new ArrayList<String>(first);
         result.addAll(second);
@@ -34,4 +43,37 @@ final class Utils {
     public static boolean isRelative(String path) {
         return !path.startsWith("/") && !path.startsWith("file:") && !path.matches("^[a-zA-Z]:\\\\.*");
     }
+    
+    /**
+     * This method is a convenience for copying all contents from 1 directory to another while preserving file permissions
+     * @param sourceDirectory - The directory to copy all contents from
+     * @param destDirectory - The new directory to copy all contents to
+     */
+    public static void copyDirectoryContents(File sourceDirectory, File destDirectory) {
+    		if(sourceDirectory.isDirectory()) {
+	    		//Get all files and directory names from the current source directory
+			for(File child : sourceDirectory.listFiles()) {
+				//If the File is a Directory then we need to create it and any parent directories that may not exist
+				//At the same time we need to go ahead and recursively call our current method to go into all child directories to copy
+				//all of their contents as well
+				if(child.isDirectory()) {
+					File newDirectory = new File(destDirectory.getAbsolutePath() + File.separator + child.getName());
+					logger.debug("Creating directory :" + newDirectory.getAbsolutePath());
+					newDirectory.mkdirs();
+					copyDirectoryContents(child, newDirectory);
+				}
+				else {
+					//If this is a plain file then we need to copy it and preserve permissions
+					File dest = new File(destDirectory.getPath() + File.separator + child.getName());
+					try {
+						logger.debug("Creating file :" + dest.getAbsolutePath());
+						Files.copy(Paths.get(child.getAbsolutePath()), Paths.get(dest.getAbsolutePath()), StandardCopyOption.COPY_ATTRIBUTES);
+					} catch (IOException e) {
+						e.printStackTrace();
+					}
+				}
+			}
+	    }
+    }
+
 }

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/UtilsIT.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/UtilsIT.java
@@ -1,0 +1,114 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class UtilsIT{
+	private File srcDirectory;
+	private File destDirectory;
+	
+	@Before
+	public void setup() {
+		srcDirectory = new File((String)System.getProperties().get("srcDirectory"));
+		destDirectory = new File((String)System.getProperties().get("destDirectory"));
+		
+		System.out.println("Project Build Directory set to " + srcDirectory.getAbsolutePath());
+		System.out.println("Project Build Directory set to " + destDirectory.getAbsolutePath());
+	}
+	
+	@Test
+	public void testSourceFolderAttributeContent() {
+		System.out.println("Testing source Folder file permissions at: " + srcDirectory.getAbsolutePath());
+		
+		traverseDirectoryForAllFiles(srcDirectory);
+	}
+	
+	@Test
+	public void testDestinationFolderAttributeContent() {
+		System.out.println("Testing Destination Folder file permissions at: " + destDirectory.getAbsolutePath());
+		
+		Utils.copyDirectoryContents(srcDirectory, destDirectory);
+	}
+	
+	private void traverseDirectoryForAllFiles(File sourceDirectory) {
+		File[] files = sourceDirectory.listFiles();
+		
+		for(File file: files) {
+			if(file.isDirectory()) {
+				traverseDirectoryForAllFiles(file);
+			}
+			else {
+				assertTrue(FilePermissions.isPermissionCorrect(file));
+			}
+		}
+	}
+	
+	/**
+	 * This Enum will be used as a convenience for this test class to assert that permissions remain intact after calling Utils.copyDirectoryContents
+	 * Note that we expect that all files have at least READ permission, otherwise the ability to copy a file is pointless.
+	 * @author mjimenez
+	 *
+	 */
+	enum FilePermissions{
+		READONLY("readonly", true, false, false),
+		READWRITE("readwrite", true, true, false),
+		READEXECUTE("readexecute", true, false, true),
+		READWRITEEXEUCTE("readwriteexecute", true, true, true);
+		
+		private String fileName;
+		private boolean canRead;
+		private boolean canWrite;
+		private boolean canExecute;
+		
+		private static Map<String, FilePermissions> filePermissionsMap = new HashMap<String, FilePermissions>();
+		
+		static {
+			for(FilePermissions filePermission: FilePermissions.values()) {
+				filePermissionsMap.put(filePermission.fileName, filePermission);
+			}
+		}
+		
+		private FilePermissions(String filename, boolean canRead, boolean canWrite, boolean canExecute) {
+			this.fileName = filename;
+			this.canRead = canRead;
+			this.canWrite = canWrite;
+			this.canExecute = canExecute;
+		}
+		
+		public String getFileName() {
+			return fileName;
+		}
+		
+		public boolean canRead() {
+			return canRead;
+		}
+		
+		public boolean canWrite() {
+			return canWrite;
+		}
+		
+		public boolean canExecute() {
+			return canExecute;
+		}
+		
+		public static boolean isPermissionCorrect(File file) {
+			boolean isCorrectPermission = false;
+			if(filePermissionsMap.containsKey(file.getName())) {
+				isCorrectPermission = (filePermissionsMap.get(file.getName()).canRead() == file.canRead() &&
+										filePermissionsMap.get(file.getName()).canWrite() == file.canWrite() &&
+										filePermissionsMap.get(file.getName()).canExecute() == file.canExecute()) ? true:false;
+			}
+			else {
+				System.out.println("Could not determine expected file attributes for file: " + file.getName());
+			}
+			return isCorrectPermission;
+		}
+	}
+}


### PR DESCRIPTION
…opyDirectoryContents() rather than using the FileUtils.copyDirectory() which does not preserve file attributes. Also modified the ArchiveExtractor class to use a umask of 0001 when checking to set execute permission on files being unpacked.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

We recently upgraded the version of Node for our webapp application to 6.11.3 and when using the frontend-maven-plugin to help with installation we ran into a permission error at build time.  Several scripts included in the Node 6.11.3 archive which should have execute permission were not longer set to executable after the plugin's lifecycle.  This fix is meant to cover this issue posted: https://github.com/eirslett/frontend-maven-plugin/issues/667

The root cause of the issue was in the plugin's use of FileUtils.copyDirectory which does not preserve File attributes.  To fix this issue I have implemented a new method to copyDirectory contents which is used instead of the FileUtils method.

We have tested the fix on our local developer machines and jenkins machine and have confirmed that our Node installation has all of the correct permissions now.