### PR TITLE
Fix #703: Mark all remaining Mojos with threadSafe = true (and synchronized)

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/BowerMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/BowerMojo.java
@@ -12,7 +12,7 @@ import org.apache.maven.settings.crypto.SettingsDecrypter;
 
 import java.util.Collections;
 
-@Mojo(name = "bower", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name = "bower", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public final class BowerMojo extends AbstractFrontendMojo {
 
     /**
@@ -42,7 +42,7 @@ public final class BowerMojo extends AbstractFrontendMojo {
     }
 
     @Override
-    protected void execute(FrontendPluginFactory factory) throws TaskRunnerException {
+    protected synchronized void execute(FrontendPluginFactory factory) throws TaskRunnerException {
         ProxyConfig proxyConfig = getProxyConfig();
         factory.getBowerRunner(proxyConfig).execute(arguments, environmentVariables);
     }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/EmberMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/EmberMojo.java
@@ -12,7 +12,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
-@Mojo(name="ember", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name="ember", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public final class EmberMojo extends AbstractFrontendMojo {
 
     /**
@@ -59,7 +59,7 @@ public final class EmberMojo extends AbstractFrontendMojo {
     }
 
     @Override
-    public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
+    public synchronized void execute(FrontendPluginFactory factory) throws TaskRunnerException {
         if (shouldExecute()) {
             factory.getEmberRunner().execute(arguments, environmentVariables);
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
@@ -12,7 +12,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
-@Mojo(name="grunt", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name="grunt", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public final class GruntMojo extends AbstractFrontendMojo {
 
     /**
@@ -59,7 +59,7 @@ public final class GruntMojo extends AbstractFrontendMojo {
     }
 
     @Override
-    public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
+    public synchronized void execute(FrontendPluginFactory factory) throws TaskRunnerException {
         if (shouldExecute()) {
             factory.getGruntRunner().execute(arguments, environmentVariables);
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
@@ -12,7 +12,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
-@Mojo(name="gulp", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name="gulp", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public final class GulpMojo extends AbstractFrontendMojo {
 
     /**
@@ -59,7 +59,7 @@ public final class GulpMojo extends AbstractFrontendMojo {
     }
 
     @Override
-    public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
+    public synchronized void execute(FrontendPluginFactory factory) throws TaskRunnerException {
         if (shouldExecute()) {
             factory.getGulpRunner().execute(arguments, environmentVariables);
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/JspmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/JspmMojo.java
@@ -11,7 +11,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
 
-@Mojo(name="jspm",  defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name="jspm",  defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public class JspmMojo extends AbstractFrontendMojo {
 
     /**
@@ -32,7 +32,7 @@ public class JspmMojo extends AbstractFrontendMojo {
     }
 
     @Override
-    protected void execute(FrontendPluginFactory factory) throws TaskRunnerException {
+    protected synchronized void execute(FrontendPluginFactory factory) throws TaskRunnerException {
         factory.getJspmRunner().execute(arguments, environmentVariables);
     }
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/KarmaRunMojo.java
@@ -7,7 +7,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 
-@Mojo(name="karma",  defaultPhase = LifecyclePhase.TEST)
+@Mojo(name="karma",  defaultPhase = LifecyclePhase.TEST, threadSafe = true)
 public final class KarmaRunMojo extends AbstractFrontendMojo {
 
     /**
@@ -28,7 +28,7 @@ public final class KarmaRunMojo extends AbstractFrontendMojo {
     }
 
     @Override
-    public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
+    public synchronized void execute(FrontendPluginFactory factory) throws TaskRunnerException {
         factory.getKarmaRunner().execute("start " + karmaConfPath, environmentVariables);
     }
 }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -14,7 +14,7 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 import java.io.File;
 import java.util.Collections;
 
-@Mojo(name="npm",  defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name="npm",  defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public final class NpmMojo extends AbstractFrontendMojo {
 
     private static final String NPM_REGISTRY_URL = "npmRegistryURL";
@@ -55,7 +55,7 @@ public final class NpmMojo extends AbstractFrontendMojo {
     }
 
     @Override
-    public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
+    public synchronized void execute(FrontendPluginFactory factory) throws TaskRunnerException {
         File packageJson = new File(workingDirectory, "package.json");
         if (buildContext == null || buildContext.hasDelta(packageJson) || !buildContext.isIncremental()) {
             ProxyConfig proxyConfig = getProxyConfig();

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/WebpackMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/WebpackMojo.java
@@ -12,7 +12,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
-@Mojo(name="webpack", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name="webpack", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public final class WebpackMojo extends AbstractFrontendMojo {
 
     /**
@@ -59,7 +59,7 @@ public final class WebpackMojo extends AbstractFrontendMojo {
     }
 
     @Override
-    public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
+    public synchronized void execute(FrontendPluginFactory factory) throws TaskRunnerException {
         if (shouldExecute()) {
             factory.getWebpackRunner().execute(arguments, environmentVariables);
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/YarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/YarnMojo.java
@@ -15,7 +15,7 @@ import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
 import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
 
-@Mojo(name = "yarn", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name = "yarn", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public final class YarnMojo extends AbstractFrontendMojo {
 
     private static final String NPM_REGISTRY_URL = "npmRegistryURL";
@@ -57,7 +57,7 @@ public final class YarnMojo extends AbstractFrontendMojo {
     }
 
     @Override
-    public void execute(FrontendPluginFactory factory) throws TaskRunnerException {
+    public synchronized void execute(FrontendPluginFactory factory) throws TaskRunnerException {
         File packageJson = new File(this.workingDirectory, "package.json");
         if (this.buildContext == null || this.buildContext.hasDelta(packageJson)
             || !this.buildContext.isIncremental()) {

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.0.0-M1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -130,6 +131,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.0.1</version>
+                    <configuration>
+                        <source>${maven.compiler.source}</source>
+                    </configuration>
                     <executions>
                         <execution>
                             <id>attach-javadocs</id>


### PR DESCRIPTION
**Summary**

Fixes #703 by adding `synchronized` and `threadSafe = true` to all Mojos that are not already declared "threadSafe".
This can be considered a pretty dumb but also a pretty safe approach.
I did _not_ check each Mojo in detail whether or not it actually needs synchronization.
So in the worst case this change reduces throughput unnecessarily, but not for `GruntMojo` which was already reported to be _not_ thread-safe (without synchronization).
IMHO this is better than the current state (users are _assuming thread-safety, are annoyed by the warnings and might run into sporadic build failures).
Further fine-tuning can be done at a later time, Mojo per Mojo.

Btw, `InstallNodeAnd*Mojo` are already declared "threadSafe". I don't know whether this is really the case, haven't checked.

**Tests and Documentation**

n/a