### PR TITLE
Added No Proxy Support

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
@@ -37,6 +37,7 @@ final class DefaultNpmRunner extends NodeTaskExecutor implements NpmRunner {
 
             arguments.add("--https-proxy=" + proxy.getUri().toString());
             arguments.add("--proxy=" + proxy.getUri().toString());
+            arguments.add("--noproxy=" + proxy.getNonProxyHosts());
         }
         
         return arguments;

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
@@ -14,7 +14,8 @@ final class DefaultNpmRunner extends NodeTaskExecutor implements NpmRunner {
         super(config, TASK_NAME, config.getNpmPath().getAbsolutePath(), buildArguments(proxyConfig, npmRegistryURL));
     }
 
-    private static List<String> buildArguments(ProxyConfig proxyConfig, String npmRegistryURL) {
+    // Visible for testing only.
+    static List<String> buildArguments(ProxyConfig proxyConfig, String npmRegistryURL) {
         List<String> arguments = new ArrayList<String>();
                
         if(npmRegistryURL != null && !npmRegistryURL.isEmpty()){
@@ -37,7 +38,11 @@ final class DefaultNpmRunner extends NodeTaskExecutor implements NpmRunner {
 
             arguments.add("--https-proxy=" + proxy.getUri().toString());
             arguments.add("--proxy=" + proxy.getUri().toString());
-            arguments.add("--noproxy=" + proxy.getNonProxyHosts());
+
+            final String nonProxyHosts = proxy.getNonProxyHosts();
+            if (nonProxyHosts != null && !nonProxyHosts.isEmpty()) {
+                arguments.add("--noproxy=" + nonProxyHosts);
+            }
         }
         
         return arguments;

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProxyConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProxyConfig.java
@@ -62,6 +62,7 @@ public class ProxyConfig {
         public final int port;
         public final String username;
         public final String password;
+
         public final String nonProxyHosts;
 
         public Proxy(String id, String protocol, String host, int port, String username, String password, String nonProxyHosts) {
@@ -106,12 +107,26 @@ public class ProxyConfig {
             return false;
         }
 
+        /**
+         * As per https://docs.npmjs.com/misc/config#noproxy , npm expects a comma (`,`) separated list but
+         * maven settings.xml usually specifies the no proxy hosts as a bar (`|`) separated list (see
+         * http://maven.apache.org/guides/mini/guide-proxies.html) .
+         *
+         * We could do the conversion here but npm seems to accept the bar separated list regardless
+         * of what the documentation says so we do no conversion for now.
+         * @return
+         */
+        public String getNonProxyHosts() {
+            return nonProxyHosts;
+        }
+
         @Override
         public String toString() {
             return id + "{" +
                     "protocol='" + protocol + '\'' +
                     ", host='" + host + '\'' +
                     ", port=" + port +
+                    ", nonProxyHosts='" + nonProxyHosts + '\'' +
                     (useAuthentication()? ", with username/passport authentication" : "") +
                     '}';
         }

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/DefaultNpmRunnerTest.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/DefaultNpmRunnerTest.java
@@ -1,0 +1,83 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class DefaultNpmRunnerTest {
+
+    private final String id = "id";
+    private final String protocol = "http";
+    private final String host = "localhost";
+    private final int port = 8888;
+    private final String username = "someusername";
+    private final String password = "somepassword";
+    private final String nonProxyHosts = "www.google.ca";
+    private final String registryUrl = "www.npm.org";
+    private final String expectedUrl = "http://someusername:somepassword@localhost:8888";
+
+    @Test
+    public void buildArguments_basicTest() {
+        List<String> strings = runBuildArguments(nonProxyHosts, registryUrl);
+
+        assertThat(strings, CoreMatchers.hasItem("--proxy=" + expectedUrl));
+        assertThat(strings, CoreMatchers.hasItem("--https-proxy=" + expectedUrl));
+        assertThat(strings, CoreMatchers.hasItem("--noproxy=" + nonProxyHosts));
+        assertThat(strings, CoreMatchers.hasItem("--registry=" + registryUrl));
+        assertEquals(4, strings.size());
+    }
+
+
+    @Test
+    public void buildArguments_emptyRegistryUrl() {
+        List<String> strings = runBuildArguments(nonProxyHosts, "");
+
+        assertThat(strings, CoreMatchers.hasItem("--proxy=" + expectedUrl));
+        assertThat(strings, CoreMatchers.hasItem("--https-proxy=" + expectedUrl));
+        assertThat(strings, CoreMatchers.hasItem("--noproxy=" + nonProxyHosts));
+        assertEquals(3, strings.size());
+    }
+
+    @Test
+    public void buildArguments_nullRegistryUrl() {
+        List<String> strings = runBuildArguments(nonProxyHosts, null);
+
+        assertThat(strings, CoreMatchers.hasItem("--proxy=" + expectedUrl));
+        assertThat(strings, CoreMatchers.hasItem("--https-proxy=" + expectedUrl));
+        assertThat(strings, CoreMatchers.hasItem("--noproxy=" + nonProxyHosts));
+        assertEquals(3, strings.size());
+    }
+
+    @Test
+    public void buildArguments_emptyNoProxy() {
+        List<String> strings = runBuildArguments("", "");
+
+        assertThat(strings, CoreMatchers.hasItem("--proxy=" + expectedUrl));
+        assertThat(strings, CoreMatchers.hasItem("--https-proxy=" + expectedUrl));
+        assertEquals(2, strings.size());
+    }
+
+    @Test
+    public void buildArguments_nullNoProxy() {
+        List<String> strings = runBuildArguments(null, "");
+
+        assertThat(strings, CoreMatchers.hasItem("--proxy=" + expectedUrl));
+        assertThat(strings, CoreMatchers.hasItem("--https-proxy=" + expectedUrl));
+        assertEquals(2, strings.size());
+    }
+
+    private List<String> runBuildArguments(String nonProxyHost, String registryUrl) {
+        List<ProxyConfig.Proxy> proxyList = Stream.of(
+                new ProxyConfig.Proxy(id, protocol, host, port, username, password, nonProxyHost)
+        ).collect(Collectors.toList());
+
+        return DefaultNpmRunner.buildArguments(new ProxyConfig(proxyList), registryUrl);
+    }
+}


### PR DESCRIPTION

**Summary**
NPM now supports setting noproxy hosts, which is a field that is often set
by users in their setting.xml proxy settings. We now push that all the way
down to the npm calls.

This should enable users to inherit their settings.xml proxy settings faithfully,
avoiding the need to use the `npmInheritsProxyConfigFromMaven` setting in
these cases at least.

This also fixes https://github.com/eirslett/frontend-maven-plugin/issues/887

**Tests and Documentation**
No tests were necessary as it is fairly trivial and non seem to exist presently. I can write some if desired. 