### PR TITLE
Enhance logging

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProcessExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProcessExecutor.java
@@ -155,7 +155,14 @@ final class ProcessExecutor {
             if (logLevel == 0) {
                 logger.info(line);
             } else {
-                if (line.startsWith("npm WARN ")) {
+                // log empty/blank lines as info
+                if (line == null || line.isEmpty()) {
+                    logger.info(line);
+                // log npm warnings as warning
+                } else if (line.startsWith("npm WARN ")) {
+                    logger.warn(line);
+                // log yarn warnings as warning
+                } else if (line.startsWith("warning ")) {
                     logger.warn(line);
                 } else {
                     logger.error(line);


### PR DESCRIPTION
*Summary*

Enhance/Optimize logging:
- log yarn warnings as warning not error (like we did for npm)
- log empty lines as info instead of error

See PR #655 too.  Replacement for PR #713 