### PR TITLE
Add npm-cache goal with self-install mojo.

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractNpmMojo.java
@@ -1,0 +1,96 @@
+package com.github.eirslett.maven.plugins.frontend.mojo;
+
+import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
+import com.github.eirslett.maven.plugins.frontend.lib.NpmRunner;
+import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
+import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
+import java.io.File;
+import java.util.Collections;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+/**
+ * Abstract mojo for npm build steps.
+ *
+ * @author dtuerk
+ */
+abstract class AbstractNpmMojo extends AbstractFrontendMojo {
+
+    private static final String NPM_REGISTRY_URL = "npmRegistryURL";
+
+    /**
+     * npm arguments. Default is "install".
+     */
+    @Parameter(defaultValue = "install", property = "frontend.npm.arguments", required = false)
+    private String arguments;
+
+    @Parameter(property = "frontend.npm.npmInheritsProxyConfigFromMaven", required = false, defaultValue = "true")
+    private boolean npmInheritsProxyConfigFromMaven;
+
+    /**
+     * Registry override, passed as the registry option during npm install if set.
+     */
+    @Parameter(property = NPM_REGISTRY_URL, required = false, defaultValue = "")
+    private String npmRegistryURL;
+
+    @Parameter(property = "session", defaultValue = "${session}", readonly = true)
+    private MavenSession session;
+
+    @Component
+    private BuildContext buildContext;
+
+    @Component(role = SettingsDecrypter.class)
+    private SettingsDecrypter decrypter;
+
+    /**
+     * Skips execution of this mojo.
+     */
+    @Parameter(property = "skip.npm", defaultValue = "${skip.npm}")
+    private boolean skip;
+
+    @Override
+    protected boolean skipExecution() {
+        return this.skip;
+    }
+
+    @Override
+    public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
+        File packageJson = new File(workingDirectory, "package.json");
+        if (buildContext == null || buildContext.hasDelta(packageJson) || !buildContext.isIncremental()) {
+            ProxyConfig proxyConfig = getProxyConfig();
+            executeNpm(factory, proxyConfig);
+        } else {
+            getLog().info("Skipping npm install as package.json unchanged");
+        }
+    }
+
+    protected void executeNpm(FrontendPluginFactory factory, ProxyConfig proxyConfig) throws TaskRunnerException {
+        getNpmRunner(factory, proxyConfig).execute(arguments, environmentVariables);
+    }
+
+    /**
+     * Create and return the {@link NpmRunner}.
+     *
+     * @param factory {@link FrontendPluginFactory}
+     * @param proxyConfig {@link ProxyConfig}
+     * @return {@link NpmRunner}
+     */
+    abstract protected NpmRunner getNpmRunner(FrontendPluginFactory factory, ProxyConfig proxyConfig);
+
+    private ProxyConfig getProxyConfig() {
+        if (npmInheritsProxyConfigFromMaven) {
+            return MojoUtils.getProxyConfig(session, decrypter);
+        } else {
+            getLog().info("npm not inheriting proxy config from Maven");
+            return new ProxyConfig(Collections.<ProxyConfig.Proxy>emptyList());
+        }
+    }
+
+    String getRegistryUrl() {
+        // check to see if overridden via `-D`, otherwise fallback to pom value
+        return System.getProperty(NPM_REGISTRY_URL, npmRegistryURL);
+    }
+}

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmCacheMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmCacheMojo.java
@@ -1,0 +1,41 @@
+package com.github.eirslett.maven.plugins.frontend.mojo;
+
+import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
+import com.github.eirslett.maven.plugins.frontend.lib.NpmRunner;
+import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
+import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
+import java.util.HashMap;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+
+
+/**
+ * Mojo for the npm-cache build. It will use a special {@link NpmRunner} to call the "npm-cache" command instead of the
+ * "npm" one.
+ *
+ * @author dtuerk
+ */
+@Mojo(name = "npm-cache", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+public final class NpmCacheMojo extends AbstractNpmMojo {
+
+    private static final String INSTALL_NPM_CACHE = "install -g npm-cache";
+
+    protected NpmRunner getNpmRunner(FrontendPluginFactory factory, ProxyConfig proxyConfig) {
+        return factory.getNpmCacheRunner(proxyConfig, getRegistryUrl());
+    }
+
+    @Override
+    protected void executeNpm(FrontendPluginFactory factory, ProxyConfig proxyConfig) throws TaskRunnerException {
+        if (!factory.isNpmCacheInstalled()) {
+            getLog().info("No npm-cache found! Trying to install it local...");
+            try {
+                factory.getNpmRunner(proxyConfig, getRegistryUrl())
+                        .execute(INSTALL_NPM_CACHE, new HashMap<String, String>());
+                getLog().info("... npm-cache installed!");
+            } catch (TaskRunnerException e) {
+                getLog().error("Can't install npm-cache!", e);
+            }
+        }
+        super.executeNpm(factory, proxyConfig);
+    }
+}

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -1,81 +1,15 @@
 package com.github.eirslett.maven.plugins.frontend.mojo;
 
 import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
+import com.github.eirslett.maven.plugins.frontend.lib.NpmRunner;
 import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
-import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.settings.crypto.SettingsDecrypter;
-import org.sonatype.plexus.build.incremental.BuildContext;
-
-import java.io.File;
-import java.util.Collections;
 
 @Mojo(name="npm",  defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
-public final class NpmMojo extends AbstractFrontendMojo {
+public final class NpmMojo extends AbstractNpmMojo {
 
-    private static final String NPM_REGISTRY_URL = "npmRegistryURL";
-    
-    /**
-     * npm arguments. Default is "install".
-     */
-    @Parameter(defaultValue = "install", property = "frontend.npm.arguments", required = false)
-    private String arguments;
-
-    @Parameter(property = "frontend.npm.npmInheritsProxyConfigFromMaven", required = false, defaultValue = "true")
-    private boolean npmInheritsProxyConfigFromMaven;
-
-    /**
-     * Registry override, passed as the registry option during npm install if set.
-     */
-    @Parameter(property = NPM_REGISTRY_URL, required = false, defaultValue = "")
-    private String npmRegistryURL;
-    
-    @Parameter(property = "session", defaultValue = "${session}", readonly = true)
-    private MavenSession session;
-
-    @Component
-    private BuildContext buildContext;
-
-    @Component(role = SettingsDecrypter.class)
-    private SettingsDecrypter decrypter;
-
-    /**
-     * Skips execution of this mojo.
-     */
-    @Parameter(property = "skip.npm", defaultValue = "${skip.npm}")
-    private boolean skip;
-
-    @Override
-    protected boolean skipExecution() {
-        return this.skip;
-    }
-
-    @Override
-    public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
-        File packageJson = new File(workingDirectory, "package.json");
-        if (buildContext == null || buildContext.hasDelta(packageJson) || !buildContext.isIncremental()) {
-            ProxyConfig proxyConfig = getProxyConfig();
-            factory.getNpmRunner(proxyConfig, getRegistryUrl()).execute(arguments, environmentVariables);
-        } else {
-            getLog().info("Skipping npm install as package.json unchanged");
-        }
-    }
-
-    private ProxyConfig getProxyConfig() {
-        if (npmInheritsProxyConfigFromMaven) {
-            return MojoUtils.getProxyConfig(session, decrypter);
-        } else {
-            getLog().info("npm not inheriting proxy config from Maven");
-            return new ProxyConfig(Collections.<ProxyConfig.Proxy>emptyList());
-        }
-    }
-
-    private String getRegistryUrl() {
-        // check to see if overridden via `-D`, otherwise fallback to pom value
-        return System.getProperty(NPM_REGISTRY_URL, npmRegistryURL);
+    protected NpmRunner getNpmRunner(FrontendPluginFactory factory, ProxyConfig proxyConfig) {
+        return factory.getNpmRunner(proxyConfig, getRegistryUrl());
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -45,6 +45,10 @@ public final class FrontendPluginFactory {
         return new DefaultNpmRunner(getExecutorConfig(), proxy, npmRegistryURL);
     }
 
+    public NpmRunner getNpmCacheRunner(ProxyConfig proxy, String npmRegistryURL) {
+        return new DefaultNpmRunner(getNpmCacheExecutorConfig(), proxy, npmRegistryURL);
+    }
+
     public YarnRunner getYarnRunner(ProxyConfig proxy, String npmRegistryURL) {
         return new DefaultYarnRunner(new InstallYarnExecutorConfig(getInstallConfig()), proxy, npmRegistryURL);
     }
@@ -69,8 +73,15 @@ public final class FrontendPluginFactory {
         return new DefaultWebpackRunner(getExecutorConfig());
     }
 
+    public boolean isNpmCacheInstalled() {
+        return getNpmCacheExecutorConfig().getNpmPath().exists();
+    }
     private NodeExecutorConfig getExecutorConfig() {
         return new InstallNodeExecutorConfig(getInstallConfig());
+    }
+
+    private NodeExecutorConfig getNpmCacheExecutorConfig() {
+        return new InstallNodeNpmCacheExecutorConfig(getInstallConfig());
     }
 
     private InstallConfig getInstallConfig() {

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutorConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutorConfig.java
@@ -10,41 +10,64 @@ public interface NodeExecutorConfig {
   Platform getPlatform();
 }
 
-final class InstallNodeExecutorConfig implements NodeExecutorConfig {
+class InstallNodeExecutorConfig implements NodeExecutorConfig {
 
-  private static final String NODE_WINDOWS = NodeInstaller.INSTALL_PATH.replaceAll("/", "\\\\") + "\\node.exe";
-  private static final String NODE_DEFAULT = NodeInstaller.INSTALL_PATH + "/node";
-  private static final String NPM = NodeInstaller.INSTALL_PATH + "/node_modules/npm/bin/npm-cli.js";
+    private static final String NODE_WINDOWS = NodeInstaller.INSTALL_PATH.replaceAll("/", "\\\\") + "\\node.exe";
+    private static final String NODE_DEFAULT = NodeInstaller.INSTALL_PATH + "/node";
+    private static final String NPM = NodeInstaller.INSTALL_PATH + "/node_modules/npm/bin/npm-cli.js";
 
-  private final InstallConfig installConfig;
+    private final InstallConfig installConfig;
 
-  public InstallNodeExecutorConfig(InstallConfig installConfig) {
-    this.installConfig = installConfig;
-  }
+    public InstallNodeExecutorConfig(InstallConfig installConfig) {
+        this.installConfig = installConfig;
+    }
 
-  @Override
-  public File getNodePath() {
-    String nodeExecutable = getPlatform().isWindows() ? NODE_WINDOWS : NODE_DEFAULT;
-    return new File(installConfig.getInstallDirectory() + nodeExecutable);
-  }
+    @Override
+    public File getNodePath() {
+        String nodeExecutable = getPlatform().isWindows() ? NODE_WINDOWS : NODE_DEFAULT;
+        return new File(installConfig.getInstallDirectory() + nodeExecutable);
+    }
 
-  @Override
-  public File getNpmPath() {
-    return new File(installConfig.getInstallDirectory() + Utils.normalize(NPM));
-  }
+    @Override
+    public File getNpmPath() {
+        return new File(installConfig.getInstallDirectory() + Utils.normalize(NPM));
+    }
 
-  @Override
-  public File getInstallDirectory() {
-    return installConfig.getInstallDirectory();
-  }
-  
-  @Override
-  public File getWorkingDirectory() {
-    return installConfig.getWorkingDirectory();
-  }
+    @Override
+    public File getInstallDirectory() {
+        return installConfig.getInstallDirectory();
+    }
 
-  @Override
-  public Platform getPlatform() {
-    return installConfig.getPlatform();
-  }
+    @Override
+    public File getWorkingDirectory() {
+        return installConfig.getWorkingDirectory();
+    }
+
+    @Override
+    public Platform getPlatform() {
+        return installConfig.getPlatform();
+    }
+
+    InstallConfig getInstallConfig() {
+        return installConfig;
+    }
+}
+
+/**
+ * This {@link NodeExecutorConfig} provides the install path to the npm-cache command in the install folder.
+ *
+ * @author dtuerk
+ */
+final class InstallNodeNpmCacheExecutorConfig extends InstallNodeExecutorConfig {
+
+    private static final String NPM_CACHE = "/bin/npm-cache";
+
+    InstallNodeNpmCacheExecutorConfig(InstallConfig installConfig) {
+        super(installConfig);
+    }
+
+    @Override
+    public File getNpmPath() {
+        return new File(getInstallConfig().getInstallDirectory() + Utils.normalize(NPM_CACHE));
+    }
 }


### PR DESCRIPTION
**Summary**

Use the npm-cache plugin to cache the "node_modules" of the projects in the local file system.
That could be used for large projects which are build by jenkins with the "wipe workspace" option.

The plugin will be installed automatically for the local npm if not existing.

**Tests and Documentation**

The Output should not change, just the output of "npm" will change to "npm-cache" and for each build the node_modules are packed and stored to the local file system.

Tested for OSX and Linux. Maven 3.5

Example:

```
<execution>
    <id>npm install</id>
    <goals>
        <goal>npm-cache</goal>
    </goals>
    <phase>generate-resources</phase>
    <configuration>
        <arguments>install</arguments>
    </configuration>
</execution>
```