### PR TITLE
Adding serverId documentation to authenticate on node download

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ present).
 </plugin>
 ```
 
-You can also specify separate download roots for npm and node as they are stored in separate repos.
+You can also specify separate download roots for npm and node as they are stored in separate repos. In case the root configured requires authentication, you can specify a server ID from your maven settings file:
 
 ```xml
 <plugin>
@@ -116,6 +116,8 @@ You can also specify separate download roots for npm and node as they are stored
     <configuration>
         <!-- optional: where to download node from. Defaults to https://nodejs.org/dist/ -->
         <nodeDownloadRoot>http://myproxy.example.org/nodejs/</nodeDownloadRoot>
+	<!-- optional: credentials to use from Maven settings to download node -->
+        <serverId>server001</serverId>
         <!-- optional: where to download npm from. Defaults to https://registry.npmjs.org/npm/-/ -->
         <npmDownloadRoot>https://myproxy.example.org/npm/</npmDownloadRoot>
     </configuration>


### PR DESCRIPTION
**Summary**

I needed to authenticate when downloading Node and couldn't find how to do it reading the documentation. Finally through google I found this issue where the 2nd message pointed me to the right direction: https://github.com/eirslett/frontend-maven-plugin/issues/410 

As we can see in this PR: https://github.com/eirslett/frontend-maven-plugin/pull/390, it enabled to specify a server ID from the Maven settings, but this was not explained in the README.md.

**Tests and Documentation**

No required as it is just an improvement on the README.md
