### PR TITLE
Issue #750: Add support for npx runner

### DIFF
--- a/frontend-maven-plugin/src/it/npx-integration/package.json
+++ b/frontend-maven-plugin/src/it/npx-integration/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "example",
+  "version": "0.0.1",
+  "dependencies": { }
+}

--- a/frontend-maven-plugin/src/it/npx-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/npx-integration/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.eirslett</groupId>
+    <artifactId>example</artifactId>
+    <version>0</version>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
+                <version>@project.version@</version>
+
+                <configuration>
+                    <installDirectory>target</installDirectory>
+                </configuration>
+
+                <executions>
+
+                    <execution>
+                        <id>install node and yarn</id>
+                        <goals>
+                            <goal>install-node-and-yarn</goal>
+                        </goals>
+                        <configuration>
+                            <nodeVersion>v12.16.1</nodeVersion>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>npx test</id>
+                        <goals>
+                            <goal>npx</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>cowsay hello</arguments>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/frontend-maven-plugin/src/it/npx-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/npx-integration/pom.xml
@@ -22,12 +22,13 @@
                 <executions>
 
                     <execution>
-                        <id>install node and yarn</id>
+                        <id>install node and npm</id>
                         <goals>
-                            <goal>install-node-and-yarn</goal>
+                            <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
                             <nodeVersion>v12.16.1</nodeVersion>
+                            <npmVersion>6.13.4</npmVersion>
                         </configuration>
                     </execution>
 

--- a/frontend-maven-plugin/src/it/npx-integration/verify.groovy
+++ b/frontend-maven-plugin/src/it/npx-integration/verify.groovy
@@ -1,0 +1,2 @@
+String buildLog = new File(basedir, 'build.log').text
+assert buildLog.contains('< Hello >') : 'gulp failed to run as expected'

--- a/frontend-maven-plugin/src/it/npx-integration/verify.groovy
+++ b/frontend-maven-plugin/src/it/npx-integration/verify.groovy
@@ -1,2 +1,2 @@
 String buildLog = new File(basedir, 'build.log').text
-assert buildLog.contains('< Hello >') : 'gulp failed to run as expected'
+assert buildLog.contains('< hello >') : 'gulp failed to run as expected'

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpxMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpxMojo.java
@@ -1,0 +1,81 @@
+package com.github.eirslett.maven.plugins.frontend.mojo;
+
+import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
+import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
+import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+import java.io.File;
+import java.util.Collections;
+
+@Mojo(name="npx",  defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+public final class NpxMojo extends AbstractFrontendMojo {
+
+    private static final String NPM_REGISTRY_URL = "npmRegistryURL";
+    
+    /**
+     * npm arguments. Default is "install".
+     */
+    @Parameter(defaultValue = "install", property = "frontend.npx.arguments", required = false)
+    private String arguments;
+
+    @Parameter(property = "frontend.npx.npmInheritsProxyConfigFromMaven", required = false, defaultValue = "true")
+    private boolean npmInheritsProxyConfigFromMaven;
+
+    /**
+     * Registry override, passed as the registry option during npm install if set.
+     */
+    @Parameter(property = NPM_REGISTRY_URL, required = false, defaultValue = "")
+    private String npmRegistryURL;
+    
+    @Parameter(property = "session", defaultValue = "${session}", readonly = true)
+    private MavenSession session;
+
+    @Component
+    private BuildContext buildContext;
+
+    @Component(role = SettingsDecrypter.class)
+    private SettingsDecrypter decrypter;
+
+    /**
+     * Skips execution of this mojo.
+     */
+    @Parameter(property = "skip.npx", defaultValue = "${skip.npx}")
+    private boolean skip;
+
+    @Override
+    protected boolean skipExecution() {
+        return this.skip;
+    }
+
+    @Override
+    public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
+        File packageJson = new File(workingDirectory, "package.json");
+        if (buildContext == null || buildContext.hasDelta(packageJson) || !buildContext.isIncremental()) {
+            ProxyConfig proxyConfig = getProxyConfig();
+            factory.getNpxRunner(proxyConfig, getRegistryUrl()).execute(arguments, environmentVariables);
+        } else {
+            getLog().info("Skipping npm install as package.json unchanged");
+        }
+    }
+
+    private ProxyConfig getProxyConfig() {
+        if (npmInheritsProxyConfigFromMaven) {
+            return MojoUtils.getProxyConfig(session, decrypter);
+        } else {
+            getLog().info("npm not inheriting proxy config from Maven");
+            return new ProxyConfig(Collections.<ProxyConfig.Proxy>emptyList());
+        }
+    }
+
+    private String getRegistryUrl() {
+        // check to see if overridden via `-D`, otherwise fallback to pom value
+        return System.getProperty(NPM_REGISTRY_URL, npmRegistryURL);
+    }
+}

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -45,6 +45,10 @@ public final class FrontendPluginFactory {
         return new DefaultNpmRunner(getExecutorConfig(), proxy, npmRegistryURL);
     }
 
+    public NpxRunner getNpxRunner(ProxyConfig proxy, String npmRegistryURL) {
+        return new DefaultNpxRunner(getExecutorConfig(), proxy, npmRegistryURL);
+    }
+
     public YarnRunner getYarnRunner(ProxyConfig proxy, String npmRegistryURL) {
         return new DefaultYarnRunner(new InstallYarnExecutorConfig(getInstallConfig()), proxy, npmRegistryURL);
     }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutorConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutorConfig.java
@@ -5,6 +5,7 @@ import java.io.File;
 public interface NodeExecutorConfig {
   File getNodePath();
   File getNpmPath();
+  File getNpxPath();
   File getInstallDirectory();
   File getWorkingDirectory();
   Platform getPlatform();
@@ -15,6 +16,7 @@ final class InstallNodeExecutorConfig implements NodeExecutorConfig {
   private static final String NODE_WINDOWS = NodeInstaller.INSTALL_PATH.replaceAll("/", "\\\\") + "\\node.exe";
   private static final String NODE_DEFAULT = NodeInstaller.INSTALL_PATH + "/node";
   private static final String NPM = NodeInstaller.INSTALL_PATH + "/node_modules/npm/bin/npm-cli.js";
+  private static final String NPX = NodeInstaller.INSTALL_PATH + "/node_modules/npm/bin/npx-cli.js";
 
   private final InstallConfig installConfig;
 
@@ -31,6 +33,11 @@ final class InstallNodeExecutorConfig implements NodeExecutorConfig {
   @Override
   public File getNpmPath() {
     return new File(installConfig.getInstallDirectory() + Utils.normalize(NPM));
+  }
+
+  @Override
+  public File getNpxPath() {
+    return new File(installConfig.getInstallDirectory() + Utils.normalize(NPX));
   }
 
   @Override

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpxRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpxRunner.java
@@ -1,0 +1,44 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig.Proxy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public interface NpxRunner extends NodeTaskRunner {}
+
+final class DefaultNpxRunner extends NodeTaskExecutor implements NpxRunner {
+    static final String TASK_NAME = "npx";
+
+    public DefaultNpxRunner(NodeExecutorConfig config, ProxyConfig proxyConfig, String npmRegistryURL) {
+        super(config, TASK_NAME, config.getNpxPath().getAbsolutePath(), buildArguments(proxyConfig, npmRegistryURL));
+    }
+
+    private static List<String> buildArguments(ProxyConfig proxyConfig, String npmRegistryURL) {
+        List<String> arguments = new ArrayList<String>();
+               
+        if(npmRegistryURL != null && !npmRegistryURL.isEmpty()){
+            arguments.add ("--registry=" + npmRegistryURL);
+        }
+
+        if(!proxyConfig.isEmpty()){
+            Proxy proxy = null;
+            if(npmRegistryURL != null && !npmRegistryURL.isEmpty()){
+                proxy = proxyConfig.getProxyForUrl(npmRegistryURL);
+            }
+
+            if(proxy == null){
+                proxy = proxyConfig.getSecureProxy();
+            }
+
+            if(proxy == null){
+                proxy = proxyConfig.getInsecureProxy();
+            }
+
+            arguments.add("--https-proxy=" + proxy.getUri().toString());
+            arguments.add("--proxy=" + proxy.getUri().toString());
+        }
+        
+        return arguments;
+    }
+}


### PR DESCRIPTION
Trying to address: #750 

We internally use "license-checker", but since we are mostly a java shop we build our react ui with this mvn plugin. We wanted to have license checking integrated with the build configuration without having to rely on workarounds.

The change in this request allow our configuration to work. I know it may need some adjustments and testing, and I'd be happy to gather feedback and integrate it.

Little slice of our pom.xml:
```
<execution>
	<id>generate license list</id>
	<goals>
		<goal>npx</goal>
	</goals>
	<configuration>
		<arguments>license-checker --production --csv</arguments>
	</configuration>
</execution>
```