### PR TITLE
Replace npm with yarn in execution ID

### DIFF
--- a/frontend-maven-plugin/src/it/yarn-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/yarn-integration/pom.xml
@@ -22,7 +22,7 @@
                 <executions>
 
                     <execution>
-                        <id>install node and npm</id>
+                        <id>install node and yarn</id>
                         <goals>
                             <goal>install-node-and-yarn</goal>
                         </goals>


### PR DESCRIPTION
I noticed the ID of execution was wrong so I fixed it.