### PR TITLE
Copying npx scripts for embedded node

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NPMInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NPMInstaller.java
@@ -185,7 +185,7 @@ public class NPMInstaller {
         File nodeModulesDirectory = new File(installDirectory, "node_modules");
         File npmDirectory = new File(nodeModulesDirectory, "npm");
         // create a copy of the npm scripts next to the node executable
-        for (String script : Arrays.asList("npm", "npm.cmd")) {
+        for (String script : Arrays.asList("npm", "npm.cmd", "npx", "npx.cmd")) {
             File scriptFile = new File(npmDirectory, "bin" + File.separator + script);
             if (scriptFile.exists()) {
                 File copy = new File(installDirectory, script);


### PR DESCRIPTION
**Summary**

Copies npx scripts along with npm ones to be able to run preinstall script from package.json that uses npx.

Resolves [#1002](https://github.com/eirslett/frontend-maven-plugin/issues/1002)