### PR TITLE
add support for Alpine Linux using experimental nodejs download url

### DIFF
--- a/frontend-maven-plugin/src/it/custom-install-directory/pom.xml
+++ b/frontend-maven-plugin/src/it/custom-install-directory/pom.xml
@@ -27,7 +27,7 @@
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v8.11.1</nodeVersion>
+                            <nodeVersion>v8.16.1</nodeVersion>
                             <npmVersion>5.6.0</npmVersion>
                         </configuration>
                     </execution>

--- a/frontend-maven-plugin/src/it/custom-working-directory/pom.xml
+++ b/frontend-maven-plugin/src/it/custom-working-directory/pom.xml
@@ -27,7 +27,7 @@
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v8.11.1</nodeVersion>
+                            <nodeVersion>v8.16.1</nodeVersion>
                             <npmVersion>5.6.0</npmVersion>
                         </configuration>
                     </execution>

--- a/frontend-maven-plugin/src/it/example project/pom.xml
+++ b/frontend-maven-plugin/src/it/example project/pom.xml
@@ -25,7 +25,7 @@
             </goals>
             <configuration>
               <!-- See https://nodejs.org/en/download/ for latest node and npm (lts) versions -->
-              <nodeVersion>v8.11.1</nodeVersion>
+              <nodeVersion>v8.16.1</nodeVersion>
               <npmVersion>5.6.0</npmVersion>
             </configuration>
           </execution>

--- a/frontend-maven-plugin/src/it/node-provided-npm/pom.xml
+++ b/frontend-maven-plugin/src/it/node-provided-npm/pom.xml
@@ -27,7 +27,7 @@
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v8.11.1</nodeVersion>
+                            <nodeVersion>v8.16.1</nodeVersion>
                         </configuration>
                     </execution>
 

--- a/frontend-maven-plugin/src/it/yarn-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/yarn-integration/pom.xml
@@ -27,7 +27,7 @@
                             <goal>install-node-and-yarn</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v8.11.1</nodeVersion>
+                            <nodeVersion>v8.16.1</nodeVersion>
                             <yarnVersion>v1.6.0</yarnVersion>
                         </configuration>
                     </execution>

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
@@ -17,7 +17,9 @@ public class NodeInstaller {
     public static final String INSTALL_PATH = "/node";
 
     public static final String DEFAULT_NODEJS_DOWNLOAD_ROOT = "https://nodejs.org/dist/";
-
+    
+    public static final String DEFAULT_NODEJS_EXPERIMENTAL_DOWNLOAD_ROOT = "https://unofficial-builds.nodejs.org/download/release/";
+    
     private static final Object LOCK = new Object();
 
     private String npmVersion, nodeVersion, nodeDownloadRoot, userName, password;
@@ -81,6 +83,9 @@ public class NodeInstaller {
         synchronized (LOCK) {
             if (this.nodeDownloadRoot == null || this.nodeDownloadRoot.isEmpty()) {
                 this.nodeDownloadRoot = DEFAULT_NODEJS_DOWNLOAD_ROOT;
+            }
+            if (this.config.getPlatform().isExperimentalArchitecture() && DEFAULT_NODEJS_DOWNLOAD_ROOT.equals(this.nodeDownloadRoot)) {
+                this.nodeDownloadRoot = DEFAULT_NODEJS_EXPERIMENTAL_DOWNLOAD_ROOT;
             }
             if (!nodeIsAlreadyInstalled()) {
                 this.logger.info("Installing node version {}", this.nodeVersion);


### PR DESCRIPTION
**Summary**

This pull request is an attempt to support _frontend-maven-plugin_ on **Alpine Linux**. The issue has been reported several times here and there: https://github.com/eirslett/frontend-maven-plugin/issues/633, https://github.com/eirslett/frontend-maven-plugin/issues/636, https://github.com/eirslett/frontend-maven-plugin/issues/287

The proposed solution is to detect when we are running under Alpine Linux (_musl libc_) using the `ldd` command. In such case, we should download from https://unofficial-builds.nodejs.org/download/release/ instead. Although experimental, these builds are stable enough for Alpine Linux in most cases.

This prevents from forcing _glibc_ into Alpine Linux, hence avoiding some annoying Warning messages.

**Caveats**

Currently the following integration test fails, but it's the same behaviour on *master* branch.
```
[ERROR] The following builds failed:
[ERROR] *  yarn-integration/pom.xml
[...]
Running post-build script: /some/path/to/frontend-maven-plugin/frontend-maven-plugin/target/it/yarn-integration/verify.groovy
java.lang.AssertionError: incorrect local repository location. Expression: buildLog.replace(java.io.File.separatorChar, (char) /).matches((?s).+Unpacking .+\Q/local-repo/com/github/eirslett/yarn/[1-9\.]*/yarn-[1-9\.]*.tar.gz\E into .+/target/node/yarn.+)
```
