### PR TITLE
Fixes #329 changes behavior of srcdir when it is null

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
@@ -89,7 +89,7 @@ class MojoUtils {
     }
 
     if (srcdir == null) {
-      return true;
+      return triggerfiles == null;
     }
 
     // Check for changes in the srcdir


### PR DESCRIPTION
**Summary**
In tthe m2e integration build phase if triggerfile is define and srcdir it isn't any file changed trigger
the build. This behavior should be that just triggerfile must trigger the build.

**Tests and Documentation**

I tested it with https://github.com/Cavva79/frontend-maven-plugin-test but I didn't provide unit test or integration tests for m2e integration. 

For docs there is no change