### PR TITLE
Added support to disable proxy when downloading node,npm and yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,22 @@ If you want to disable proxy for Yarn you can use `yarnInheritsProxyConfigFromMa
 
 ```
 
+If you want to disable proxy for installing node, npm and yarn you can use `installNodeAndNpmDirectly`(for npm)
+or `installNodeAndYarnDirectly`(for yarn). The plugin uses the maven proxy settings in your settings.xml file to
+download node,npm and yarn by default, it may cause the download to fail if the resource cannot be accessed through
+your proxy,you can configure the plugin like this to download node,npm and yarn directly:
+
+```xml
+<plugin>
+    ...
+    <configuration>
+        <installNodeAndNpmDirectly>false</installNodeAndNpmDirectly>
+        <installNodeAndYarnDirectly>false</installNodeAndYarnDirectly>
+    </configuration>
+</plugin>
+
+```
+
 
 #### Environment variables
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -1,13 +1,17 @@
 package com.github.eirslett.maven.plugins.frontend.mojo;
 
-import com.github.eirslett.maven.plugins.frontend.lib.*;
+import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
+import com.github.eirslett.maven.plugins.frontend.lib.InstallationException;
+import com.github.eirslett.maven.plugins.frontend.lib.NPMInstaller;
+import com.github.eirslett.maven.plugins.frontend.lib.NodeInstaller;
+import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.settings.Server;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.apache.maven.settings.Server;
 
 @Mojo(name="install-node-and-npm", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
@@ -59,6 +59,12 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
     @Parameter(property = "skip.installyarn", alias = "skip.installyarn", defaultValue = "${skip.installyarn}")
     private boolean skip;
 
+    /**
+     * Ignore maven proxy settings, download Node.js and Yarn directly
+     */
+    @Parameter(property = "installNodeAndYarnDirectly", required = false, defaultValue = "false")
+    private boolean installNodeAndYarnDirectly;
+
     @Component(role = SettingsDecrypter.class)
     private SettingsDecrypter decrypter;
 
@@ -69,7 +75,7 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
 
     @Override
     public void execute(FrontendPluginFactory factory) throws InstallationException {
-        ProxyConfig proxyConfig = MojoUtils.getProxyConfig(this.session, this.decrypter);
+        ProxyConfig proxyConfig = getProxyConfig();
         Server server = MojoUtils.decryptServer(this.serverId, this.session, this.decrypter);
         if (null != server) {
             factory.getNodeInstaller(proxyConfig).setNodeDownloadRoot(this.nodeDownloadRoot)
@@ -84,6 +90,14 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
             factory.getYarnInstaller(proxyConfig).setYarnDownloadRoot(this.yarnDownloadRoot)
                 .setYarnVersion(this.yarnVersion).install();
         }
+    }
+
+    private ProxyConfig getProxyConfig() {
+        if (installNodeAndYarnDirectly) {
+            getLog().info("Ignore maven proxy settings, will download Node.js and NPM directly");
+            return MojoUtils.getProxyConfig(null, decrypter);
+        }
+        return MojoUtils.getProxyConfig(session, decrypter);
     }
 
 }


### PR DESCRIPTION
Added `installNodeAndYarnDirectly` and `installNodeAndNpmDirectly` property

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Add this two property to disable maven proxy when downloading node, npm and yarn. 

**Tests and Documentation**

<!-- Demonstrate the code is solid. Add a simple description to CHANGELOG.md and add some infos to README.md or Wiki, if necessary. -->
The plugin uses the maven proxy settings to download node,npm and yarn by default, it may cause the download to fail if the resource cannot be accessed through the proxy, and there is no way to edit the maven settings file to change the proxy setting, you can configure the plugin like this to download node,npm and yarn directly instead of using maven proxy:

```xml
<plugin>
    ...
    <configuration>
        <installNodeAndNpmDirectly>false</installNodeAndNpmDirectly>
        <installNodeAndYarnDirectly>false</installNodeAndYarnDirectly>
    </configuration>
</plugin>

```