### PR TITLE
fix parsing repeating arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 
 ## Changelog
 
+### 1.7.7
+
+* Allow repeating arguments
+
 ### 1.7.6
 
 * Fix #670: Plugin will no longer fail to install node.exe if node.exe already exists 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParser.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParser.java
@@ -65,7 +65,9 @@ class ArgumentsParser {
         addArgument(argumentBuilder, arguments);
 
         for (String argument : this.additionalArguments) {
-            addArgument(argument, arguments);
+            if (!arguments.contains(argument)) {
+                arguments.add(argument);
+            }
         }
 
         return new ArrayList<>(arguments);
@@ -74,14 +76,8 @@ class ArgumentsParser {
     private static void addArgument(StringBuilder argumentBuilder, List<String> arguments) {
         if (argumentBuilder.length() > 0) {
             String argument = argumentBuilder.toString();
-            addArgument(argument, arguments);
-            argumentBuilder.setLength(0);
-        }
-    }
-
-    private static void addArgument(String argument, List<String> arguments) {
-        if (!arguments.contains(argument)) {
             arguments.add(argument);
+            argumentBuilder.setLength(0);
         }
     }
 }

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParserTest.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParserTest.java
@@ -15,7 +15,7 @@ public class ArgumentsParserTest {
 
         assertEquals(0, parser.parse(null).size());
         assertEquals(0, parser.parse("null").size());
-        assertEquals(0, parser.parse(String.valueOf("")).size());
+        assertEquals(0, parser.parse("").size());
     }
 
     @Test
@@ -48,7 +48,7 @@ public class ArgumentsParserTest {
     }
 
     @Test
-    public void testAdditionalArgumentsNoIntersection() {
+    public void testAdditionalArguments() {
         ArgumentsParser parser = new ArgumentsParser(Arrays.asList("foo", "bar"));
 
         assertArrayEquals(new Object[] { "foobar", "foo", "bar" }, parser.parse("foobar").toArray());
@@ -59,5 +59,12 @@ public class ArgumentsParserTest {
         ArgumentsParser parser = new ArgumentsParser(Arrays.asList("foo", "foobar"));
 
         assertArrayEquals(new Object[] { "bar", "foobar", "foo" }, parser.parse("bar foobar").toArray());
+    }
+
+    @Test
+    public void testRepeatingArguments() {
+        ArgumentsParser parser = new ArgumentsParser();
+
+        assertArrayEquals(new Object[] { "foo", "foo", "foo" }, parser.parse("foo foo foo").toArray());
     }
 }


### PR DESCRIPTION
**Summary**

Sometimes it might be necessary to pass arguments with repeating value, for example building Angular application you can use:

```npm run build -- --base-href /some/href/ --deploy-url /some/href/```

which is valid build command, but this plugin tries to remove duplicates, so resulting command will be:

```npm run build -- --base-href /some-href/ --deploy-url```.

There are workarounds possible, but it still may be confusing for users if some args are removed.

This PR changes behavior, so that it's now possible to add duplicates into the build command. Additional parameters are still checked for duplicates.

**Tests and Documentation**

Added changelog info.
Added unittest.
