### PR TITLE
Download x64 binary on Apple Silicon

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
@@ -135,7 +135,12 @@ class Platform {
     }
 
     public String getNodeClassifier() {
-        String result = getCodename() + "-" + architecture.name();
+        final String result;
+        if(isMac() && architecture == Architecture.arm64) { // this check is required to download the x64 binary until there is an arm64 version available for macOS (darwin).
+            result = getCodename() + "-" + Architecture.x64.name();
+        } else {
+            result = getCodename() + "-" + architecture.name();
+        }
         return classifier != null ? result + "-" + classifier : result;
     }
 }

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/PlatformTest.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/PlatformTest.java
@@ -32,6 +32,18 @@ public class PlatformTest {
     }
 
     @Test
+    public void detect_arm_mac_download_x64_binary() {
+        mockStatic(OS.class);
+        mockStatic(Architecture.class);
+
+        when(OS.guess()).thenReturn(OS.Mac);
+        when(Architecture.guess()).thenReturn(Architecture.arm64);
+
+        Platform platform = Platform.guess();
+        assertEquals("darwin-x64", platform.getNodeClassifier());
+    }
+
+    @Test
     public void detect_linux_notAlpine() throws Exception {
         mockStatic(OS.class);
         mockStatic(Architecture.class);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I have been testing out an Apple Silicon Mac mini. I am using the Azul Zulu arm64 OpenJDK (JDK 8). This change tells the plugin to download the x64 version of Node on macOS, which should run fine under Rosetta. 

I'm happy to write up an issue also, if you so desire! Thank you!

**Tests and Documentation**

When building using Maven on Apple Silicon, I receive an error, as the URL generated by the plugin doesn't work, since there is not currently (as of 12/15/2020) an arm64 version of Node for macOS. So, this uses a simple check when generating the download URL: if the OS is Mac, and the architecture is arm64, download the x64 binary.

```
[INFO] 
[INFO] --- frontend-maven-plugin:1.9.1:install-node-and-npm (install-npm) @ <<PROJECT NAME>> ---
[INFO] Installing node version v11.9.0
[INFO] Downloading https://nodejs.org/dist/v11.9.0/node-v11.9.0-darwin-arm64.tar.gz to /Users/localuser/.m2/repository/com/github/eirslett/node/11.9.0/node-11.9.0-darwin-arm64.tar.gz
[INFO] No proxies configured
[INFO] No proxy was configured, downloading directly
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.065 s
[INFO] Finished at: 2020-12-15T13:10:54-08:00
[INFO] Final Memory: 29M/359M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.9.1:install-node-and-npm (install-npm) on project <<PROJECT NAME>>: Could not download Node.js: Got error code 404 from the server. -> [Help 1]
```

<!-- Demonstrate the code is solid. Add a simple description to CHANGELOG.md and add some infos to README.md or Wiki, if necessary. -->
