### PR TITLE
Supports Alpine by detecting OS using /etc/alpine-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 
 ## Changelog
 
+### 1.10.0
+
+* Supports Alpine Linux
+
 ### 1.9.0
 
 * Copy npm scripts, so they are available for execution ([#868](https://github.com/eirslett/frontend-maven-plugin/pull/868))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 
 ## Changelog
 
-### 1.10.0
+### 1.10.1
 
 * Supports Alpine Linux
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -3,7 +3,6 @@ package com.github.eirslett.maven.plugins.frontend.mojo;
 import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
 import com.github.eirslett.maven.plugins.frontend.lib.InstallationException;
 import com.github.eirslett.maven.plugins.frontend.lib.NPMInstaller;
-import com.github.eirslett.maven.plugins.frontend.lib.NodeInstaller;
 import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugins.annotations.Component;
@@ -19,7 +18,7 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
     /**
      * Where to download Node.js binary from. Defaults to https://nodejs.org/dist/
      */
-    @Parameter(property = "nodeDownloadRoot", required = false, defaultValue = NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)
+    @Parameter(property = "nodeDownloadRoot", required = false)
     private String nodeDownloadRoot;
 
     /**
@@ -108,7 +107,7 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
     }
 
     private String getNodeDownloadRoot() {
-        if (downloadRoot != null && !"".equals(downloadRoot) && NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT.equals(nodeDownloadRoot)) {
+        if (downloadRoot != null && !"".equals(downloadRoot) && nodeDownloadRoot == null) {
             return downloadRoot;
         }
         return nodeDownloadRoot;

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
@@ -10,7 +10,6 @@ import org.apache.maven.settings.crypto.SettingsDecrypter;
 
 import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
 import com.github.eirslett.maven.plugins.frontend.lib.InstallationException;
-import com.github.eirslett.maven.plugins.frontend.lib.NodeInstaller;
 import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 import com.github.eirslett.maven.plugins.frontend.lib.YarnInstaller;
 
@@ -20,8 +19,7 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
     /**
      * Where to download Node.js binary from. Defaults to https://nodejs.org/dist/
      */
-    @Parameter(property = "nodeDownloadRoot", required = false,
-        defaultValue = NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)
+    @Parameter(property = "nodeDownloadRoot", required = false)
     private String nodeDownloadRoot;
 
     /**

--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -62,7 +62,22 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- to mock Platform calls -->
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>2.0.7</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>2.0.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
@@ -16,8 +16,6 @@ public class NodeInstaller {
 
     public static final String INSTALL_PATH = "/node";
 
-    public static final String DEFAULT_NODEJS_DOWNLOAD_ROOT = "https://nodejs.org/dist/";
-
     private static final Object LOCK = new Object();
 
     private String npmVersion, nodeVersion, nodeDownloadRoot, userName, password;
@@ -80,7 +78,7 @@ public class NodeInstaller {
         // use static lock object for a synchronized block
         synchronized (LOCK) {
             if (this.nodeDownloadRoot == null || this.nodeDownloadRoot.isEmpty()) {
-                this.nodeDownloadRoot = DEFAULT_NODEJS_DOWNLOAD_ROOT;
+                this.nodeDownloadRoot = this.config.getPlatform().getNodeDownloadRoot();
             }
             if (!nodeIsAlreadyInstalled()) {
                 this.logger.info("Installing node version {}", this.nodeVersion);

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
@@ -1,5 +1,7 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
+import java.io.File;
+
 enum Architecture { x86, x64, ppc64le, s390x, arm64, armv7l;
     public static Architecture guess(){
         String arch = System.getProperty("os.arch");
@@ -10,9 +12,9 @@ enum Architecture { x86, x64, ppc64le, s390x, arm64, armv7l;
         } else if (arch.equals("aarch64")) {
             return arm64;
         } else if (arch.equals("s390x")) {
-                return s390x;		
+                return s390x;
         } else if (arch.equals("arm") && version.contains("v7")) {
-                return armv7l;		
+                return armv7l;
         } else {
             return arch.contains("64") ? x64 : x86;
         }
@@ -51,18 +53,41 @@ enum OS { Windows, Mac, Linux, SunOS;
 }
 
 class Platform {
+    private final String nodeDownloadRoot;
     private final OS os;
     private final Architecture architecture;
+    private final String classifier;
 
     public Platform(OS os, Architecture architecture) {
+        this("https://nodejs.org/dist/", os, architecture, null);
+    }
+
+    public Platform(String nodeDownloadRoot, OS os, Architecture architecture, String classifier) {
+        this.nodeDownloadRoot = nodeDownloadRoot;
         this.os = os;
         this.architecture = architecture;
+        this.classifier = classifier;
     }
 
     public static Platform guess(){
         OS os = OS.guess();
         Architecture architecture = Architecture.guess();
-        return new Platform(os,architecture);
+        // The default libc is glibc, but Alpine uses musl. When not default, the nodejs download
+        // (and path within it) needs a classifier in the suffix (ex. -musl).
+        // We know Alpine is in use if the release file exists, and this is the simplest check.
+        if (os == OS.Linux && new File("/etc/alpine-release").exists()) {
+            return new Platform(
+                // Currently, musl is Experimental. The download root can be overridden with config
+                // if this changes and there's not been an update to this project, yet.
+                // See https://github.com/nodejs/node/blob/master/BUILDING.md#platform-list
+                "https://unofficial-builds.nodejs.org/download/release/",
+                os, architecture, "musl");
+        }
+        return new Platform(os, architecture);
+    }
+
+    public String getNodeDownloadRoot(){
+        return nodeDownloadRoot;
     }
 
     public String getArchiveExtension(){
@@ -110,6 +135,7 @@ class Platform {
     }
 
     public String getNodeClassifier() {
-        return this.getCodename() + "-" + this.architecture.name();
+        String result = getCodename() + "-" + architecture.name();
+        return classifier != null ? result + "-" + classifier : result;
     }
 }

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/PlatformTest.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/PlatformTest.java
@@ -1,0 +1,72 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import java.io.File;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyNoMoreInteractions;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Platform.class, OS.class, Architecture.class, File.class})
+public class PlatformTest {
+
+    @Test
+    public void detect_win_doesntLookForAlpine() {
+        mockStatic(OS.class);
+        mockStatic(Architecture.class);
+
+        when(OS.guess()).thenReturn(OS.Windows);
+        when(Architecture.guess()).thenReturn(Architecture.x86);
+
+        Platform platform = Platform.guess();
+        assertEquals("win-x86", platform.getNodeClassifier());
+
+        verifyNoMoreInteractions(File.class); // doesn't look for a file path
+    }
+
+    @Test
+    public void detect_linux_notAlpine() throws Exception {
+        mockStatic(OS.class);
+        mockStatic(Architecture.class);
+
+        when(OS.guess()).thenReturn(OS.Linux);
+        when(Architecture.guess()).thenReturn(Architecture.x86);
+
+        File alpineRelease = mock(File.class);
+        whenNew(File.class)
+                .withArguments("/etc/alpine-release").thenReturn(alpineRelease);
+
+        when(alpineRelease.exists()).thenReturn(false);
+
+        Platform platform = Platform.guess();
+        assertEquals("linux-x86", platform.getNodeClassifier());
+        assertEquals("https://nodejs.org/dist/", platform.getNodeDownloadRoot());
+    }
+
+    @Test
+    public void detect_linux_alpine() throws Exception {
+        mockStatic(OS.class);
+        mockStatic(Architecture.class);
+
+        when(OS.guess()).thenReturn(OS.Linux);
+        when(Architecture.guess()).thenReturn(Architecture.x86);
+
+        File alpineRelease = mock(File.class);
+        whenNew(File.class).withArguments("/etc/alpine-release")
+            .thenReturn(alpineRelease);
+
+        when(alpineRelease.exists()).thenReturn(true);
+
+        Platform platform = Platform.guess();
+        assertEquals("linux-x86-musl", platform.getNodeClassifier());
+        assertEquals("https://unofficial-builds.nodejs.org/download/release/",
+                platform.getNodeDownloadRoot());
+    }
+}


### PR DESCRIPTION
**Summary**

Alpine is a small OS distribution that supports JDK. Supporting Alpine
means less download time and cost when building projects in Docker.

This solves the same problem #853 did, via a different approach.

* Move the default download root to the `Platform` impl
* Allow a classifier (currently only musl, but there are others)
* Special case Alpine instead of generically

The above changes allow someone to override the download root regardless
of if the nodejs dist is experimental or not.

**Tests and Documentation**

This backfills tests for `Platform` using the same approach as we do in Brave
(powermock).
