### PR TITLE
Output  [INFO] for npm info messages

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProcessExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProcessExecutor.java
@@ -155,7 +155,9 @@ final class ProcessExecutor {
             if (logLevel == 0) {
                 logger.info(line);
             } else {
-                if (line.startsWith("npm WARN ")) {
+                if (line.startsWith("npm info ")) {
+                    logger.info(line);
+                } else if (line.startsWith("npm WARN ")) {
                     logger.warn(line);
                 } else {
                     logger.error(line);


### PR DESCRIPTION
**Summary**

When running npm with loglevel=info, any info message output is prefixed with [ERROR]:

> NPM_CONFIG_LOGLEVEL=info mvn clean install
```
[INFO] --- frontend-maven-plugin:1.6:npm (install-dependencies) @ hello ---
[INFO] Running 'npm ci' in /m/git/misc/hello
[ERROR] npm info it worked if it ends with ok
[ERROR] npm info using npm@6.1.0
[ERROR] npm info using node@v8.11.2
[ERROR] npm info prepare initializing installer
```

This change will change the prefix to [INFO]:

```
[INFO] Running 'npm ci' in /m/git/misc/hello
[INFO] npm info it worked if it ends with ok
[INFO] npm info using npm@6.1.0
[INFO] npm info using node@v8.11.2
[INFO] npm info prepare initializing installer
```
