### PR TITLE
Copying npm scripts for embedded node

### DIFF
--- a/frontend-maven-plugin/src/it/node-provided-npm/package.json
+++ b/frontend-maven-plugin/src/it/node-provided-npm/package.json
@@ -3,5 +3,8 @@
   "version": "0.0.1",
   "dependencies": {
     "less": "~3.0.2"
+  },
+  "scripts": {
+    "prebuild": "npm install"
   }
 }

--- a/frontend-maven-plugin/src/it/node-provided-npm/verify.groovy
+++ b/frontend-maven-plugin/src/it/node-provided-npm/verify.groovy
@@ -1,5 +1,6 @@
 assert new File(basedir, 'target/node').exists() : "Node was not installed in the custom install directory";
 assert new File(basedir, 'node_modules').exists() : "Node modules were not installed in the base directory";
+assert new File(basedir, 'target/node/npm').exists() : "npm was not copied to the node directory";
 
 import org.codehaus.plexus.util.FileUtils;
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NPMInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NPMInstaller.java
@@ -82,6 +82,7 @@ public class NPMInstaller {
             if (!npmProvided() && !npmIsAlreadyInstalled()) {
                 installNpm();
             }
+            copyNpmScripts();
         }
     }
 
@@ -169,16 +170,6 @@ public class NPMInstaller {
                 }
             }
 
-            // create a copy of the npm scripts next to the node executable
-            for (String script : Arrays.asList("npm", "npm.cmd")) {
-                File scriptFile = new File(npmDirectory, "bin" + File.separator + script);
-                if (scriptFile.exists()) {
-                    File copy = new File(installDirectory, script);
-                    FileUtils.copyFile(scriptFile, copy);
-                    copy.setExecutable(true);
-                }
-            }
-
             this.logger.info("Installed npm locally.");
         } catch (DownloadException e) {
             throw new InstallationException("Could not download npm", e);
@@ -186,6 +177,31 @@ public class NPMInstaller {
             throw new InstallationException("Could not extract the npm archive", e);
         } catch (IOException e) {
             throw new InstallationException("Could not copy npm", e);
+        }
+    }
+
+    private void copyNpmScripts() throws InstallationException{
+        File installDirectory = getNodeInstallDirectory();
+
+        File nodeModulesDirectory = new File(installDirectory, "node_modules");
+        File npmDirectory = new File(nodeModulesDirectory, "npm");
+        // create a copy of the npm scripts next to the node executable
+        for (String script : Arrays.asList("npm", "npm.cmd")) {
+            File scriptFile = new File(npmDirectory, "bin" + File.separator + script);
+            if (scriptFile.exists()) {
+                File copy = new File(installDirectory, script);
+                if (!copy.exists()) {
+                    try
+                    {
+                        FileUtils.copyFile(scriptFile, copy);
+                    }
+                    catch (IOException e)
+                    {
+                        throw new InstallationException("Could not copy npm", e);
+                    }
+                    copy.setExecutable(true);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
If the "provided" npm version is used, the binaries are not copied into the node directory so they aren't in the path for `npm` executions started from the plugin. For example, the `prebuild` in the example project calls `npm install` which will use the system npm rather than that installed for the porject. This is experienced by reporters of #458 and #860.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Tests and Documentation**
Modified existing node-provided-npm integration test.

The example test is failing due to some phantomjs error and is apparently unrelated.
<!-- Demonstrate the code is solid. Add a simple description to CHANGELOG.md and add some infos to README.md or Wiki, if necessary. -->
