### PR TITLE
Fix JavaDoc build failures on JDK 11 by setting source to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.0.0-M1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -130,6 +131,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.0.1</version>
+                    <configuration>
+                        <source>${maven.compiler.source}</source>
+                    </configuration>
                     <executions>
                         <execution>
                             <id>attach-javadocs</id>


### PR DESCRIPTION
**Summary**

Fixes:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.1:jar (attach-javadocs) on project frontend-plugin-core: MavenReportException: Error while generating Javadoc:
[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
```
Also adds explicit maven-deploy-plugin version to get rid of nagging warning banner.

**Tests and Documentation**

n/a