### PR TITLE
add support for armv7l (ignores armv6l)

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
@@ -1,6 +1,6 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
-enum Architecture { x86, x64, ppc64le, s390x, arm64;
+enum Architecture { x86, x64, ppc64le, s390x, arm64, armv7l;
     public static Architecture guess(){
         String arch = System.getProperty("os.arch");
         if (arch.equals("ppc64le")) {
@@ -8,7 +8,9 @@ enum Architecture { x86, x64, ppc64le, s390x, arm64;
         } else if (arch.equals("aarch64")) {
             return arm64;
         } else if (arch.equals("s390x")) {
-                return s390x;		
+                return s390x;
+        } else if (arch.equals("arm")) {
+            return armv7l;
         } else {
             return arch.contains("64") ? x64 : x86;
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Add support for armv7l (ignores armv6l) for "arm" architecture (as detected by Java system property "os.arch").

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Related to issue #704
This PR adds support for installing node on armv7l on a Raspberry Pi.

On the LTS node download site: https://nodejs.org/dist/v8.10.0/
there are only two choices for "arm" versions of node ("aarch64" is a different case): armv6l and armv7l. This patch simply uses the newer v7 flavor. 

**Tests and Documentation**

I ran the following test code on a raspberry pi to confirm the behavior produced valid node download URLs:

```
package com.github.eirslett.maven.plugins.frontend.lib;

public class PlatformTest
{
  public static void main(final String[] args) {
    final com.github.eirslett.maven.plugins.frontend.lib.Platform platform = Platform.guess();

    System.out.println("os.arch:" + System.getProperty("os.arch"));
    final Architecture architecture = Architecture.guess();
    System.out.println("Architecture.guess(): " + architecture);

    final String actual = platform.getNodeDownloadFilename("v8.10.0", false);
    System.out.println("Platform.getNodeDownloadFilename(): " + actual);
  }
}
```

The test output was:

```
os.arch:arm
Architecture.guess(): armv7l
Platform.getNodeDownloadFilename(): v8.10.0/node-v8.10.0-linux-armv7l.tar.gz
```

<!-- Demonstrate the code is solid. Add a simple description to CHANGELOG.md and add some infos to README.md or Wiki, if necessary. -->

That output should produce a valid download URL from this page:

https://nodejs.org/dist/v8.10.0/
