### PR TITLE
fix(arguments): respect quotes splitting arguments by whitespaces (#336)

### DIFF
--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -58,5 +58,12 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.5</version>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParser.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParser.java
@@ -7,11 +7,6 @@ import java.util.List;
 
 class ArgumentsParser {
 
-    enum State {
-        NEUTRAL,
-        QUOTED
-    }
-
     private final List<String> additionalArguments;
 
     ArgumentsParser() {
@@ -45,20 +40,23 @@ class ArgumentsParser {
 
         final List<String> arguments = new LinkedList<>();
         final StringBuilder argumentBuilder = new StringBuilder();
-        State state = State.NEUTRAL;
+        Character quote = null;
 
         for (int i = 0, l = args.length(); i < l; i++) {
             char c = args.charAt(i);
 
-            if (Character.isWhitespace(c) && state != State.QUOTED) {
+            if (Character.isWhitespace(c) && quote == null) {
                 addArgument(argumentBuilder, arguments);
                 continue;
             } else if (c == '"' || c == '\'') {
-                if (state == State.NEUTRAL) {
-                    state = State.QUOTED;
-                } else {
-                    state = State.NEUTRAL;
-                }
+                // explicit boxing allows us to use object caching of the Character class
+                Character currentQuote = Character.valueOf(c);
+                if (quote == null) {
+                    quote = currentQuote;
+                } else if (quote.equals(currentQuote)){
+                    quote = null;
+                } // else
+                // we ignore the case when a quoted argument contains the other kind of quote
             }
 
             argumentBuilder.append(c);

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParser.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParser.java
@@ -1,0 +1,89 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+class ArgumentsParser {
+
+    enum State {
+        NEUTRAL,
+        QUOTED
+    }
+
+    private final List<String> additionalArguments;
+
+    ArgumentsParser() {
+        this(Collections.<String>emptyList());
+    }
+
+    ArgumentsParser(List<String> additionalArguments) {
+        this.additionalArguments = additionalArguments;
+    }
+
+    /**
+     * Parses a given string of arguments, splitting it by characters that are whitespaces according to {@link Character#isWhitespace(char)}.
+     * <p>
+     * This method respects quoted arguments. Meaning that whitespaces appearing phrases that are enclosed by an opening
+     * single or double quote and a closing single or double quote or the end of the string will not be considered.
+     * <p>
+     * All characters excluding whitespaces considered for splitting stay in place.
+     * <p>
+     * Examples:
+     * "foo bar" will be split to ["foo", "bar"]
+     * "foo \"bar foobar\"" will be split to ["foo", "\"bar foobar\""]
+     * "foo 'bar" will be split to ["foo", "'bar"]
+     *
+     * @param args a string of arguments
+     * @return an mutable copy of the list of all arguments
+     */
+    List<String> parse(String args) {
+        if (args == null || "null".equals(args) || args.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        final List<String> arguments = new LinkedList<>();
+        final StringBuilder argumentBuilder = new StringBuilder();
+        State state = State.NEUTRAL;
+
+        for (int i = 0, l = args.length(); i < l; i++) {
+            char c = args.charAt(i);
+
+            if (Character.isWhitespace(c) && state != State.QUOTED) {
+                addArgument(argumentBuilder, arguments);
+                continue;
+            } else if (c == '"' || c == '\'') {
+                if (state == State.NEUTRAL) {
+                    state = State.QUOTED;
+                } else {
+                    state = State.NEUTRAL;
+                }
+            }
+
+            argumentBuilder.append(c);
+        }
+
+        addArgument(argumentBuilder, arguments);
+
+        for (String argument : this.additionalArguments) {
+            addArgument(argument, arguments);
+        }
+
+        return new ArrayList<>(arguments);
+    }
+
+    private static void addArgument(StringBuilder argumentBuilder, List<String> arguments) {
+        if (argumentBuilder.length() > 0) {
+            String argument = argumentBuilder.toString();
+            addArgument(argument, arguments);
+            argumentBuilder.setLength(0);
+        }
+    }
+
+    private static void addArgument(String argument, List<String> arguments) {
+        if (!arguments.contains(argument)) {
+            arguments.add(argument);
+        }
+    }
+}

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeTaskExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeTaskExecutor.java
@@ -21,7 +21,7 @@ abstract class NodeTaskExecutor {
     private final Logger logger;
     private final String taskName;
     private final String taskLocation;
-    private final List<String> additionalArguments;
+    private final ArgumentsParser argumentsParser;
     private final NodeExecutorConfig config;
 
     public NodeTaskExecutor(NodeExecutorConfig config, String taskLocation) {
@@ -41,7 +41,7 @@ abstract class NodeTaskExecutor {
         this.config = config;
         this.taskName = taskName;
         this.taskLocation = taskLocation;
-        this.additionalArguments = additionalArguments;
+        this.argumentsParser = new ArgumentsParser(additionalArguments);
     }
 
     private static String getTaskNameFromLocation(String taskLocation) {
@@ -79,17 +79,7 @@ abstract class NodeTaskExecutor {
 
 
     private List<String> getArguments(String args) {
-        List<String> arguments = new ArrayList<String>();
-        if (args != null && !args.equals("null") && !args.isEmpty()) {
-            arguments.addAll(Arrays.asList(args.split("\\s+")));
-        }
-
-        for (String argument : additionalArguments) {
-            if (!arguments.contains(argument)) {
-                arguments.add(argument);
-            }
-        }
-        return arguments;
+        return argumentsParser.parse(args);
     }
 
     private static String taskToString(String taskName, List<String> arguments) {

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnTaskExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnTaskExecutor.java
@@ -20,7 +20,7 @@ abstract class YarnTaskExecutor {
 
     private final String taskName;
 
-    private final List<String> additionalArguments;
+    private final ArgumentsParser argumentsParser;
 
     private final YarnExecutorConfig config;
 
@@ -42,7 +42,7 @@ abstract class YarnTaskExecutor {
         logger = LoggerFactory.getLogger(getClass());
         this.config = config;
         this.taskName = taskName;
-        this.additionalArguments = additionalArguments;
+        this.argumentsParser = new ArgumentsParser(additionalArguments);
     }
 
     private static String getTaskNameFromLocation(String taskLocation) {
@@ -66,17 +66,7 @@ abstract class YarnTaskExecutor {
     }
 
     private List<String> getArguments(String args) {
-        List<String> arguments = new ArrayList<>();
-        if (args != null && !args.equals("null") && !args.isEmpty()) {
-            arguments.addAll(Arrays.asList(args.split("\\s+")));
-        }
-
-        for (String argument : additionalArguments) {
-            if (!arguments.contains(argument)) {
-                arguments.add(argument);
-            }
-        }
-        return arguments;
+        return argumentsParser.parse(args);
     }
 
     private static String taskToString(String taskName, List<String> arguments) {

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParserTest.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParserTest.java
@@ -1,0 +1,55 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class ArgumentsParserTest {
+
+    @Test
+    public void testNoArguments() {
+        ArgumentsParser parser = new ArgumentsParser();
+
+        assertEquals(0, parser.parse(null).size());
+        assertEquals(0, parser.parse("null").size());
+        assertEquals(0, parser.parse(String.valueOf("")).size());
+    }
+
+    @Test
+    public void testMultipleArgumentsNoQuotes() {
+        ArgumentsParser parser = new ArgumentsParser();
+
+        assertArrayEquals(new Object[] { "foo" }, parser.parse("foo").toArray());
+        assertArrayEquals(new Object[] { "foo", "bar" }, parser.parse("foo bar").toArray());
+        assertArrayEquals(new Object[] { "foo", "bar", "foobar" }, parser.parse("foo bar foobar").toArray());
+    }
+
+    @Test
+    public void testMultipleArgumentsWithQuotes() {
+        ArgumentsParser parser = new ArgumentsParser();
+
+        assertArrayEquals(new Object[] { "foo", "\"bar foobar\"" }, parser.parse("foo \"bar foobar\"").toArray());
+        assertArrayEquals(new Object[] { "\"foo bar\"", "foobar" }, parser.parse("\"foo bar\" foobar").toArray());
+        assertArrayEquals(new Object[] { "foo", "'bar foobar'" }, parser.parse("foo 'bar foobar'").toArray());
+        assertArrayEquals(new Object[] { "'foo bar'", "foobar" }, parser.parse("'foo bar' foobar").toArray());
+        // unclosed quotes
+        assertArrayEquals(new Object[] { "foo", "\"bar foobar" }, parser.parse("foo \"bar foobar").toArray());
+    }
+
+    @Test
+    public void testAdditionalArgumentsNoIntersection() {
+        ArgumentsParser parser = new ArgumentsParser(Arrays.asList("foo", "bar"));
+
+        assertArrayEquals(new Object[] { "foobar", "foo", "bar" }, parser.parse("foobar").toArray());
+    }
+
+    @Test
+    public void testAdditionalArgumentsWithIntersection() {
+        ArgumentsParser parser = new ArgumentsParser(Arrays.asList("foo", "foobar"));
+
+        assertArrayEquals(new Object[] { "bar", "foobar", "foo" }, parser.parse("bar foobar").toArray());
+    }
+}

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParserTest.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParserTest.java
@@ -43,7 +43,7 @@ public class ArgumentsParserTest {
     public void testArgumentsWithMixedQuotes() {
         ArgumentsParser parser = new ArgumentsParser();
 
-        assertArrayEquals(new Object[] { "foo", "\"bar 'foobar'\"" }, parser.parse("foo \"bar 'foobar'\"").toArray());
+        assertArrayEquals(new Object[] { "foo", "\"bar 'foo bar'\"" }, parser.parse("foo \"bar 'foo bar'\"").toArray());
         assertArrayEquals(new Object[] { "foo", "\"bar 'foo\"", "'bar " }, parser.parse("foo \"bar 'foo\" 'bar ").toArray());
     }
 

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParserTest.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParserTest.java
@@ -40,6 +40,14 @@ public class ArgumentsParserTest {
     }
 
     @Test
+    public void testArgumentsWithMixedQuotes() {
+        ArgumentsParser parser = new ArgumentsParser();
+
+        assertArrayEquals(new Object[] { "foo", "\"bar 'foobar'\"" }, parser.parse("foo \"bar 'foobar'\"").toArray());
+        assertArrayEquals(new Object[] { "foo", "\"bar 'foo\"", "'bar " }, parser.parse("foo \"bar 'foo\" 'bar ").toArray());
+    }
+
+    @Test
     public void testAdditionalArgumentsNoIntersection() {
         ArgumentsParser parser = new ArgumentsParser(Arrays.asList("foo", "bar"));
 


### PR DESCRIPTION
This PR improves the handling of quotes in arguments passed in through execution configurations. It modifies the behaviour of splitting the given arguments line by whitespace, by ignoring whitespaces that are enclosed in double quotes, single quotes or either of the both and the end of the line. 

A unit test for the new ArgumentsParser is provided covering 100% of its functionality. Documentation is available as Javadoc of the ArgumentsParser#parse(String) method.

Fixes #336 