### PR TITLE
#794 Node, npm and yarn installer delete corrupted archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 ### 1.7.6
 
 * Fix #670: Plugin will no longer fail to install node.exe if node.exe already exists 
+* Fix #794: Plugin will self-repair if previous node/npm/yarn archive download was interrupted
 
 ### 1.5
 


### PR DESCRIPTION
**Summary**
Issue #794
The node, npm and yarn installer deletes corrupted archive and destination directory in case if the downloading was interrupted (causes EOFException when extracted).

**Detailed**
The possible real-life example:
* The build is started and at the phase of downloading npm, node or yarn it is interrupted on the slow connection, the build fails
* Re-start the build - it has lazy download logic and determines that the destination archive is already in place
* The archive is extracted and fails with root cause EOFException, the build fails
  * Re-start the build and either node (npm / yarn file) is here, but the package is incomplete - the build may fail
  * or the previous step (extract archive) is repeated again and again fails.
This requires manual investigation and deleting the cached archive and can take much time.

How to simulate it locally.
* Make a successful build of npm (yarn) project.
* Go to `$HOME/.m2/repository/com/github/eirslett/node/${node.version}` directory
* Rename the existing archive to `-full` suffix and make it's partial copy of first bytes:
```
dd if=node-8.9.4-darwin-x64.tar.gz-full of=node-8.9.9-darwin-x64.tag.gz bs=1000000 count=1
```
* Remove project cached node version
* Run the build
* Re-run the build

Please note, that no integration tests are provided for the reasons of non-clear approach for it (the build should be interrupted while the archive is being downloaded; or it can be pre-cached manually to the maven directory). I tested it locally step-by-step.

**Also please note, that there is another way to solve this:**
The downloading should be done to a temp file unless completed and then renamed to destination. Both approaches can be mixed in case if someone will face the described above scenario expecting that it will be solved with plugin update.
