### PR TITLE
Fix windows bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 
 ## Changelog
 
+### 1.7.7
+
+* Fix #749: Plugin will no longer fail during the node install step if it cannot delete the temporary directory.
+
 ### 1.7.6
 
 * Fix #670: Plugin will no longer fail to install node.exe if node.exe already exists 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
@@ -317,7 +317,13 @@ public class NodeInstaller {
     private void deleteTempDirectory(File tmpDirectory) throws IOException {
         if (tmpDirectory != null && tmpDirectory.exists()) {
             this.logger.debug("Deleting temporary directory {}", tmpDirectory);
-            FileUtils.deleteDirectory(tmpDirectory);
+            try {
+                FileUtils.deleteDirectory(tmpDirectory);
+            } catch (IOException e) {
+                this.logger.warn(
+                    "Temporary directory could not be deleted, please delete it manually. Tempdir location: {}", 
+                    tmpDirectory.getPath());
+            }
         }
     }
 


### PR DESCRIPTION
Stop an error from killing the build when it can't delete the temp directory.

**Summary**

Works around the issue from #749, which boils down to an error when deleting the temp directory. The crux of the problem is that Java must delete a folder's contents before deleting the directory itself (possibly an OS level requirement, but that is irrelevant). When deleting recursively, eventually a path [becomes too long for windows](https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#maximum-path-length-limitation).

Exception stack trace snippet:
```
...
Caused by: java.io.IOException: Unable to delete directory <redacted for privacy>\node\tmp\node-v10.16.0-win-x64\node_modules\npm\test\tap.
    at org.apache.commons.io.FileUtils.deleteDirectory (FileUtils.java:873)
    at org.apache.commons.io.FileUtils.forceDelete (FileUtils.java:1239)
    at org.apache.commons.io.FileUtils.cleanDirectory (FileUtils.java:903)
    at org.apache.commons.io.FileUtils.deleteDirectory (FileUtils.java:869)
    at org.apache.commons.io.FileUtils.forceDelete (FileUtils.java:1239)
    at org.apache.commons.io.FileUtils.cleanDirectory (FileUtils.java:903)
    at org.apache.commons.io.FileUtils.deleteDirectory (FileUtils.java:869)
    at org.apache.commons.io.FileUtils.forceDelete (FileUtils.java:1239)
    at org.apache.commons.io.FileUtils.cleanDirectory (FileUtils.java:903)
    at org.apache.commons.io.FileUtils.deleteDirectory (FileUtils.java:869)
    at org.apache.commons.io.FileUtils.forceDelete (FileUtils.java:1239)
    at org.apache.commons.io.FileUtils.cleanDirectory (FileUtils.java:903)
    at org.apache.commons.io.FileUtils.deleteDirectory (FileUtils.java:869)
    at org.apache.commons.io.FileUtils.forceDelete (FileUtils.java:1239)
    at org.apache.commons.io.FileUtils.cleanDirectory (FileUtils.java:903)
    at org.apache.commons.io.FileUtils.deleteDirectory (FileUtils.java:869)
    at com.github.eirslett.maven.plugins.frontend.lib.NodeInstaller.deleteTempDirectory (NodeInstaller.java:320)
...
```

**Tests and Documentation**

Tested locally, on a windows machine,  prints the following message when it installs node, but fails to delete the tempdir:

```
[WARNING] Temporary directory could not be deleted, please delete it manually. Tempdir location: <redacted for privacy>\node\tmp
```