### PR TITLE
Strip quotes from arguments

### DIFF
--- a/frontend-maven-plugin/src/it/npx-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/npx-integration/pom.xml
@@ -42,6 +42,16 @@
                         </configuration>
                     </execution>
 
+                    <execution>
+                        <id>npx -c test</id>
+                        <goals>
+                            <goal>npx</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>-p cowsay -c 'cowsay command'</arguments>
+                        </configuration>
+                    </execution>
+
                 </executions>
             </plugin>
         </plugins>

--- a/frontend-maven-plugin/src/it/npx-integration/verify.groovy
+++ b/frontend-maven-plugin/src/it/npx-integration/verify.groovy
@@ -1,2 +1,3 @@
 String buildLog = new File(basedir, 'build.log').text
-assert buildLog.contains('< hello >') : 'gulp failed to run as expected'
+assert buildLog.contains('< hello >') : 'npx failed to run as expected'
+assert buildLog.contains('< command >') : 'npx -c failed to run as expected'

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParser.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParser.java
@@ -55,11 +55,14 @@ class ArgumentsParser {
                     quote = currentQuote;
                 } else if (quote.equals(currentQuote)){
                     quote = null;
-                } // else
-                // we ignore the case when a quoted argument contains the other kind of quote
+                } else {
+                    // we ignore the case when a quoted argument contains the other kind of quote
+                    argumentBuilder.append(c);
+                }
+            } else {
+                argumentBuilder.append(c);
             }
 
-            argumentBuilder.append(c);
         }
 
         addArgument(argumentBuilder, arguments);

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParserTest.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParserTest.java
@@ -31,20 +31,32 @@ public class ArgumentsParserTest {
     public void testMultipleArgumentsWithQuotes() {
         ArgumentsParser parser = new ArgumentsParser();
 
-        assertArrayEquals(new Object[] { "foo", "\"bar foobar\"" }, parser.parse("foo \"bar foobar\"").toArray());
-        assertArrayEquals(new Object[] { "\"foo bar\"", "foobar" }, parser.parse("\"foo bar\" foobar").toArray());
-        assertArrayEquals(new Object[] { "foo", "'bar foobar'" }, parser.parse("foo 'bar foobar'").toArray());
-        assertArrayEquals(new Object[] { "'foo bar'", "foobar" }, parser.parse("'foo bar' foobar").toArray());
+        assertArrayEquals(new Object[] { "foo", "bar foobar" }, parser.parse("foo \"bar foobar\"").toArray());
+        assertArrayEquals(new Object[] { "foo bar", "foobar" }, parser.parse("\"foo bar\" foobar").toArray());
+        assertArrayEquals(new Object[] { "foo", "bar foobar" }, parser.parse("foo 'bar foobar'").toArray());
+        assertArrayEquals(new Object[] { "foo bar", "foobar" }, parser.parse("'foo bar' foobar").toArray());
         // unclosed quotes
-        assertArrayEquals(new Object[] { "foo", "\"bar foobar" }, parser.parse("foo \"bar foobar").toArray());
+        assertArrayEquals(new Object[] { "foo", "bar foobar" }, parser.parse("foo \"bar foobar").toArray());
     }
 
     @Test
     public void testArgumentsWithMixedQuotes() {
         ArgumentsParser parser = new ArgumentsParser();
 
-        assertArrayEquals(new Object[] { "foo", "\"bar 'foo bar'\"" }, parser.parse("foo \"bar 'foo bar'\"").toArray());
-        assertArrayEquals(new Object[] { "foo", "\"bar 'foo\"", "'bar " }, parser.parse("foo \"bar 'foo\" 'bar ").toArray());
+        assertArrayEquals(new Object[] { "foo", "bar 'foo bar'" }, parser.parse("foo \"bar 'foo bar'\"").toArray());
+        assertArrayEquals(new Object[] { "foo", "bar 'foo", "bar " }, parser.parse("foo \"bar 'foo\" 'bar ").toArray());
+    }
+
+    @Test
+    public void testArgumentsWithRetainedQuotes() {
+        ArgumentsParser parser = new ArgumentsParser();
+
+        assertArrayEquals(new Object[] { "foo", "\"bar foobar\"" }, parser.parse("foo '\"bar foobar\"'").toArray());
+        assertArrayEquals(new Object[] { "\"foo bar\"", "foobar" }, parser.parse("'\"foo bar\"' foobar").toArray());
+        assertArrayEquals(new Object[] { "foo", "'bar foobar'" }, parser.parse("foo \"'bar foobar'\"").toArray());
+        assertArrayEquals(new Object[] { "'foo bar'", "foobar" }, parser.parse("\"'foo bar'\" foobar").toArray());
+        // unclosed quotes
+        assertArrayEquals(new Object[] { "foo", "\"bar foobar" }, parser.parse("foo '\"bar foobar").toArray());
     }
 
     @Test


### PR DESCRIPTION
So far quotes were not stripped from arguments. This can lead to issues in downstream processes, as shell-environments usually strip these arguments.
To retain quotes in an argument the argument needs to be quoted twice now.
Arguments that retain mixed quotes are no longer supported. This would now require escaping support.

With these changes the npx runner can now be used with -c option. Earlier using the -c option was not possible, as the command was parsed to npx with quotes, resulting in the complete argument being interpreted as a command name.