### PR TITLE
ensure mojos are ignoring pom packaging

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
@@ -1,6 +1,7 @@
 package com.github.eirslett.maven.plugins.frontend.mojo;
 
 import java.io.File;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.plugin.AbstractMojo;
@@ -53,6 +54,12 @@ public abstract class AbstractFrontendMojo extends AbstractMojo {
     @Parameter
     protected Map<String, String> environmentVariables;
 
+    /**
+     * Whether you should skip while running in the test phase (default is false)
+     */
+    @Parameter(property = "frontend.ignoredPackagings", defaultValue = "pom")
+    protected List<String> ignoredPackagings;
+
     @Parameter(defaultValue = "${project}", readonly = true)
     private MavenProject project;
 
@@ -83,6 +90,10 @@ public abstract class AbstractFrontendMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoFailureException {
+        if (ignoredPackagings != null && project != null && ignoredPackagings.contains(project.getPackaging())) {
+            getLog().info("Ignoring execution for packaging " + project.getPackaging());
+            return;
+        }
         if (testFailureIgnore && !isTestingPhase()) {
             getLog().info("testFailureIgnore property is ignored in non test phases");
         }


### PR DESCRIPTION
**Summary**

For a hierachy of modules using the same lifecycle (install node, npm install etc), it is today hard to define it until you do a maven extension whereas defining it in the parent would be convenient.
This PR defines ignored packaging - default to pom - which enables this use case.

**Tests and Documentation**

Didn't write yet cause I think an IT is too hard to write and didn't find any unit test so any help if you think it is worth it for such a simple test would be welcomed.


**Sample usage**

```
<plugin>
  <groupId>com.github.eirslett</groupId>
  <artifactId>frontend-maven-plugin</artifactId>
  <version>1.12.1-SNAPSHOT</version>
  <executions>
    <execution>
      <id>install-node-npm</id>
      <phase>generate-resources</phase>
      <goals>
        <goal>install-node-and-npm</goal>
      </goals>
      <configuration> <!-- install it once in the parent -->
        <installDirectory>${project.basedir}/.node</installDirectory>
        <nodeVersion>v17.0.1</nodeVersion>
        <npmVersion>8.1.0</npmVersion>
        <ignoredPackagings> <!-- ignore in children -->
          <ignoredPackaging>jar</ignoredPackaging>
        </ignoredPackagings>
      </configuration>
    </execution>
    <execution>
      <id>npm-install</id>
      <phase>process-classes</phase>
      <goals>
        <goal>npm</goal>
      </goals>
    </execution>
    <execution>
      <id>npm-build</id>
      <phase>process-classes</phase>
      <goals>
        <goal>npm</goal>
      </goals>
      <configuration>
        <arguments>run build</arguments>
      </configuration>
    </execution>
  </executions>
  <configuration> <!-- for children, reuse parent installation of node and run the build in child module -->
    <installDirectory>${project.parent.basedir}/.node</installDirectory>
    <workingDirectory>${project.basedir}</workingDirectory>
  </configuration>
</plugin>
```