### PR TITLE
Added option for specifying installers locally instead of downloading…

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -16,6 +16,23 @@ import org.apache.maven.settings.Server;
 @Mojo(name="install-node-and-npm", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
 
+
+    /**
+     * Where a local copy of node can be found.
+     * Useful if you just do not want to download anything. (eg some corporate build policies prevent this)
+     * If this value is set, the plugin will not attempt to download anything and instead will use the local version
+     */
+    @Parameter(property = "nodeLocalRoot", required = false)
+    private String nodeLocalRoot;
+
+    /**
+     * Where a local copy of npm can be found.
+     * Useful if you just do not want to download anything. (eg some corporate build policies prevent this)
+     * If this value is set, the plugin will not attempt to download anything and instead will use the local version
+     */
+    @Parameter(property = "npmLocalRoot", required = false)
+    private String npmLocalRoot;
+
     /**
      * Where to download Node.js binary from. Defaults to https://nodejs.org/dist/
      */
@@ -82,6 +99,7 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
             factory.getNodeInstaller(proxyConfig)
                 .setNodeVersion(nodeVersion)
                 .setNodeDownloadRoot(nodeDownloadRoot)
+                .setNodeLocalRoot(nodeLocalRoot)
                 .setNpmVersion(npmVersion)
                 .setUserName(server.getUsername())
                 .setPassword(server.getPassword())
@@ -90,6 +108,7 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
                 .setNodeVersion(nodeVersion)
                 .setNpmVersion(npmVersion)
                 .setNpmDownloadRoot(npmDownloadRoot)
+                .setNpmLocalRoot(npmLocalRoot)
                 .setUserName(server.getUsername())
                 .setPassword(server.getPassword())
                 .install();
@@ -97,12 +116,14 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
             factory.getNodeInstaller(proxyConfig)
                 .setNodeVersion(nodeVersion)
                 .setNodeDownloadRoot(nodeDownloadRoot)
+                .setNodeLocalRoot(nodeLocalRoot)
                 .setNpmVersion(npmVersion)
                 .install();
             factory.getNPMInstaller(proxyConfig)
                 .setNodeVersion(this.nodeVersion)
                 .setNpmVersion(this.npmVersion)
                 .setNpmDownloadRoot(npmDownloadRoot)
+                .setNpmLocalRoot(npmLocalRoot)
                 .install();
         }
     }


### PR DESCRIPTION
The corporate policy where I work makes it hard for me to download anything from any unauthorized urls into the build servers even by proxy. 

So by having these options,we can store the node and npm installers locally and skip the need to download anything from the Internet. 

The downside is that you will have to manually copy the node and npm installers into version control but certainly better that not being able to run this wonderful plugin. 