### PR TITLE
Add support to use the system wide installation of node.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 
 * update Dependency: Jackson (2.13.0), Mockito (4.1.0), JUnit (5.8.1), Hamcrest (2.2; now a direct dependency)
 * remove Dependency: Powermock
+* Add Option `useSystemNode` (true/false) which will use the system wide installation of node.js and npm. If you use that make sure you have all the tools in the PATH.
 
 ### 1.11.4
 * Support node arm64 binaries since v16 major release

--- a/README.md
+++ b/README.md
@@ -167,6 +167,25 @@ https://github.com/eirslett/frontend-maven-plugin/blob/master/frontend-maven-plu
 </plugin>
 ```
 
+### Omitting the installation using the locally installed environment
+
+When you use the system node installation, the plugin will try to detect your local Node.js
+installation in the system PATH and it will auto detect the npm_modules directory for that system.
+If you set that flag, the specific version will not be ensured!
+
+Using this setup is recommended in restricted environments, where you cannot download node or
+where you would download it all over the time, such as build servers,
+where you can ensure the version by a build container for example.
+
+```xml
+<plugin>
+    ...
+    <configuration>
+        <useSystemNode>true</useSystemNode>       
+    </configuration>
+</plugin>
+```
+
 ### Running npm
 
 All node packaged modules will be installed in the `node_modules` folder in your [working directory](#working-directory).
@@ -556,4 +575,3 @@ You can find a full list of [contributors here](https://github.com/eirslett/fron
 ## License
 
 [Apache 2.0](LICENSE)
-

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
@@ -27,6 +27,12 @@ public abstract class AbstractFrontendMojo extends AbstractMojo {
     protected Boolean skipTests;
 
     /**
+     * Whether the OS provided npm should be used (must be in PATH)
+     */
+    @Parameter(property = "useSystemNode", required = false, defaultValue = "false")
+    protected Boolean useSystemNode;
+
+    /**
      * Set this to true to ignore a failure during testing. Its use is NOT RECOMMENDED, but quite convenient on
      * occasion.
      *
@@ -92,7 +98,7 @@ public abstract class AbstractFrontendMojo extends AbstractMojo {
             }
             try {
                 execute(new FrontendPluginFactory(workingDirectory, installDirectory,
-                        new RepositoryCacheResolver(repositorySystemSession)));
+                        new RepositoryCacheResolver(repositorySystemSession), useSystemNode));
             } catch (TaskRunnerException e) {
                 if (testFailureIgnore && isTestingPhase()) {
                     getLog().error("There are test failures.\nFailed to run task: " + e.getMessage(), e);

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -10,15 +10,18 @@ public final class FrontendPluginFactory {
     private final File workingDirectory;
     private final File installDirectory;
     private final CacheResolver cacheResolver;
+    private final boolean useSystemNode;
 
-    public FrontendPluginFactory(File workingDirectory, File installDirectory){
-        this(workingDirectory, installDirectory, getDefaultCacheResolver(installDirectory));
+    public FrontendPluginFactory(File workingDirectory, File installDirectory, boolean useSystemNode){
+        this(workingDirectory, installDirectory, getDefaultCacheResolver(installDirectory), useSystemNode);
     }
 
-    public FrontendPluginFactory(File workingDirectory, File installDirectory, CacheResolver cacheResolver){
+    public FrontendPluginFactory(File workingDirectory, File installDirectory, CacheResolver cacheResolver,
+                                 boolean useSystemNode){
         this.workingDirectory = workingDirectory;
         this.installDirectory = installDirectory;
         this.cacheResolver = cacheResolver;
+        this.useSystemNode = useSystemNode;
     }
 
     public NodeInstaller getNodeInstaller(ProxyConfig proxy) {
@@ -82,11 +85,15 @@ public final class FrontendPluginFactory {
     }
 
     private NodeExecutorConfig getExecutorConfig() {
-        return new InstallNodeExecutorConfig(getInstallConfig());
+        if (getInstallConfig().isUseSystemNode()) {
+            return new NodeSystemExecuterConfig(getInstallConfig());
+        } else{
+            return new InstallNodeExecutorConfig(getInstallConfig());
+        }
     }
 
     private InstallConfig getInstallConfig() {
-        return new DefaultInstallConfig(installDirectory, workingDirectory, cacheResolver, defaultPlatform);
+        return new DefaultInstallConfig(installDirectory, workingDirectory, cacheResolver, defaultPlatform, useSystemNode);
     }
 
     private static final CacheResolver getDefaultCacheResolver(File root) {

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/InstallConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/InstallConfig.java
@@ -7,6 +7,7 @@ public interface InstallConfig {
   File getWorkingDirectory();
   CacheResolver getCacheResolver();
   Platform getPlatform();
+  boolean isUseSystemNode();
 }
 
 final class DefaultInstallConfig implements InstallConfig {
@@ -15,15 +16,18 @@ final class DefaultInstallConfig implements InstallConfig {
   private final File workingDirectory;
   private final CacheResolver cacheResolver;
   private final Platform platform;
+  private final boolean useSystemNode;
   
   public DefaultInstallConfig(File installDirectory,
                               File workingDirectory,
                               CacheResolver cacheResolver,
-                              Platform platform) {
+                              Platform platform,
+                              boolean useSystemNode) {
     this.installDirectory = installDirectory;
     this.workingDirectory = workingDirectory;
     this.cacheResolver = cacheResolver;
     this.platform = platform;
+    this.useSystemNode = useSystemNode;
   }
 
   @Override
@@ -45,4 +49,8 @@ final class DefaultInstallConfig implements InstallConfig {
     return this.platform;
   }
 
+  @Override
+  public boolean isUseSystemNode() {
+    return useSystemNode;
+  }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutorConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutorConfig.java
@@ -1,6 +1,11 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 public interface NodeExecutorConfig {
   File getNodePath();
@@ -60,7 +65,108 @@ final class InstallNodeExecutorConfig implements NodeExecutorConfig {
   public File getInstallDirectory() {
     return installConfig.getInstallDirectory();
   }
-  
+
+  @Override
+  public File getWorkingDirectory() {
+    return installConfig.getWorkingDirectory();
+  }
+
+  @Override
+  public Platform getPlatform() {
+    return installConfig.getPlatform();
+  }
+}
+
+final class NodeSystemExecuterConfig implements NodeExecutorConfig {
+  private final String nodeExecutable;
+  private final String npmExecutable;
+
+
+  private final String npm;
+  private final String pnpm;
+  private final String pnpmCjs;
+  private final String npx;
+
+  private final InstallConfig installConfig;
+
+  public NodeSystemExecuterConfig(InstallConfig installConfig) {
+    this.installConfig = installConfig;
+    String nodeBinaryName = getPlatform().isWindows() ? "node.exe" : "node";
+    String environmentSeparator = getPlatform().isWindows() ? ";" : ":";
+    String npmCliName = getPlatform().isWindows() ? "npm.cmd" : "npm";
+
+    nodeExecutable = getPathOfExecutable(nodeBinaryName, environmentSeparator);
+    npmExecutable = getPathOfExecutable(npmCliName, environmentSeparator);
+
+
+    String systemLibDir = findGloballyInstalledPackages();
+
+
+    npm = systemLibDir + "/npm/bin/npm-cli.js";
+    pnpm = systemLibDir + "/pnpm/bin/pnpm.js";
+    pnpmCjs = systemLibDir + "/pnpm/bin/pnpm.cjs";
+    npx = systemLibDir + "/npm/bin/npx-cli.js";
+  }
+
+  private String findGloballyInstalledPackages() {
+    String systemLibDir;
+    try {
+      Runtime runtime = Runtime.getRuntime();
+      Process process = runtime.exec(new String[]{npmExecutable, "root", "-g"});
+      try (BufferedReader br = new BufferedReader(
+              new InputStreamReader(process.getInputStream(),
+              StandardCharsets.UTF_8))) {
+        systemLibDir = br.readLine().trim();
+      }
+      process.destroy();
+    } catch (IOException | NullPointerException e) {
+      throw new IllegalStateException("NPM cannot be executed!", e);
+    }
+    return systemLibDir;
+  }
+
+  private String getPathOfExecutable(String binaryName, String environmentSeparator) {
+    return Arrays.stream(System.getenv("PATH").split(environmentSeparator))
+            .map(File::new)
+            .filter(File::isDirectory)
+            .map(file -> new File(file.getAbsolutePath() + File.separator + binaryName))
+            .filter(File::exists)
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException(binaryName + " was not found on the system"))
+            .getAbsolutePath();
+  }
+
+  @Override
+  public File getNodePath() {
+    return new File(nodeExecutable);
+  }
+
+  @Override
+  public File getNpmPath() {
+    return new File(Utils.normalize(npm));
+  }
+
+
+  @Override
+  public File getPnpmPath() {
+    return new File(Utils.normalize(pnpm));
+  }
+
+  @Override
+  public File getPnpmCjsPath() {
+    return new File(Utils.normalize(pnpmCjs));
+  }
+
+  @Override
+  public File getNpxPath() {
+    return new File(Utils.normalize(npx));
+  }
+
+  @Override
+  public File getInstallDirectory() {
+    return new File(nodeExecutable);
+  }
+
   @Override
   public File getWorkingDirectory() {
     return installConfig.getWorkingDirectory();

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,9 @@
             <id>release</id>
             <properties>
                 <gpg.executable>gpg</gpg.executable>
+                <!--suppress UnresolvedMavenProperty -->
                 <gpg.keyname>${env.GPG_KEYNAME}</gpg.keyname>
+                <!--suppress UnresolvedMavenProperty -->
                 <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
             </properties>
             <build>


### PR DESCRIPTION
**Summary**

This allows to use the node.js version provided by the operating system (installed via pacman, apt, dnf, whatever).


* In a restricted environment, It is very uncommon that you can download arbitrary executables from all over the internet
* It saves bandwidth of the build server since we don't have to download the npm and node in every build


**Tests and Documentation**

I guess this is hard to test as it heavily depends on the underlying operating system and it makes no sense to mock everything away. However I updated all relevant documentation.
