### PR TITLE
Handle custom yarn tar ball location; make yarn/dist/bin/yarn working again

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ present).
 Have a look at the example `POM` to see how it should be set up with Yarn: 
 https://github.com/eirslett/frontend-maven-plugin/blob/master/frontend-maven-plugin/src/it/yarn-integration/pom.xml
 
-
+For standard default node and yarn location
 ```xml
 <plugin>
     ...
@@ -164,6 +164,16 @@ https://github.com/eirslett/frontend-maven-plugin/blob/master/frontend-maven-plu
     </configuration>
 </plugin>
 ```
+
+To specify a custom yarn dist tar ball location:
+```xml
+        <yarnDownloadUrl>https://repository.xyz.com/content/repositories/public/yarn/</yarnDownloadUrl>
+        <yarnVersion>1.17.3</yarnVersion>
+        <yarnExtension>tgz</yarnExtension>
+```
+Then the program will look for a tar file at:
+```<yarnDownloadUrl>/yarn-<yarnVersion>.tgz```, which translates to
+```https://repository.xyz.com/content/repositories/public/yarn/yarn-1.17.3.tgz```
 
 ### Running npm
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
@@ -32,6 +32,14 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
     private String yarnDownloadRoot;
 
     /**
+     * Full path minus version to download Yarn binary from. No default. Ends with slash.
+     * Example: https://a-host.a-domain/blah/blah/-/ of  https://a-host.a-domain/blah/blah/-/yarn-1.17.3.tgz
+     */
+    @Parameter(property = "yarnDownloadUrl", required = false,
+        defaultValue = "")
+    private String yarnDownloadUrl;
+
+    /**
      * The version of Node.js to install. IMPORTANT! Most Node.js version names start with 'v', for example
      * 'v0.10.18'
      */
@@ -43,6 +51,12 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
      */
     @Parameter(property = "yarnVersion", required = true)
     private String yarnVersion;
+
+    /**
+     * The tarball extension of Yarn to install, something like tgz, tar.gz, etc.
+     */
+    @Parameter(property = "yarnExtension", required = false, defaultValue = "")
+    private String yarnExtension;
 
     /**
      * Server Id for download username and password
@@ -81,8 +95,13 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
         } else {
             factory.getNodeInstaller(proxyConfig).setNodeDownloadRoot(this.nodeDownloadRoot)
                 .setNodeVersion(this.nodeVersion).install();
-            factory.getYarnInstaller(proxyConfig).setYarnDownloadRoot(this.yarnDownloadRoot)
-                .setYarnVersion(this.yarnVersion).install();
+            if (this.yarnDownloadUrl != null && !this.yarnDownloadUrl.isEmpty()) {
+                factory.getYarnInstaller(proxyConfig).setYarnVersion(this.yarnVersion)
+                    .install(this.yarnDownloadUrl, this.yarnExtension);
+            } else {
+                factory.getYarnInstaller(proxyConfig).setYarnDownloadRoot(this.yarnDownloadRoot)
+                    .setYarnVersion(this.yarnVersion).install();
+            }
         }
     }
 


### PR DESCRIPTION
Summary
fixed two thing:

#504: Let user specify a custom location of yarn dist tar ball.
#647: copy installed /node/yarn/yarn- to /node/yarn/dist for execution path.
Tests and Documentation
Updated README