### PR TITLE
Fix regression when extracting tar archive

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArchiveExtractor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArchiveExtractor.java
@@ -81,53 +81,53 @@ final class DefaultArchiveExtractor implements ArchiveExtractor {
                         final File destPath = new File(destinationDirectory + File.separator + entry.getName());
                         prepDestination(destPath, entry.isDirectory());
                         if(!entry.isDirectory()){
-		                        InputStream in = null;
-		                        OutputStream out = null;
-		                        try {
-		                            in = zipFile.getInputStream(entry);
-		                            out = new FileOutputStream(destPath);
-		                            IOUtils.copy(in, out);
-		                        } finally {
-		                            IOUtils.closeQuietly(in);
-		                            IOUtils.closeQuietly(out);
-		                        }
+                            InputStream in = null;
+                            OutputStream out = null;
+                            try {
+                                in = zipFile.getInputStream(entry);
+                                out = new FileOutputStream(destPath);
+                                IOUtils.copy(in, out);
+                            } finally {
+                                IOUtils.closeQuietly(in);
+                                IOUtils.closeQuietly(out);
+                            }
                         }
                     }
                 } finally {
                     zipFile.close();
                 }
             } else {
-		            // TarArchiveInputStream can be constructed with a normal FileInputStream if
-		            // we ever need to extract regular '.tar' files.
+                // TarArchiveInputStream can be constructed with a normal FileInputStream if
+                // we ever need to extract regular '.tar' files.
                 TarArchiveInputStream tarIn = null;
                 try {
-				            tarIn = new TarArchiveInputStream(new GzipCompressorInputStream(fis));
+                    tarIn = new TarArchiveInputStream(new GzipCompressorInputStream(fis));
 
-				            TarArchiveEntry tarEntry = tarIn.getNextTarEntry();
-				            while (tarEntry != null) {
-				                // Create a file for this tarEntry
-				                final File destPath = new File(destinationDirectory + File.separator + tarEntry.getName());
-		                    prepDestination(destPath, tarEntry.isDirectory());
-                                if (!destPath.getCanonicalPath().startsWith(destinationDirectory)) {
-                                     throw new IOException(
-                                             "Expanding " + tarEntry.getName() + " would create file outside of " + destinationDirectory
-                                     );
-                                }
-				                if (!tarEntry.isDirectory()) {
-				                    destPath.createNewFile();
-				                    boolean isExecutable = (tarEntry.getMode() & 0100) > 0;
-				                    destPath.setExecutable(isExecutable);
+                    TarArchiveEntry tarEntry = tarIn.getNextTarEntry();
+                    while (tarEntry != null) {
+                        // Create a file for this tarEntry
+                        final File destPath = new File(destinationDirectory + File.separator + tarEntry.getName());
+                        prepDestination(destPath, tarEntry.isDirectory());
+                        if (!destPath.getCanonicalPath().startsWith(destinationDirectory)) {
+                             throw new IOException(
+                                 "Expanding " + tarEntry.getName() + " would create file outside of " + destinationDirectory
+                             );
+                        }
+                        if (!tarEntry.isDirectory()) {
+                            destPath.createNewFile();
+                            boolean isExecutable = (tarEntry.getMode() & 0100) > 0;
+                            destPath.setExecutable(isExecutable);
 
-		                        OutputStream out = null;
-		                        try {
-		                            out = new FileOutputStream(destPath);
-		                            IOUtils.copy(tarIn, out);
-		                        } finally {
-		                            IOUtils.closeQuietly(out);
-		                        }
-				                }
-				                tarEntry = tarIn.getNextTarEntry();
-				            }
+                            OutputStream out = null;
+                            try {
+                                out = new FileOutputStream(destPath);
+                                IOUtils.copy(tarIn, out);
+                            } finally {
+                                IOUtils.closeQuietly(out);
+                            }
+                        }
+                        tarEntry = tarIn.getNextTarEntry();
+                    }
                 } finally {
                     IOUtils.closeQuietly(tarIn);
                 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArchiveExtractor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArchiveExtractor.java
@@ -104,13 +104,14 @@ final class DefaultArchiveExtractor implements ArchiveExtractor {
                     tarIn = new TarArchiveInputStream(new GzipCompressorInputStream(fis));
 
                     TarArchiveEntry tarEntry = tarIn.getNextTarEntry();
+                    String canonicalDestinationDirectory = new File(destinationDirectory).getCanonicalPath();
                     while (tarEntry != null) {
                         // Create a file for this tarEntry
                         final File destPath = new File(destinationDirectory + File.separator + tarEntry.getName());
                         prepDestination(destPath, tarEntry.isDirectory());
-                        if (!destPath.getCanonicalPath().startsWith(destinationDirectory)) {
+                        if (!destPath.getCanonicalPath().startsWith(canonicalDestinationDirectory)) {
                              throw new IOException(
-                                 "Expanding " + tarEntry.getName() + " would create file outside of " + destinationDirectory
+                                 "Expanding " + tarEntry.getName() + " would create file outside of " + canonicalDestinationDirectory
                              );
                         }
                         if (!tarEntry.isDirectory()) {


### PR DESCRIPTION
**Summary**

Commit 93d77ffc023effbcb36813648b578a0541709d76 introduced a check that files extracted from a tar archive will not be written outside of the destination directory. Unfortunately it also introduced a regression prventing the extraction of any tar archive when the path to the destination directory contains a symbolic link.

For example on a jenkins agent where `/var/lib/jenkins` is a symbolic link to `/data/jenkins` and a job tries to extact nodejs to `/var/lib/jenkins/workspace/example-project/target/node/tmp`. The old code would then check if canonical path to a tar entry like `/data/jenkins/workspace/example-project/target/node/tmp/XXX` starts with `/var/lib/jenkins/workspace/example-project/target/node/tmp` which always fails.

The new check compares the **canonical** extraction paths of the tar entries with the **canonical** path of the destination directory. This also works when the destination directory path contains a symbolic link and still protects against extracting files outside the destination directory.
