### PR TITLE
Fix symbolic link bug of `installDirectory`

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArchiveExtractor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArchiveExtractor.java
@@ -106,11 +106,12 @@ final class DefaultArchiveExtractor implements ArchiveExtractor {
 				            TarArchiveEntry tarEntry = tarIn.getNextTarEntry();
 				            while (tarEntry != null) {
 				                // Create a file for this tarEntry
+						final File directoryPath = new File(destinationDirectory);
 				                final File destPath = new File(destinationDirectory + File.separator + tarEntry.getName());
 		                    prepDestination(destPath, tarEntry.isDirectory());
-                                if (!destPath.getCanonicalPath().startsWith(destinationDirectory)) {
+                                if (!destPath.getCanonicalPath().startsWith(directoryPath.getCanonicalPath())) {
                                      throw new IOException(
-                                             "Expanding " + tarEntry.getName() + " would create file outside of " + destinationDirectory
+                                             "Expanding " + tarEntry.getName() + " would create file " + destPath.getCanonicalPath() + ", which is outside of " + directoryPath.getCanonicalPath()
                                      );
                                 }
 				                if (!tarEntry.isDirectory()) {


### PR DESCRIPTION
if `installDirectory` is placed in a path which contains symbolic link, an exception will throw because `getCanonicalPath()` may resolve to another different path.
For example, set `installDirectory` to `${java.io.tmpdir}/nodejs` in mac os x throws exception, because `getCanonicalPath()` resolve `/var/folders/**/nodejs` to `/private/var/folders/**/nodejs`.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Tests and Documentation**

<!-- Demonstrate the code is solid. Add a simple description to CHANGELOG.md and add some infos to README.md or Wiki, if necessary. -->
