### PR TITLE
Support arm64 binaries since Node.js v16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 
 ## Changelog
 
-### 1.11.2
-
+### 1.11.4
+* Support node arm64 binaries since v16 major release
 
 ### 1.11.1
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
@@ -128,7 +128,7 @@ public class NodeInstaller {
                 this.config.getPlatform().getLongNodeFilename(this.nodeVersion, false);
             String downloadUrl = this.nodeDownloadRoot
                 + this.config.getPlatform().getNodeDownloadFilename(this.nodeVersion, false);
-            String classifier = this.config.getPlatform().getNodeClassifier();
+            String classifier = this.config.getPlatform().getNodeClassifier(this.nodeVersion);
 
             File tmpDirectory = getTempDirectory();
 
@@ -216,7 +216,7 @@ public class NodeInstaller {
                 this.config.getPlatform().getLongNodeFilename(this.nodeVersion, true);
             String downloadUrl = this.nodeDownloadRoot
                 + this.config.getPlatform().getNodeDownloadFilename(this.nodeVersion, true);
-            String classifier = this.config.getPlatform().getNodeClassifier();
+            String classifier = this.config.getPlatform().getNodeClassifier(this.nodeVersion);
 
             File tmpDirectory = getTempDirectory();
 
@@ -274,7 +274,7 @@ public class NodeInstaller {
 
             File destination = new File(destinationDirectory, "node.exe");
 
-            String classifier = this.config.getPlatform().getNodeClassifier();
+            String classifier = this.config.getPlatform().getNodeClassifier(this.nodeVersion);
 
             CacheDescriptor cacheDescriptor =
                 new CacheDescriptor("node", this.nodeVersion, classifier, "exe");

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/PlatformTest.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/PlatformTest.java
@@ -17,6 +17,10 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 @PrepareForTest({Platform.class, OS.class, Architecture.class, File.class})
 public class PlatformTest {
 
+    private static final String NODE_VERSION_8 = "v8.17.2";
+    private static final String NODE_VERSION_15 = "v15.14.0";
+    private static final String NODE_VERSION_16 = "v16.1.0";
+
     @Test
     public void detect_win_doesntLookForAlpine() {
         mockStatic(OS.class);
@@ -26,13 +30,13 @@ public class PlatformTest {
         when(Architecture.guess()).thenReturn(Architecture.x86);
 
         Platform platform = Platform.guess();
-        assertEquals("win-x86", platform.getNodeClassifier());
+        assertEquals("win-x86", platform.getNodeClassifier(NODE_VERSION_15));
 
         verifyNoMoreInteractions(File.class); // doesn't look for a file path
     }
 
     @Test
-    public void detect_arm_mac_download_x64_binary() {
+    public void detect_arm_mac_download_x64_binary_node15() {
         mockStatic(OS.class);
         mockStatic(Architecture.class);
 
@@ -40,7 +44,19 @@ public class PlatformTest {
         when(Architecture.guess()).thenReturn(Architecture.arm64);
 
         Platform platform = Platform.guess();
-        assertEquals("darwin-x64", platform.getNodeClassifier());
+        assertEquals("darwin-x64", platform.getNodeClassifier(NODE_VERSION_15));
+    }
+
+    @Test
+    public void detect_arm_mac_download_x64_binary_node16() {
+        mockStatic(OS.class);
+        mockStatic(Architecture.class);
+
+        when(OS.guess()).thenReturn(OS.Mac);
+        when(Architecture.guess()).thenReturn(Architecture.arm64);
+
+        Platform platform = Platform.guess();
+        assertEquals("darwin-arm64", platform.getNodeClassifier(NODE_VERSION_16));
     }
 
     @Test
@@ -58,7 +74,7 @@ public class PlatformTest {
         when(alpineRelease.exists()).thenReturn(false);
 
         Platform platform = Platform.guess();
-        assertEquals("linux-x86", platform.getNodeClassifier());
+        assertEquals("linux-x86", platform.getNodeClassifier(NODE_VERSION_15));
         assertEquals("https://nodejs.org/dist/", platform.getNodeDownloadRoot());
     }
 
@@ -77,7 +93,7 @@ public class PlatformTest {
         when(alpineRelease.exists()).thenReturn(true);
 
         Platform platform = Platform.guess();
-        assertEquals("linux-x86-musl", platform.getNodeClassifier());
+        assertEquals("linux-x86-musl", platform.getNodeClassifier(NODE_VERSION_15));
         assertEquals("https://unofficial-builds.nodejs.org/download/release/",
                 platform.getNodeDownloadRoot());
     }
@@ -91,6 +107,14 @@ public class PlatformTest {
         when(Architecture.guess()).thenReturn(Architecture.ppc64);
 
         Platform platform = Platform.guess();
-        assertEquals("aix-ppc64", platform.getNodeClassifier());
+        assertEquals("aix-ppc64", platform.getNodeClassifier(NODE_VERSION_15));
     }
+
+    @Test
+    public void getNodeMajorVersion() {
+        assertEquals(Integer.valueOf(8), Platform.getNodeMajorVersion(NODE_VERSION_8));
+        assertEquals(Integer.valueOf(15), Platform.getNodeMajorVersion(NODE_VERSION_15));
+        assertEquals(Integer.valueOf(16), Platform.getNodeMajorVersion(NODE_VERSION_16));
+    }
+
 }


### PR DESCRIPTION
**Summary**
Node.js supports native arm64 binary release since v16:
https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V16.md#toolchain-and-compiler-upgrades
For example, you can see `darwin-arm64` releases here: https://nodejs.org/download/release/v16.0.0/

Old logic: for mac arm64 always prefer x64 instead.
New logic: for mac arm64 prefer arm64 since node v16, otherwise fallback to old behavior.
