### PR TITLE
Fix proxy parsing

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
@@ -41,7 +41,10 @@ final class DefaultNpmRunner extends NodeTaskExecutor implements NpmRunner {
 
             final String nonProxyHosts = proxy.getNonProxyHosts();
             if (nonProxyHosts != null && !nonProxyHosts.isEmpty()) {
-                arguments.add("--noproxy=" + nonProxyHosts.replace('|',','));
+                final String[] nonProxyHostList = nonProxyHosts.split("\\|");
+                for (String nonProxyHost: nonProxyHostList) {
+                    arguments.add("--noproxy=" + nonProxyHost.replace("*", ""));
+                }
             }
         }
         

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/DefaultNpmRunnerTest.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/DefaultNpmRunnerTest.java
@@ -19,8 +19,8 @@ public class DefaultNpmRunnerTest {
     private final int port = 8888;
     private final String username = "someusername";
     private final String password = "somepassword";
-    private final String nonProxyHosts = "www.google.ca|www.google.com";
-    private final String expectedNonProxyHosts = "www.google.ca,www.google.com";
+    private final String nonProxyHosts = "www.google.ca|www.google.com|*.google.de";
+    private final String[] expectedNonProxyHosts = new String[] {"www.google.ca","www.google.com",".google.de"};
     private final String registryUrl = "www.npm.org";
     private final String expectedUrl = "http://someusername:somepassword@localhost:8888";
 
@@ -30,9 +30,11 @@ public class DefaultNpmRunnerTest {
 
         assertThat(strings, CoreMatchers.hasItem("--proxy=" + expectedUrl));
         assertThat(strings, CoreMatchers.hasItem("--https-proxy=" + expectedUrl));
-        assertThat(strings, CoreMatchers.hasItem("--noproxy=" + expectedNonProxyHosts));
+        for (String expectedNonProxyHost: expectedNonProxyHosts) {
+            assertThat(strings, CoreMatchers.hasItem("--noproxy=" + expectedNonProxyHost));
+        }
         assertThat(strings, CoreMatchers.hasItem("--registry=" + registryUrl));
-        assertEquals(4, strings.size());
+        assertEquals(6, strings.size());
     }
 
 
@@ -42,8 +44,10 @@ public class DefaultNpmRunnerTest {
 
         assertThat(strings, CoreMatchers.hasItem("--proxy=" + expectedUrl));
         assertThat(strings, CoreMatchers.hasItem("--https-proxy=" + expectedUrl));
-        assertThat(strings, CoreMatchers.hasItem("--noproxy=" + expectedNonProxyHosts));
-        assertEquals(3, strings.size());
+        for (String expectedNonProxyHost: expectedNonProxyHosts) {
+            assertThat(strings, CoreMatchers.hasItem("--noproxy=" + expectedNonProxyHost));
+        }
+        assertEquals(5, strings.size());
     }
 
     @Test
@@ -52,8 +56,10 @@ public class DefaultNpmRunnerTest {
 
         assertThat(strings, CoreMatchers.hasItem("--proxy=" + expectedUrl));
         assertThat(strings, CoreMatchers.hasItem("--https-proxy=" + expectedUrl));
-        assertThat(strings, CoreMatchers.hasItem("--noproxy=" + expectedNonProxyHosts));
-        assertEquals(3, strings.size());
+        for (String expectedNonProxyHost: expectedNonProxyHosts) {
+            assertThat(strings, CoreMatchers.hasItem("--noproxy=" + expectedNonProxyHost));
+        }
+        assertEquals(5, strings.size());
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

After fixing the proxy parsing (replacing | with ,) a friend of mine pointed me towards: https://npm.community/t/noproxy-setting-with-more-than-one-hostname/5054/3
So the comma separated String seems not to work from commandline. Hence this fix adds an extra parameter for every proxy exclusion.
I also noted that the npm documentation not mentions wildcards (seems to be a java thingy), so they are also removed when parsing the proxy settings.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Tests and Documentation**

<!-- Demonstrate the code is solid. Add a simple description to CHANGELOG.md and add some infos to README.md or Wiki, if necessary. -->
