### PR TITLE
add support for armv6l or armv7l

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
@@ -16,7 +16,7 @@ enum Architecture { x86, x64, ppc64le, s390x, arm64, armv6l, armv7l;
         } else if (arch.equals("arm")) {
             final Process p;
             try {
-                p = Runtime.getRuntime().exec("uname -");
+                p = Runtime.getRuntime().exec("uname -a");
                 p.waitFor();
                 final BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
                 final String line = reader.readLine();

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
@@ -1,6 +1,10 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
-enum Architecture { x86, x64, ppc64le, s390x, arm64;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+enum Architecture { x86, x64, ppc64le, s390x, arm64, armv6l, armv7l;
     public static Architecture guess(){
         String arch = System.getProperty("os.arch");
         if (arch.equals("ppc64le")) {
@@ -9,6 +13,25 @@ enum Architecture { x86, x64, ppc64le, s390x, arm64;
             return arm64;
         } else if (arch.equals("s390x")) {
                 return s390x;		
+        } else if (arch.equals("arm")) {
+            final Process p;
+            try {
+                p = Runtime.getRuntime().exec("uname -");
+                p.waitFor();
+                final BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
+                final String line = reader.readLine();
+                if (line.contains(armv6l.name())) {
+                    return armv6l;
+                } else {
+                    return armv7l;
+                }
+            }
+            catch (IOException e) {
+                return armv7l;
+            }
+            catch (InterruptedException e) {
+                return armv7l;
+            }
         } else {
             return arch.contains("64") ? x64 : x86;
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Add support for armv6l or armv7l for "arm" architecture (as detected by Java system property "os.arch").

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Related to issue #704
This PR adds support for installing node on armv6l or armv7l on a Raspberry Pi.

On the LTS node download site: https://nodejs.org/dist/v8.10.0/
there are only two choices for "arm" versions of node ("aarch64" is a different case): armv6l and armv7l. 

This patch executes a "name -a" command and looks for "armv6l" in the result.  If no such string is found (or any other error occurs), the return value is "armv7l".

**Tests and Documentation**

I ran the following test code on a raspberry pi to confirm the behavior produced valid node download URLs:

```
package com.github.eirslett.maven.plugins.frontend.lib;

public class PlatformTest
{
  public static void main(final String[] args) {
    final com.github.eirslett.maven.plugins.frontend.lib.Platform platform = Platform.guess();

    System.out.println("os.arch:" + System.getProperty("os.arch"));
    final Architecture architecture = Architecture.guess();
    System.out.println("Architecture.guess(): " + architecture);

    final String actual = platform.getNodeDownloadFilename("v8.10.0", false);
    System.out.println("Platform.getNodeDownloadFilename(): " + actual);
  }
}
```

The test output was:

```
os.arch:arm
Architecture.guess(): armv7l
Platform.getNodeDownloadFilename(): v8.10.0/node-v8.10.0-linux-armv7l.tar.gz
```

<!-- Demonstrate the code is solid. Add a simple description to CHANGELOG.md and add some infos to README.md or Wiki, if necessary. -->

That output should produce a valid download URL from this page:

https://nodejs.org/dist/v8.10.0/
