### PR TITLE
Accept repeated values for regular arguments.

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParser.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParser.java
@@ -65,7 +65,9 @@ class ArgumentsParser {
         addArgument(argumentBuilder, arguments);
 
         for (String argument : this.additionalArguments) {
-            addArgument(argument, arguments);
+            if (!arguments.contains(argument)) {
+                arguments.add(argument);
+            }
         }
 
         return new ArrayList<>(arguments);
@@ -74,14 +76,8 @@ class ArgumentsParser {
     private static void addArgument(StringBuilder argumentBuilder, List<String> arguments) {
         if (argumentBuilder.length() > 0) {
             String argument = argumentBuilder.toString();
-            addArgument(argument, arguments);
-            argumentBuilder.setLength(0);
-        }
-    }
-
-    private static void addArgument(String argument, List<String> arguments) {
-        if (!arguments.contains(argument)) {
             arguments.add(argument);
+            argumentBuilder.setLength(0);
         }
     }
 }

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParserTest.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParserTest.java
@@ -48,6 +48,13 @@ public class ArgumentsParserTest {
     }
 
     @Test
+    public void repeatedArgumentsAreAccepted() {
+        ArgumentsParser parser = new ArgumentsParser();
+
+        assertArrayEquals(new Object[] { "echo", "echo" }, parser.parse("echo echo").toArray());
+    }
+
+    @Test
     public void testAdditionalArgumentsNoIntersection() {
         ArgumentsParser parser = new ArgumentsParser(Arrays.asList("foo", "bar"));
 


### PR DESCRIPTION
The arguments you want to pass may repeat a value. Accept this case, but continue to ignore additionalArguments that have already been supplied.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Accept repeated values for arguments. I have a use case of:

```
<arguments>--arg1 Value --arg2 Value</arguments>
```

and, currently, this is passed through as `--arg1 Value --arg2`.

As a workaround, I could use another form (e.g., `--arg1=Value --arg2=Value`), but I'm aiming to upgrade from a pre-`ArgumentsParser` version of this plugin, and it would be good to leave usage as-is.

(I believe this is also the bug reported in #880.)

**Tests and Documentation**

Existing unit tests pass. A new test demonstrates the new behaviour. I don't believe the original behaviour was documented, so this doesn't make any documentation changes.

<!-- Demonstrate the code is solid. Add a simple description to CHANGELOG.md and add some infos to README.md or Wiki, if necessary. -->
