### PR TITLE
Fix #670: Use Files.move instead of File.rename to move files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 
 ## Changelog
 
+### 1.7.6
+
+* Fix #670: Plugin will no longer fail to install node.exe if node.exe already exists 
+
 ### 1.5
 
 * Revert support for the maven.frontend.failOnError flag ([#572](https://github.com/eirslett/frontend-maven-plugin/pull/572)), due to

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
@@ -3,6 +3,8 @@ package com.github.eirslett.maven.plugins.frontend.lib;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 
 import org.apache.commons.io.FileUtils;
@@ -151,7 +153,12 @@ public class NodeInstaller {
 
                 File destination = new File(destinationDirectory, "node");
                 this.logger.info("Copying node binary from {} to {}", nodeBinary, destination);
-                if (!nodeBinary.renameTo(destination)) {
+                if (destination.exists() && !destination.delete()) {
+                    throw new InstallationException("Could not install Node: Was not allowed to delete " + destination);
+                }
+                try {
+                    Files.move(nodeBinary.toPath(), destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                } catch (IOException e) {
                     throw new InstallationException("Could not install Node: Was not allowed to rename "
                         + nodeBinary + " to " + destination);
                 }
@@ -219,7 +226,9 @@ public class NodeInstaller {
 
                 File destination = new File(destinationDirectory, "node.exe");
                 this.logger.info("Copying node binary from {} to {}", nodeBinary, destination);
-                if (!nodeBinary.renameTo(destination)) {
+                try {
+                    Files.move(nodeBinary.toPath(), destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                } catch (IOException e) {
                     throw new InstallationException("Could not install Node: Was not allowed to rename "
                         + nodeBinary + " to " + destination);
                 }


### PR DESCRIPTION
 because File.rename does not support overwriting existing files on windows

**Summary**

This fixes #670: Repeated invocations of the plugin fail on windows.

**Tests and Documentation**

Tested on local Windows machine. Logic is not changed, only updated for compatibility.