### PR TITLE
Fix testFailureIgnore config in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ tag of an execution like this:
 
 ```xml
 <configuration>
-    <maven.test.failure.ignore>true</maven.test.failure.ignore>
+    <testFailureIgnore>true</testFailureIgnore>
 </configuration>
 ```
 


### PR DESCRIPTION
**Summary**
Readme is wrong about the config option for enabling/disabling test failure ignore setting. The config is different from the property name.

