### PR TITLE
integrationTestFailureAfterPostIntegration flag delegates integration…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 
 ## Changelog
 
+### 1.9.2
+
+* Parameter **integrationTestFailureAfterPostIntegration** logs the failures during *integration-test* phase but only fails the build during the *verify* phase.  This allows the *post-integration-test* phase to finish.  An execution with *verify* phase is required.
+
 ### 1.9.0
 
 * Copy npm scripts, so they are available for execution ([#868](https://github.com/eirslett/frontend-maven-plugin/pull/868))

--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>frontend-plugins</artifactId>
     <groupId>com.github.eirslett</groupId>
-    <version>1.9.1</version>
+    <version>1.9.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>frontend-maven-plugin</artifactId>

--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>frontend-plugins</artifactId>
         <groupId>com.github.eirslett</groupId>
-        <version>1.9.1</version>
+        <version>1.9.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.eirslett</groupId>
     <artifactId>frontend-plugins</artifactId>
-    <version>1.9.1</version>
+    <version>1.9.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
… test failures to fail maven build during verify phase; requires a verify execution phase

**Summary**

Test failures during the *integration-test* phase causes build to fail before *post-integration-test* can be carried out.  Adding the **testFailureIgnore** flag is insufficient as it solves the above problem, but allows the build to print SUCCESS even when tests fail.

This pull request adds another option: parameter **integrationTestFailureAfterPostIntegration** still logs the failures during *integration-test* phase but only fails the build during the *verify* phase.  This allows the *post-integration-test* phase to finish.  

The downside to this implementation is that an execution with *verify* phase is required, even it this phase doesn't do anything functionally.  A working example is:

```
    <execution>
        <id>npm run integration tests</id>
        <goals>
            <goal>npm</goal>
        </goals>
        <phase>integration-test</phase>
        <configuration>
            <arguments>run e2e</arguments>
            <integrationTestFailureAfterPostIntegration>true</integrationTestFailureAfterPostIntegration>
        </configuration>
    </execution>
    <execution>
        <id>fail any integration tests</id>
        <goals>
            <goal>npm</goal>
        </goals>
        <phase>verify</phase>
        <configuration>
            <arguments>-version</arguments>
        </configuration>
    </execution>
```

**Tests and Documentation**

Documentation updated to 1.9.2
