### PR TITLE
Add re-downloading Node archive in case of EOFException (#882)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 
 ## Changelog
 
+### 1.9.2
+
+* Add re-downloading and trying to extract again Node archive in case of EOFException ([#882](https://github.com/eirslett/frontend-maven-plugin/issues/882))
+
 ### 1.9.0
 
 * Copy npm scripts, so they are available for execution ([#868](https://github.com/eirslett/frontend-maven-plugin/pull/868))


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Add re-downloading and trying to extract again Node archive in case of EOFException.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

([#882](https://github.com/eirslett/frontend-maven-plugin/issues/882))

**Tests and Documentation**

<!-- Demonstrate the code is solid. Add a simple description to CHANGELOG.md and add some infos to README.md or Wiki, if necessary. -->

none
