### PR TITLE
Support NPM Registry authentication with credentials from Maven settings

### DIFF
--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -53,6 +53,13 @@
       <artifactId>plexus-build-api</artifactId>
       <version>0.0.7</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-client-java</artifactId>
+      <version>5.3.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -110,6 +117,7 @@
           <postBuildHookScript>verify</postBuildHookScript>
           <filterProperties>
             <repository.proxy.url>${repository.proxy.url}</repository.proxy.url>
+            <npm.registry.url>http://localhost:${npm.registry.port}</npm.registry.url>
           </filterProperties>
         </configuration>
 
@@ -120,6 +128,54 @@
               <goal>install</goal>
               <goal>run</goal>
               <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>reserve-network-port</goal>
+            </goals>
+            <configuration>
+              <randomPort>true</randomPort>
+              <portNames>
+                <name>npm.registry.port</name>
+              </portNames>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.mock-server</groupId>
+        <artifactId>mockserver-maven-plugin</artifactId>
+        <version>5.3.0</version>
+        <configuration>
+          <serverPort>${npm.registry.port}</serverPort>
+          <logLevel>INFO</logLevel>
+          <initializationClass>com.github.eirslett.maven.plugins.frontend.NpmRegistryMock</initializationClass>
+        </configuration>
+        <executions>
+          <execution>
+            <id>process-test-classes</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>start</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>verify</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>stop</goal>
             </goals>
           </execution>
         </executions>

--- a/frontend-maven-plugin/src/it/npm-project-with-custom-registry-required-auth/package.json
+++ b/frontend-maven-plugin/src/it/npm-project-with-custom-registry-required-auth/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "example",
+  "version": "0.0.1",
+  "dependencies": {
+    "mkdirp": "~0.5.1"
+  }
+}

--- a/frontend-maven-plugin/src/it/npm-project-with-custom-registry-required-auth/pom.xml
+++ b/frontend-maven-plugin/src/it/npm-project-with-custom-registry-required-auth/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.eirslett</groupId>
+    <artifactId>example</artifactId>
+    <version>0</version>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
+                <version>@project.version@</version>
+
+                <configuration>
+                    <installDirectory>target</installDirectory>
+                </configuration>
+
+                <executions>
+
+                    <execution>
+                        <id>install node and npm</id>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
+                        <configuration>
+                            <nodeVersion>v8.11.1</nodeVersion>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>npm install</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <!-- Optional configuration which provides for running any npm command -->
+                        <configuration>
+                            <npmRegistryURL>@npm.registry.url@</npmRegistryURL>
+                            <npmRegistryServerId>private-npm-repository</npmRegistryServerId>
+                            <environmentVariables>
+                                <npm_config_cache>${project.build.directory}/.npm</npm_config_cache>
+                            </environmentVariables>
+                            <arguments>install</arguments>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/frontend-maven-plugin/src/it/npm-project-with-custom-registry-required-auth/verify.groovy
+++ b/frontend-maven-plugin/src/it/npm-project-with-custom-registry-required-auth/verify.groovy
@@ -1,0 +1,8 @@
+assert new File(basedir, 'target/node').exists() : "Node was not installed in the custom install directory";
+assert new File(basedir, 'node_modules').exists() : "Node modules were not installed in the base directory";
+
+import org.codehaus.plexus.util.FileUtils;
+
+String buildLog = FileUtils.fileRead(new File(basedir, 'build.log'));
+
+assert buildLog.contains('BUILD SUCCESS') : 'build was not successful'

--- a/frontend-maven-plugin/src/it/npm-project-with-custom-registry/package.json
+++ b/frontend-maven-plugin/src/it/npm-project-with-custom-registry/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "example",
+  "version": "0.0.1",
+  "dependencies": {
+    "mkdirp": "~0.5.1"
+  }
+}

--- a/frontend-maven-plugin/src/it/npm-project-with-custom-registry/pom.xml
+++ b/frontend-maven-plugin/src/it/npm-project-with-custom-registry/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.eirslett</groupId>
+    <artifactId>example</artifactId>
+    <version>0</version>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
+                <version>@project.version@</version>
+
+                <configuration>
+                    <installDirectory>target</installDirectory>
+                </configuration>
+
+                <executions>
+
+                    <execution>
+                        <id>install node and npm</id>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
+                        <configuration>
+                            <nodeVersion>v8.11.1</nodeVersion>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>npm install</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <!-- Optional configuration which provides for running any npm command -->
+                        <configuration>
+                            <npmRegistryURL>@npm.registry.url@</npmRegistryURL>
+                            <environmentVariables>
+                                <npm_config_cache>${project.build.directory}/.npm</npm_config_cache>
+                            </environmentVariables>
+                            <arguments>install</arguments>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/frontend-maven-plugin/src/it/npm-project-with-custom-registry/verify.groovy
+++ b/frontend-maven-plugin/src/it/npm-project-with-custom-registry/verify.groovy
@@ -1,0 +1,8 @@
+assert new File(basedir, 'target/node').exists() : "Node was not installed in the custom install directory";
+assert new File(basedir, 'node_modules').exists() : "Node modules were not installed in the base directory";
+
+import org.codehaus.plexus.util.FileUtils;
+
+String buildLog = FileUtils.fileRead(new File(basedir, 'build.log'));
+
+assert buildLog.contains('BUILD SUCCESS') : 'build was not successful'

--- a/frontend-maven-plugin/src/it/settings.xml
+++ b/frontend-maven-plugin/src/it/settings.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0"?>
 <settings>
+  <servers>
+    <server>
+      <id>private-npm-repository</id>
+        <username>username</username>
+        <password>password</password>
+    </server>
+  </servers>
   <mirrors>
     <mirror>
       <id>mrm-maven-plugin</id>

--- a/frontend-maven-plugin/src/it/yarn-project-with-custom-registry-required-auth/package.json
+++ b/frontend-maven-plugin/src/it/yarn-project-with-custom-registry-required-auth/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "example",
+  "version": "0.0.1",
+  "dependencies": {
+    "mkdirp": "~0.5.1"
+  }
+}

--- a/frontend-maven-plugin/src/it/yarn-project-with-custom-registry-required-auth/pom.xml
+++ b/frontend-maven-plugin/src/it/yarn-project-with-custom-registry-required-auth/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.eirslett</groupId>
+    <artifactId>example</artifactId>
+    <version>0</version>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
+                <version>@project.version@</version>
+
+                <configuration>
+                    <installDirectory>target</installDirectory>
+                </configuration>
+
+                <executions>
+
+                    <execution>
+                        <id>install node and yarn</id>
+                        <goals>
+                            <goal>install-node-and-yarn</goal>
+                        </goals>
+                        <configuration>
+                            <nodeVersion>v8.11.1</nodeVersion>
+                            <yarnVersion>v1.6.0</yarnVersion>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>yarn install</id>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <npmRegistryURL>@npm.registry.url@</npmRegistryURL>
+                            <npmRegistryServerId>private-npm-repository</npmRegistryServerId>
+                            <environmentVariables>
+                                <YARN_CACHE_FOLDER>${project.build.directory}/.yarn</YARN_CACHE_FOLDER>
+                            </environmentVariables>
+                            <arguments>install</arguments>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/frontend-maven-plugin/src/it/yarn-project-with-custom-registry-required-auth/verify.groovy
+++ b/frontend-maven-plugin/src/it/yarn-project-with-custom-registry-required-auth/verify.groovy
@@ -1,0 +1,8 @@
+assert new File(basedir, 'target/node').exists() : "Node was not installed in the custom install directory";
+assert new File(basedir, 'node_modules').exists() : "Node modules were not installed in the base directory";
+
+import org.codehaus.plexus.util.FileUtils;
+
+String buildLog = FileUtils.fileRead(new File(basedir, 'build.log'));
+
+assert buildLog.contains('BUILD SUCCESS') : 'build was not successful'

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/YarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/YarnMojo.java
@@ -3,17 +3,15 @@ package com.github.eirslett.maven.plugins.frontend.mojo;
 import java.io.File;
 import java.util.Collections;
 
+import com.github.eirslett.maven.plugins.frontend.lib.*;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.settings.Server;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.sonatype.plexus.build.incremental.BuildContext;
-
-import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
-import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
-import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
 
 @Mojo(name = "yarn", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public final class YarnMojo extends AbstractFrontendMojo {
@@ -35,6 +33,12 @@ public final class YarnMojo extends AbstractFrontendMojo {
      */
     @Parameter(property = NPM_REGISTRY_URL, required = false, defaultValue = "")
     private String npmRegistryURL;
+
+    /**
+     * Server Id for access to npm registry
+     */
+    @Parameter(property = "npmRegistryServerId", defaultValue = "")
+    private String npmRegistryServerId;
 
     @Parameter(property = "session", defaultValue = "${session}", readonly = true)
     private MavenSession session;
@@ -62,7 +66,8 @@ public final class YarnMojo extends AbstractFrontendMojo {
         if (this.buildContext == null || this.buildContext.hasDelta(packageJson)
             || !this.buildContext.isIncremental()) {
             ProxyConfig proxyConfig = getProxyConfig();
-            factory.getYarnRunner(proxyConfig, getRegistryUrl()).execute(this.arguments,
+            NpmRegistryConfig registryConfig = getRegistryConfig();
+            factory.getYarnRunner(proxyConfig, registryConfig).execute(this.arguments,
                 this.environmentVariables);
         } else {
             getLog().info("Skipping yarn install as package.json unchanged");
@@ -78,8 +83,22 @@ public final class YarnMojo extends AbstractFrontendMojo {
         }
     }
 
-    private String getRegistryUrl() {
+    private NpmRegistryConfig getRegistryConfig() {
         // check to see if overridden via `-D`, otherwise fallback to pom value
-        return System.getProperty(NPM_REGISTRY_URL, this.npmRegistryURL);
+        final String registryURL = System.getProperty(NPM_REGISTRY_URL, npmRegistryURL);
+        if (null == registryURL || registryURL.isEmpty()) {
+            return null;
+        }
+
+        String username = null;
+        String password = null;
+        if (null != npmRegistryServerId && !npmRegistryServerId.isEmpty()) {
+            Server server = MojoUtils.decryptServer(npmRegistryServerId, session, decrypter);
+            if (null != server) {
+                username = server.getUsername();
+                password = server.getPassword();
+            }
+        }
+        return new NpmRegistryConfig(registryURL, username, password);
     }
 }

--- a/frontend-maven-plugin/src/test/java/com/github/eirslett/maven/plugins/frontend/NpmRegistryMock.java
+++ b/frontend-maven-plugin/src/test/java/com/github/eirslett/maven/plugins/frontend/NpmRegistryMock.java
@@ -1,0 +1,83 @@
+package com.github.eirslett.maven.plugins.frontend;
+
+import org.mockserver.client.netty.NettyHttpClient;
+import org.mockserver.client.server.MockServerClient;
+import org.mockserver.initialize.ExpectationInitializer;
+import org.mockserver.mock.action.ExpectationCallback;
+import org.mockserver.model.Header;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockserver.model.Header.header;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.HttpStatusCode.FORBIDDEN_403;
+import static org.mockserver.model.HttpStatusCode.OK_200;
+
+public class NpmRegistryMock implements ExpectationInitializer {
+    private static final String NPM_REGISTRY_HOST = "registry.npmjs.org";
+    private static final int NPM_REGISTRY_PORT = 443;
+    private static final String NPM_USERNAME = "username";
+    private static final String NPM_PASSWORD = "password";
+    private static final String NPM_TOKEN = "NpmToken.22e3a730-9e62-11e8-98d0-529269fb1459";
+
+    private static final String HEADER_HOST = "Host";
+    private static final String HEADER_AUTHORIZATION = "Authorization";
+    private static final String HEADER_CONTENT_TYPE = "Content-Type";
+    private static final String MIME_TYPE_APPLICATION_JSON = "application/json";
+
+    private final NettyHttpClient httpClient = new NettyHttpClient();
+
+    @Override
+    public void initializeExpectations(MockServerClient mockServerClient) {
+        mockServerClient.when(
+                request()
+                        .withMethod("PUT")
+                        .withPath("/-/user/org.couchdb.user:" + NPM_USERNAME)
+                        .withHeader(HEADER_CONTENT_TYPE, MIME_TYPE_APPLICATION_JSON)
+                        .withBody("{\"name\":\"" + NPM_USERNAME + "\",\"password\":\"" + NPM_PASSWORD + "\"}")
+        )
+                .respond(
+                        response()
+                                .withStatusCode(OK_200.code())
+                                .withHeaders(
+                                        header(HEADER_CONTENT_TYPE, MIME_TYPE_APPLICATION_JSON)
+                                )
+                                .withBody("{\"rev\":\"_we_dont_use_revs_any_more\",\"id\":\"org.couchdb.user:undefined\"," +
+                                        "\"ok\":\"true\",\"token\":\"" + NPM_TOKEN + "\"}"));
+
+
+        mockServerClient.when(request()).callback(new ExpectationCallback() {
+            @Override
+            public HttpResponse handle(HttpRequest httpRequest) {
+                httpRequest.withSecure(true);
+                List<Header> headers = new ArrayList<>();
+                for (Header header : httpRequest.getHeaderList()) {
+                    if (!HEADER_HOST.equalsIgnoreCase(header.getName().getValue())) {
+                        headers.add(header);
+                    }
+                }
+                httpRequest = httpRequest.clone()
+                        .withHeaders(headers)
+                        .withHeader(HEADER_HOST, NPM_REGISTRY_HOST);
+
+                List<String> authorization = httpRequest.getHeader(HEADER_AUTHORIZATION);
+                if (null != authorization && !authorization.isEmpty()) {
+                    if (!authorization.get(0).replace("Bearer ", "").equals(NPM_TOKEN)) {
+                        return HttpResponse
+                                .response()
+                                .withStatusCode(FORBIDDEN_403.code());
+                    }
+                }
+                return httpClient.sendRequest(
+                        httpRequest,
+                        new InetSocketAddress(NPM_REGISTRY_HOST, NPM_REGISTRY_PORT)
+                );
+            }
+        });
+    }
+}

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ExecutorConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ExecutorConfig.java
@@ -1,0 +1,8 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import java.io.File;
+
+public interface ExecutorConfig {
+    File getWorkingDirectory();
+    Platform getPlatform();
+}

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -41,12 +41,12 @@ public final class FrontendPluginFactory {
         return new DefaultJspmRunner(getExecutorConfig());
     }
 
-    public NpmRunner getNpmRunner(ProxyConfig proxy, String npmRegistryURL) {
-        return new DefaultNpmRunner(getExecutorConfig(), proxy, npmRegistryURL);
+    public NpmRunner getNpmRunner(ProxyConfig proxy, NpmRegistryConfig registryConfig) {
+        return new DefaultNpmRunner(getExecutorConfig(), proxy, registryConfig);
     }
 
-    public YarnRunner getYarnRunner(ProxyConfig proxy, String npmRegistryURL) {
-        return new DefaultYarnRunner(new InstallYarnExecutorConfig(getInstallConfig()), proxy, npmRegistryURL);
+    public YarnRunner getYarnRunner(ProxyConfig proxy, NpmRegistryConfig registryConfig) {
+        return new DefaultYarnRunner(new InstallYarnExecutorConfig(getInstallConfig()), proxy, registryConfig);
     }
 
     public GruntRunner getGruntRunner(){

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutorConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutorConfig.java
@@ -2,7 +2,7 @@ package com.github.eirslett.maven.plugins.frontend.lib;
 
 import java.io.File;
 
-public interface NodeExecutorConfig {
+public interface NodeExecutorConfig extends ExecutorConfig {
   File getNodePath();
   File getNpmPath();
   File getInstallDirectory();

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRegistryAuthHandler.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRegistryAuthHandler.java
@@ -1,0 +1,204 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig.Proxy;
+import static com.github.eirslett.maven.plugins.frontend.lib.Utils.isRelative;
+import static org.apache.http.entity.ContentType.APPLICATION_JSON;
+
+public interface NpmRegistryAuthHandler {
+    void handle(List<String> arguments, Map<String, String> environment) throws Exception;
+}
+
+class DefaultNpmRegistryAuthHandler implements NpmRegistryAuthHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(NpmRegistryAuthHandler.class);
+    private static final String NPMRC_DEFAULT_FILE = ".npmrc";
+    private static final String NPMRC_TOKEN_VARIABLE = "NPM_TOKEN";
+    private static final Pattern NPMRC_PATH_PATTERN = Pattern.compile("--userconfig\\s*=?\\s*(?<path>(?:\".*?\")|(?:\\S*[^\\s]))");
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ExecutorConfig executorConfig;
+    private final ProxyConfig proxyConfig;
+    private final NpmRegistryConfig registryConfig;
+
+    public DefaultNpmRegistryAuthHandler(ExecutorConfig executorConfig, ProxyConfig proxyConfig, NpmRegistryConfig registryConfig) {
+        this.executorConfig = executorConfig;
+        this.proxyConfig = proxyConfig;
+        this.registryConfig = registryConfig;
+    }
+
+    @Override
+    public void handle(List<String> arguments, Map<String, String> environment) throws Exception {
+        if (registryConfig == null || registryConfig.getUsername() == null) {
+            LOGGER.info("NPM Registry does not require authentication");
+            return;
+        }
+
+        int index = -1;
+        Matcher matcher = null;
+        for (int i = 0; i < arguments.size(); i++) {
+            matcher = NPMRC_PATH_PATTERN.matcher(arguments.get(i));
+            if (matcher.matches()) {
+                index = i;
+                break;
+            }
+        }
+
+        final File npmrcFile;
+        if (index == -1) {
+            npmrcFile = new File(executorConfig.getWorkingDirectory(), NPMRC_DEFAULT_FILE);
+        } else {
+            final String userconfig = matcher.replaceAll("${path}").replace("\"", "");
+            npmrcFile = isRelative(userconfig) ? new File(executorConfig.getWorkingDirectory(), userconfig) :
+                    new File(userconfig);
+        }
+
+        final String token = getToken();
+
+        final List<String> list;
+        if (npmrcFile.exists()) {
+            list = IOUtils.readLines(new FileInputStream(npmrcFile));
+        } else {
+            list = new ArrayList<>();
+        }
+        final File dstNpmrcFile = File.createTempFile(".npmrc", "");
+        dstNpmrcFile.deleteOnExit();
+        final String line = "//" + registryConfig.getUrl()
+                .replaceAll("http.?://", "")
+                .replaceFirst("/$", "") +
+                "/:_authToken=${" + NPMRC_TOKEN_VARIABLE + "}";
+        list.add(line);
+        try (FileOutputStream ous = new FileOutputStream(dstNpmrcFile)) {
+            IOUtils.writeLines(list, System.lineSeparator(), ous);
+        }
+        final String argument = "--userconfig=" + dstNpmrcFile.getAbsolutePath();
+        if (index != -1) {
+            arguments.remove(index);
+            arguments.add(index, argument);
+        } else {
+            arguments.add(argument);
+        }
+        environment.put(NPMRC_TOKEN_VARIABLE, token);
+    }
+
+    private String getToken() throws Exception {
+        if (registryConfig == null) {
+            return null;
+        }
+        final HttpClientBuilder httpClientBuilder = HttpClients.custom()
+                .disableContentCompression()
+                .useSystemProperties();
+
+        final RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+
+        if (proxyConfig != null) {
+            Proxy proxy = proxyConfig.getProxyForUrl(registryConfig.getUrl());
+            if (proxy != null) {
+                if (proxy.useAuthentication()) {
+                    final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+                    credentialsProvider.setCredentials(
+                            new AuthScope(proxy.host, proxy.port),
+                            new UsernamePasswordCredentials(proxy.username, proxy.password)
+                    );
+
+                    httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                }
+                final HttpHost proxyHttpHost = new HttpHost(proxy.host, proxy.port);
+                requestConfigBuilder.setProxy(proxyHttpHost);
+            }
+        }
+
+        final HttpPut httpPut = new HttpPut(registryConfig.getUrl().replaceFirst("/$", "") + "/-/user/org.couchdb.user:" + registryConfig.getUsername());
+        httpPut.setConfig(requestConfigBuilder.build());
+        TokenRequest tokenRequest = new TokenRequest(registryConfig.getUsername(), registryConfig.getPassword());
+        httpPut.setEntity(new StringEntity(objectMapper.writeValueAsString(tokenRequest), APPLICATION_JSON));
+
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            CloseableHttpResponse response = client.execute(httpPut);
+            TokenResponse tokenResponse = objectMapper.readValue(response.getEntity().getContent(), TokenResponse.class);
+            if (tokenResponse.getError() != null) {
+                throw new IllegalStateException("Error get token: " + tokenResponse.getError());
+            }
+            return tokenResponse.getToken();
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class TokenRequest {
+        private String name;
+        private String password;
+
+        public TokenRequest() {
+        }
+
+        public TokenRequest(String name, String password) {
+            this.name = name;
+            this.password = password;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class TokenResponse {
+        private String token;
+        private String error;
+
+        public TokenResponse() {
+        }
+
+        public String getToken() {
+            return token;
+        }
+
+        public void setToken(String token) {
+            this.token = token;
+        }
+
+        public String getError() {
+            return error;
+        }
+
+        public void setError(String error) {
+            this.error = error;
+        }
+    }
+}

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRegistryConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRegistryConfig.java
@@ -1,0 +1,25 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+public class NpmRegistryConfig {
+    private final String url;
+    private final String username;
+    private final String password;
+
+    public NpmRegistryConfig(String url, String username, String password) {
+        this.url = url;
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
@@ -4,14 +4,23 @@ import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig.Proxy;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public interface NpmRunner extends NodeTaskRunner {}
 
 final class DefaultNpmRunner extends NodeTaskExecutor implements NpmRunner {
-    static final String TASK_NAME = "npm";
+    private static final String TASK_NAME = "npm";
+    private final NpmRegistryAuthHandler npmRegistryAuthHandler;
 
-    public DefaultNpmRunner(NodeExecutorConfig config, ProxyConfig proxyConfig, String npmRegistryURL) {
-        super(config, TASK_NAME, config.getNpmPath().getAbsolutePath(), buildArguments(proxyConfig, npmRegistryURL));
+    public DefaultNpmRunner(NodeExecutorConfig config, ProxyConfig proxyConfig, NpmRegistryConfig registryConfig) {
+        super(config, TASK_NAME, config.getNpmPath().getAbsolutePath(),
+                buildArguments(proxyConfig, registryConfig != null ? registryConfig.getUrl() : null));
+        this.npmRegistryAuthHandler = new DefaultNpmRegistryAuthHandler(config, proxyConfig, registryConfig);
+    }
+
+    @Override
+    protected void beforeExecute(List<String> arguments, Map<String, String> environment) throws Exception {
+        npmRegistryAuthHandler.handle(arguments, environment);
     }
 
     private static List<String> buildArguments(ProxyConfig proxyConfig, String npmRegistryURL) {

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnExecutorConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnExecutorConfig.java
@@ -2,7 +2,7 @@ package com.github.eirslett.maven.plugins.frontend.lib;
 
 import java.io.File;
 
-public interface YarnExecutorConfig {
+public interface YarnExecutorConfig extends ExecutorConfig {
 
     File getNodePath();
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnRunner.java
@@ -2,6 +2,7 @@ package com.github.eirslett.maven.plugins.frontend.lib;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig.Proxy;
 
@@ -11,10 +12,17 @@ public interface YarnRunner extends NodeTaskRunner {
 final class DefaultYarnRunner extends YarnTaskExecutor implements YarnRunner {
 
     private static final String TASK_NAME = "yarn";
+    private final NpmRegistryAuthHandler npmRegistryAuthHandler;
 
-    public DefaultYarnRunner(YarnExecutorConfig config, ProxyConfig proxyConfig, String npmRegistryURL) {
+    public DefaultYarnRunner(YarnExecutorConfig config, ProxyConfig proxyConfig, NpmRegistryConfig registryConfig) {
         super(config, TASK_NAME, config.getYarnPath().getAbsolutePath(),
-            buildArguments(proxyConfig, npmRegistryURL));
+            buildArguments(proxyConfig, registryConfig != null ? registryConfig.getUrl() : null));
+        this.npmRegistryAuthHandler = new DefaultNpmRegistryAuthHandler(config, proxyConfig, registryConfig);
+    }
+
+    @Override
+    protected void beforeExecute(List<String> arguments, Map<String, String> environment) throws Exception {
+        npmRegistryAuthHandler.handle(arguments, environment);
     }
 
     private static List<String> buildArguments(ProxyConfig proxyConfig, String npmRegistryURL) {

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnTaskExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnTaskExecutor.java
@@ -3,7 +3,6 @@ package com.github.eirslett.maven.plugins.frontend.lib;
 import static com.github.eirslett.maven.plugins.frontend.lib.Utils.implode;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -50,23 +49,23 @@ abstract class YarnTaskExecutor {
     }
 
     public final void execute(String args, Map<String, String> environment) throws TaskRunnerException {
-        final List<String> arguments = getArguments(args);
+        final List<String> arguments = argumentsParser.parse(args);
         logger.info("Running " + taskToString(taskName, arguments) + " in " + config.getWorkingDirectory());
 
         try {
+            beforeExecute(arguments, environment);
             final int result =
                 new YarnExecutor(config, arguments, environment).executeAndRedirectOutput(logger);
             if (result != 0) {
                 throw new TaskRunnerException(
                     taskToString(taskName, arguments) + " failed. (error code " + result + ")");
             }
-        } catch (ProcessExecutionException e) {
+        } catch (Exception e) {
             throw new TaskRunnerException(taskToString(taskName, arguments) + " failed.", e);
         }
     }
 
-    private List<String> getArguments(String args) {
-        return argumentsParser.parse(args);
+    protected void beforeExecute(List<String> arguments, Map<String, String> environment) throws Exception {
     }
 
     private static String taskToString(String taskName, List<String> arguments) {


### PR DESCRIPTION
Our company uses a private proxy repository (Nexus) to access the central NPM and Maven repository and our private packages (npm, maven). The task was set for developers to use the general scenario of access settings to repositories from Maven settings.

I added the configuration parameter **npmRegistryServerId** for npm and yarn goal. Thus, you can use credentials from Maven settings for authentication in NPM Registry.

An example of the settings can be found in integration test projects (frontend-maven-plugin/src/it)