### PR TITLE
Added Yarn Berry compatibility flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 
 * update Dependency: Jackson (2.13.0), Mockito (4.1.0), JUnit (5.8.1), Hamcrest (2.2; now a direct dependency)
 * remove Dependency: Powermock
+* Added compatibility mode for Yarn 2.x and above (Berry)
 
 ### 1.11.4
 * Support node arm64 binaries since v16 major release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 
 * update Dependency: Jackson (2.13.0), Mockito (4.1.0), JUnit (5.8.1), Hamcrest (2.2; now a direct dependency)
 * remove Dependency: Powermock
-* Added compatibility mode for Yarn 2.x and above (Berry)
+* Added better support for Yarn 2.x and above (Berry)
 
 ### 1.11.4
 * Support node arm64 binaries since v16 major release

--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ Node/Yarn will only be "installed" locally to your project.
 It will not be installed globally on the whole system (and it will not interfere with any Node/Yarn installations already 
 present). 
 
+If your project is using Yarn Berry (2.x or above), the Yarn version is handled per project but a Yarn 1.x install is still needed as a "bootstrap".
+Set the `isYarnBerry` flag to `true` to enable compatibility mode for this plugin. It will install the 1.x Yarn version you specify with `yarnVersion` as bootstrap, then hand over to your project-specific version.   
+
 Have a look at the example `POM` to see how it should be set up with Yarn: 
 https://github.com/eirslett/frontend-maven-plugin/blob/master/frontend-maven-plugin/src/it/yarn-integration/pom.xml
 
@@ -158,6 +161,7 @@ https://github.com/eirslett/frontend-maven-plugin/blob/master/frontend-maven-plu
     <configuration>
         <nodeVersion>v6.9.1</nodeVersion>
         <yarnVersion>v0.16.1</yarnVersion>
+        <isYarnBerry>true</isYarnBerry>
 
         <!-- optional: where to download node from. Defaults to https://nodejs.org/dist/ -->
         <nodeDownloadRoot>http://myproxy.example.org/nodejs/</nodeDownloadRoot>

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ It will not be installed globally on the whole system (and it will not interfere
 present). 
 
 If your project is using Yarn Berry (2.x or above), the Yarn version is handled per project but a Yarn 1.x install is still needed as a "bootstrap".
-The plugin will try to detect `.yarnrc.yaml` file in the current Maven project/module folder, at the root of the multi-module project if relevant, and in the folder from which the `mvn` command was run. 
+The plugin will try to detect `.yarnrc.yml` file in the current Maven project/module folder, at the root of the multi-module project if relevant, and in the folder from which the `mvn` command was run. 
 If detected, the plugin will assume your project is using Yarn Berry. It will install the 1.x Yarn version you specify with `yarnVersion` as bootstrap, then hand over to your project-specific version.   
 
 Have a look at the example `POM` to see how it should be set up with Yarn: 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ It will not be installed globally on the whole system (and it will not interfere
 present). 
 
 If your project is using Yarn Berry (2.x or above), the Yarn version is handled per project but a Yarn 1.x install is still needed as a "bootstrap".
-Set the `isYarnBerry` flag to `true` to enable compatibility mode for this plugin. It will install the 1.x Yarn version you specify with `yarnVersion` as bootstrap, then hand over to your project-specific version.   
+The plugin will try to detect `.yarnrc.yaml` file in the current Maven project/module folder, at the root of the multi-module project if relevant, and in the folder from which the `mvn` command was run. 
+If detected, the plugin will assume your project is using Yarn Berry. It will install the 1.x Yarn version you specify with `yarnVersion` as bootstrap, then hand over to your project-specific version.   
 
 Have a look at the example `POM` to see how it should be set up with Yarn: 
 https://github.com/eirslett/frontend-maven-plugin/blob/master/frontend-maven-plugin/src/it/yarn-integration/pom.xml
@@ -161,7 +162,6 @@ https://github.com/eirslett/frontend-maven-plugin/blob/master/frontend-maven-plu
     <configuration>
         <nodeVersion>v6.9.1</nodeVersion>
         <yarnVersion>v0.16.1</yarnVersion>
-        <isYarnBerry>true</isYarnBerry>
 
         <!-- optional: where to download node from. Defaults to https://nodejs.org/dist/ -->
         <nodeDownloadRoot>http://myproxy.example.org/nodejs/</nodeDownloadRoot>

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
@@ -1,5 +1,7 @@
 package com.github.eirslett.maven.plugins.frontend.mojo;
 
+import java.io.File;
+import java.util.stream.Stream;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -15,6 +17,8 @@ import com.github.eirslett.maven.plugins.frontend.lib.YarnInstaller;
 
 @Mojo(name = "install-node-and-yarn", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
+
+    private static final String YARNRC_YAML_FILE_NAME = ".yarnrc.yml";
 
     /**
      * Where to download Node.js binary from. Defaults to https://nodejs.org/dist/
@@ -43,12 +47,6 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
     private String yarnVersion;
 
     /**
-     * If Yarn Berry is used in the project
-     */
-    @Parameter(property = "isYarnBerry", required = false)
-    private boolean isYarnBerry;
-
-    /**
      * Server Id for download username and password
      */
     @Parameter(property = "serverId", defaultValue = "")
@@ -71,6 +69,22 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
         return this.skip;
     }
 
+    /**
+     * Checks whether a .yarnrc.yml file exists at the project root (in multi-module builds, it will be the Reactor project)
+     *
+     * @return true if the .yarnrc.yml file exists, false otherwise
+     */
+    private boolean isYarnrcYamlFilePresent() {
+        Stream<File> filesToCheck = Stream.of(
+                new File(session.getCurrentProject().getBasedir(), YARNRC_YAML_FILE_NAME),
+                new File(session.getRequest().getMultiModuleProjectDirectory(), YARNRC_YAML_FILE_NAME),
+                new File(session.getExecutionRootDirectory(), YARNRC_YAML_FILE_NAME)
+        );
+
+        return filesToCheck
+                .anyMatch(File::exists);
+    }
+
     @Override
     public void execute(FrontendPluginFactory factory) throws InstallationException {
         ProxyConfig proxyConfig = MojoUtils.getProxyConfig(this.session, this.decrypter);
@@ -81,12 +95,12 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
                 .setUserName(server.getUsername()).install();
             factory.getYarnInstaller(proxyConfig).setYarnDownloadRoot(this.yarnDownloadRoot)
                 .setYarnVersion(this.yarnVersion).setUserName(server.getUsername())
-                .setPassword(server.getPassword()).setIsYarnBerry(isYarnBerry).install();
+                .setPassword(server.getPassword()).setIsYarnBerry(isYarnrcYamlFilePresent()).install();
         } else {
             factory.getNodeInstaller(proxyConfig).setNodeDownloadRoot(this.nodeDownloadRoot)
                 .setNodeVersion(this.nodeVersion).install();
             factory.getYarnInstaller(proxyConfig).setYarnDownloadRoot(this.yarnDownloadRoot)
-                .setYarnVersion(this.yarnVersion).setIsYarnBerry(isYarnBerry).install();
+                .setYarnVersion(this.yarnVersion).setIsYarnBerry(isYarnrcYamlFilePresent()).install();
         }
     }
 

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
@@ -43,6 +43,12 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
     private String yarnVersion;
 
     /**
+     * If Yarn Berry is used in the project
+     */
+    @Parameter(property = "isYarnBerry", required = false)
+    private boolean isYarnBerry;
+
+    /**
      * Server Id for download username and password
      */
     @Parameter(property = "serverId", defaultValue = "")
@@ -75,12 +81,12 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
                 .setUserName(server.getUsername()).install();
             factory.getYarnInstaller(proxyConfig).setYarnDownloadRoot(this.yarnDownloadRoot)
                 .setYarnVersion(this.yarnVersion).setUserName(server.getUsername())
-                .setPassword(server.getPassword()).install();
+                .setPassword(server.getPassword()).setIsYarnBerry(isYarnBerry).install();
         } else {
             factory.getNodeInstaller(proxyConfig).setNodeDownloadRoot(this.nodeDownloadRoot)
                 .setNodeVersion(this.nodeVersion).install();
             factory.getYarnInstaller(proxyConfig).setYarnDownloadRoot(this.yarnDownloadRoot)
-                .setYarnVersion(this.yarnVersion).install();
+                .setYarnVersion(this.yarnVersion).setIsYarnBerry(isYarnBerry).install();
         }
     }
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnInstaller.java
@@ -23,6 +23,8 @@ public class YarnInstaller {
 
     private String yarnVersion, yarnDownloadRoot, userName, password;
 
+    private boolean isYarnBerry;
+
     private final Logger logger;
 
     private final InstallConfig config;
@@ -40,6 +42,11 @@ public class YarnInstaller {
 
     public YarnInstaller setYarnVersion(String yarnVersion) {
         this.yarnVersion = yarnVersion;
+        return this;
+    }
+
+    public YarnInstaller setIsYarnBerry(boolean isYarnBerry) {
+        this.isYarnBerry = isYarnBerry;
         return this;
     }
 
@@ -85,8 +92,13 @@ public class YarnInstaller {
                     logger.info("Yarn {} is already installed.", version);
                     return true;
                 } else {
-                    logger.info("Yarn {} was installed, but we need version {}", version, yarnVersion);
-                    return false;
+                    if (isYarnBerry && Integer.parseInt(version.split("\\.")[0]) > 1) {
+                        logger.info("Yarn Berry {} is installed.", version);
+                        return true;
+                    } else{
+                        logger.info("Yarn {} was installed, but we need version {}", version, yarnVersion);
+                        return false;
+                    }
                 }
             } else {
                 return false;


### PR DESCRIPTION
**Summary**

Fixes #928.
Added a compatibility flag for Yarn 2.x and above (Berry) so maven-frontend-plugin doesn't consider reported version as invalid anymore and doesn't try to re-install Yarn every time it runs.

**Tests and Documentation**

Updated CHANGELOG.md and README.md with details about the new flag