### PR TITLE
Add m2e support for npm, npx and yarn goals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 
 ## Changelog
 
+### 1.12.0
+
+* Add m2e support for npm, npx and yarn goals
+
 ### 1.11.0
 
 * Upgrade Jackson dependency to Jackson 2.9.10

--- a/README.md
+++ b/README.md
@@ -517,10 +517,10 @@ Tools and property to enable skipping
 ## Eclipse M2E support
 
 This plugin contains support for M2E, including lifecycle mappings and support for incremental builds in Eclipse.
-The `install-node-and-npm` goal will only run on a full project build. The other goals support incremental builds
-to avoid doing unnecessary work. During an incremental build the `npm` goal will only run if the `package.json` file
-has been changed. The `grunt` and `gulp` goals have new `srcdir` and `triggerfiles` optional configuration options; if
-these are set they check for changes in your source files before being run. See the wiki for more information.
+The `install-node-and-npm` and `install-node-and-yarn` goals will only run on a full project build. The other goals support incremental builds
+to avoid doing unnecessary work. Most goals have `srcdir` and `triggerfiles` optional configuration options; if
+these are set they check for changes in your source files before being run. By default, during an incremental build
+the `npm` and `yarn` goals will only run if the `package.json` file has been changed. See the wiki for more information.
 
 ## Helper scripts
 

--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -60,7 +60,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.3</version>
         <configuration>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
         </configuration>

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/EmberMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/EmberMojo.java
@@ -11,12 +11,13 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Mojo(name="ember", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public final class EmberMojo extends AbstractFrontendMojo {
 
     /**
-     * Grunt arguments. Default is empty (runs just the "grunt" command).
+     * Ember arguments. Default is empty (runs just the "ember" command).
      */
     @Parameter(property = "frontend.ember.arguments")
     private String arguments;
@@ -64,11 +65,13 @@ public final class EmberMojo extends AbstractFrontendMojo {
             factory.getEmberRunner().execute(arguments, environmentVariables);
 
             if (outputdir != null) {
-                getLog().info("Refreshing files after ember: " + outputdir);
+                getLog().info("Refreshing files after 'ember" + (arguments != null ? " " + arguments : "") + "': " + outputdir);
                 buildContext.refresh(outputdir);
             }
         } else {
-            getLog().info("Skipping ember as no modified files in " + srcdir);
+            getLog().info("Skipping 'ember" + (arguments != null ? " " + arguments : "") + "' as "
+                    + triggerfiles.stream().map(Object::toString).collect(Collectors.joining(", "))
+                    + " unchanged" + (srcdir != null ? " and no modified files in: " + srcdir : ""));
         }
     }
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GruntMojo.java
@@ -11,6 +11,7 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Mojo(name="grunt", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public final class GruntMojo extends AbstractFrontendMojo {
@@ -64,11 +65,13 @@ public final class GruntMojo extends AbstractFrontendMojo {
             factory.getGruntRunner().execute(arguments, environmentVariables);
 
             if (outputdir != null) {
-                getLog().info("Refreshing files after grunt: " + outputdir);
+                getLog().info("Refreshing files after 'grunt" + (arguments != null ? " " + arguments : "") + "': " + outputdir);
                 buildContext.refresh(outputdir);
             }
         } else {
-            getLog().info("Skipping grunt as no modified files in " + srcdir);
+            getLog().info("Skipping 'grunt" + (arguments != null ? " " + arguments : "") + "' as "
+                    + triggerfiles.stream().map(Object::toString).collect(Collectors.joining(", "))
+                    + " unchanged" + (srcdir != null ? " and no modified files in: " + srcdir : ""));
         }
     }
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/GulpMojo.java
@@ -11,6 +11,7 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Mojo(name="gulp", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public final class GulpMojo extends AbstractFrontendMojo {
@@ -64,11 +65,13 @@ public final class GulpMojo extends AbstractFrontendMojo {
             factory.getGulpRunner().execute(arguments, environmentVariables);
 
             if (outputdir != null) {
-                getLog().info("Refreshing files after gulp: " + outputdir);
+                getLog().info("Refreshing files after 'gulp" + (arguments != null ? " " + arguments : "") + "': " + outputdir);
                 buildContext.refresh(outputdir);
             }
         } else {
-            getLog().info("Skipping gulp as no modified files in " + srcdir);
+            getLog().info("Skipping 'gulp" + (arguments != null ? " " + arguments : "") + "' as "
+                    + triggerfiles.stream().map(Object::toString).collect(Collectors.joining(", "))
+                    + " unchanged" + (srcdir != null ? " and no modified files in: " + srcdir : ""));
         }
     }
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/MojoUtils.java
@@ -89,7 +89,7 @@ class MojoUtils {
     }
 
     if (srcdir == null) {
-      return true;
+      return triggerfiles == null;
     }
 
     // Check for changes in the srcdir

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -12,7 +12,10 @@ import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Mojo(name="npm",  defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public final class NpmMojo extends AbstractFrontendMojo {
@@ -44,6 +47,29 @@ public final class NpmMojo extends AbstractFrontendMojo {
     private SettingsDecrypter decrypter;
 
     /**
+     * Files that should be checked for changes, in addition to the srcdir files.
+     * Defaults to package.json in the {@link #workingDirectory}.
+     */
+    @Parameter(property = "triggerfiles")
+    private List<File> triggerfiles;
+
+    /**
+     * The directory containing front end files that will be processed by npm.
+     * If this is set then files in the directory will be checked for
+     * modifications before running npm.
+     */
+    @Parameter(property = "srcdir")
+    private File srcdir;
+
+    /**
+     * The directory where front end files will be output by npm. If this is
+     * set then they will be refreshed so they correctly show as modified in
+     * Eclipse.
+     */
+    @Parameter(property = "outputdir")
+    private File outputdir;
+
+    /**
      * Skips execution of this mojo.
      */
     @Parameter(property = "skip.npm", defaultValue = "${skip.npm}")
@@ -56,13 +82,27 @@ public final class NpmMojo extends AbstractFrontendMojo {
 
     @Override
     public synchronized void execute(FrontendPluginFactory factory) throws TaskRunnerException {
-        File packageJson = new File(workingDirectory, "package.json");
-        if (buildContext == null || buildContext.hasDelta(packageJson) || !buildContext.isIncremental()) {
+        if (shouldExecute()) {
             ProxyConfig proxyConfig = getProxyConfig();
             factory.getNpmRunner(proxyConfig, getRegistryUrl()).execute(arguments, environmentVariables);
+
+            if (outputdir != null) {
+                getLog().info("Refreshing files after 'npm" + (arguments != null ? " " + arguments : "") + "': " + outputdir);
+                buildContext.refresh(outputdir);
+            }
         } else {
-            getLog().info("Skipping npm install as package.json unchanged");
+            getLog().info("Skipping 'npm" + (arguments != null ? " " + arguments : "") + "' as "
+                    + triggerfiles.stream().map(Object::toString).collect(Collectors.joining(", "))
+                    + " unchanged" + (srcdir != null ? " and no modified files in: " + srcdir : ""));
         }
+    }
+
+    private boolean shouldExecute() {
+        if (triggerfiles == null || triggerfiles.isEmpty()) {
+            triggerfiles = Arrays.asList(new File(workingDirectory, "package.json"));
+        }
+
+        return MojoUtils.shouldExecute(buildContext, triggerfiles, srcdir);
     }
 
     private ProxyConfig getProxyConfig() {

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/WebpackMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/WebpackMojo.java
@@ -11,6 +11,7 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Mojo(name="webpack", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public final class WebpackMojo extends AbstractFrontendMojo {
@@ -64,11 +65,13 @@ public final class WebpackMojo extends AbstractFrontendMojo {
             factory.getWebpackRunner().execute(arguments, environmentVariables);
 
             if (outputdir != null) {
-                getLog().info("Refreshing files after webpack: " + outputdir);
+                getLog().info("Refreshing files after 'webpack" + (arguments != null ? " " + arguments : "") + "': " + outputdir);
                 buildContext.refresh(outputdir);
             }
         } else {
-            getLog().info("Skipping webpack as no modified files in " + srcdir);
+            getLog().info("Skipping 'webpack" + (arguments != null ? " " + arguments : "") + "' as "
+                    + triggerfiles.stream().map(Object::toString).collect(Collectors.joining(", "))
+                    + " unchanged" + (srcdir != null ? " and no modified files in: " + srcdir : ""));
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Adds support for running scripts when source files change without having to bump the package.json

My specific use case is automatically rebuilding an Angular frontend when its source is modified.

Theoretically the common functionality between EmberMojo, GruntMojo, GulpMojo, NpmMojo, NpxMojo, WebpackMojo, and YarnMojo could be factored out into a new class, but for now I've only endeavored to make their behavior consistent.

Resolves #932
Fixes #329, Closes #682 (included)

**Tests and Documentation**

<!-- Demonstrate the code is solid. Add a simple description to CHANGELOG.md and add some infos to README.md or Wiki, if necessary. -->

Tests passed. (Not that there is coverage anyway.)

Updated CHANGELOG.md and README.md
I can update the Wiki on merge.