### PR TITLE
Resolves issue #913 . Try to use gulp-cli first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 
 ## Changelog
 
+### 1.10.1
+
+* Gulp goal tries to use gulp-cli if is installed as direct dependency (#913)
+
 ### 1.9.0
 
 * Copy npm scripts, so they are available for execution ([#868](https://github.com/eirslett/frontend-maven-plugin/pull/868))

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ By default, colors will be shown in the log.
 ### Running gulp
 
 Very similar to the Grunt execution. It will run gulp according to the `gulpfile.js` in your working directory.
-By default, colors will be shown in the log.
+By default, colors will be shown in the log. If you desire to use a gulpfile write as ES6 module, it's necessary to install 'gulp-cli' 2.3.0 or greater.
 
 ```xml
 <execution>

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GulpRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/GulpRunner.java
@@ -1,11 +1,40 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
+import static com.github.eirslett.maven.plugins.frontend.lib.Utils.normalize;
+
+import java.io.File;
+
 public interface GulpRunner  extends NodeTaskRunner {}
 
 final class DefaultGulpRunner extends NodeTaskExecutor implements GulpRunner {
-    private static final String TASK_LOCATION = "node_modules/gulp/bin/gulp.js";
+    private static final String TASK_LOCATION_GULP_CLI = "node_modules/gulp-cli/bin/gulp.js";
+    private static final String TASK_LOCATION_GULP = "node_modules/gulp/bin/gulp.js";
 
     DefaultGulpRunner(NodeExecutorConfig config) {
-        super(config, TASK_LOCATION);
+        super(config, getCorrectTaskLocation(config));
+    }
+
+    private static String getAbsoluteTaskLocation(NodeExecutorConfig config, String taskLocation)
+    {
+        String location = normalize(taskLocation);
+        if (Utils.isRelative(taskLocation)) {
+            File taskFile = new File(config.getWorkingDirectory(), location);
+            if (!taskFile.exists()) {
+                taskFile = new File(config.getInstallDirectory(), location);
+            }
+            location = taskFile.getAbsolutePath();
+        }
+        return location;
+    }
+
+    private static String getCorrectTaskLocation(NodeExecutorConfig config)
+    {
+        String gulpCliLocation = getAbsoluteTaskLocation(config, TASK_LOCATION_GULP_CLI);
+        File gulpCliFile = new File(gulpCliLocation);
+        if (gulpCliFile.exists() && gulpCliFile.canRead()) {
+            return TASK_LOCATION_GULP_CLI;
+        } else {
+            return TASK_LOCATION_GULP;
+        }
     }
 }


### PR DESCRIPTION
**Summary**

Resolves issue #913 . First try to use gulp-cli if it's found on node-modules. If it not exists, then fallbacks to the old behaviour where calls to "node-modules/gulp/bin/gulp.js" that calls the embed gulp-cli of gulp.js

**Tests and Documentation**

Given this two files : 

gulpfile.js
```
import gulp from "gulp";

const { src, dest } = gulp;

export default() => {
  src('input/*.js')
    .pipe(dest('output/'))
}
```

package.js
```
{
  "main": "gulpfile.js",
  "devDependencies": {
    "gulp": "^4.0.2",
    "gulp-cli": "^2.3.0"
  },
  "type": "module"
}
```

It must run correctly and copy any js file from input to output.
