### PR TITLE
Add npm-login goal to authenticate in private npm repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 ## Changelog
 
 ### 1.12.1
+Add npm-login goal to authenticate in private npm repository
+
+### 1.12.1
 
 * update Dependency: Jackson (2.13.0), Mockito (4.1.0), JUnit (5.8.1), Hamcrest (2.2; now a direct dependency)
 * remove Dependency: Powermock

--- a/README.md
+++ b/README.md
@@ -403,6 +403,40 @@ will help to separate your frontend and backend builds even more.
 </execution>
 ```
 
+### Running Npm Login
+
+```xml
+<execution>
+    <id>npm login</id>
+    <goals>
+        <goal>npm-login</goal>
+    </goals>
+
+    <!-- optional: the default phase is "generate-resources" -->
+    <phase>generate-resources</phase>
+
+    <configuration>
+       <npmRegistryURL>https://npm-registry.com</npmRegistryURL>
+       <npmRegistryServerId>npm-registry</npmRegistryServerId>
+    </configuration>
+</execution>
+```
+
+and server section in ~/.m2/settings.xml
+```xml
+<?xml version="1.0"?>
+<settings>
+  ... 
+  <servers>
+    <server>
+      <id>npm-registry</id>
+        <username>username</username>
+        <password>password</password>
+    </server>
+  </servers>
+  ...
+```
+
 ### Optional Configuration 
 
 #### Working directory
@@ -533,6 +567,7 @@ Tools and property to enable skipping
 * jspm `-Dskip.jspm`
 * karma `-Dskip.karma`
 * webpack `-Dskip.webpack`
+* npm-login `-Dskip.npm-login`
 
 ## Eclipse M2E support
 

--- a/frontend-maven-plugin/src/it/npm-login/pom.xml
+++ b/frontend-maven-plugin/src/it/npm-login/pom.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.eirslett</groupId>
+    <artifactId>example</artifactId>
+    <version>0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-client-java</artifactId>
+            <version>5.11.2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <executions>
+                    <execution>
+                        <id>npm-registry-mock-server-compile</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>generate random port</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>reserve-network-port</goal>
+                        </goals>
+                        <configuration>
+                            <randomPort>true</randomPort>
+                            <portNames>
+                                <name>npm.registry.port</name>
+                            </portNames>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>filter .npmrc zand verify.groovy</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.basedir}</outputDirectory>
+                            <overwrite>true</overwrite>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>verify.groovy</include>
+                                        <include>**/.npmrc</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.mock-server</groupId>
+                <artifactId>mockserver-maven-plugin</artifactId>
+                <version>5.11.2</version>
+                <configuration>
+                    <serverPort>${npm.registry.port}</serverPort>
+                    <logLevel>INFO</logLevel>
+                    <initializationClass>com.github.eirslett.maven.plugins.NpmRegistryMock</initializationClass>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>npm-registry-mock-server-start</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>npm-registry-mock-server-stop</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
+                <version>@project.version@</version>
+
+                <configuration>
+                    <installDirectory>target</installDirectory>
+                </configuration>
+
+                <executions>
+                    <execution>
+                        <id>npm login (empty)</id>
+                        <goals>
+                            <goal>npm-login</goal>
+                        </goals>
+                        <configuration>
+                            <npmRegistryURL>http://localhost:${npm.registry.port}</npmRegistryURL>
+                            <npmRegistryServerId>npm-registry</npmRegistryServerId>
+                            <!--ONLY FOR IT TEST-->
+                            <userHome>${project.basedir}/user.home/empty/</userHome>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>npm login (with_token)</id>
+                        <goals>
+                            <goal>npm-login</goal>
+                        </goals>
+                        <configuration>
+                            <npmRegistryURL>http://localhost:${npm.registry.port}</npmRegistryURL>
+                            <npmRegistryServerId>npm-registry</npmRegistryServerId>
+                            <!--ONLY FOR IT TEST-->
+                            <userHome>${project.basedir}/user.home/with_token/</userHome>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>npm login (without_token)</id>
+                        <goals>
+                            <goal>npm-login</goal>
+                        </goals>
+                        <configuration>
+                            <npmRegistryURL>http://localhost:${npm.registry.port}</npmRegistryURL>
+                            <npmRegistryServerId>npm-registry</npmRegistryServerId>
+                            <!--ONLY FOR IT TEST-->
+                            <userHome>${project.basedir}/user.home/without_token/</userHome>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/frontend-maven-plugin/src/it/npm-login/src/main/java/com/github/eirslett/maven/plugins/NpmRegistryMock.java
+++ b/frontend-maven-plugin/src/it/npm-login/src/main/java/com/github/eirslett/maven/plugins/NpmRegistryMock.java
@@ -1,0 +1,37 @@
+package com.github.eirslett.maven.plugins;
+
+import org.mockserver.client.MockServerClient;
+import org.mockserver.client.initialize.PluginExpectationInitializer;
+
+import static org.mockserver.model.Header.header;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.HttpStatusCode.OK_200;
+
+public class NpmRegistryMock implements PluginExpectationInitializer {
+    private static final String NPM_USERNAME = "username";
+    private static final String NPM_PASSWORD = "password";
+    private static final String NPM_TOKEN = "NpmToken.22e3a730-9e62-11e8-98d0-529269fb1459";
+
+    private static final String HEADER_CONTENT_TYPE = "Content-Type";
+    private static final String MIME_TYPE_APPLICATION_JSON = "application/json; charset=UTF-8";
+
+    @Override
+    public void initializeExpectations(MockServerClient mockServerClient) {
+        mockServerClient.when(
+                        request()
+                                .withMethod("PUT")
+                                .withPath("/-/user/org.couchdb.user:" + NPM_USERNAME)
+                                .withHeader(HEADER_CONTENT_TYPE, MIME_TYPE_APPLICATION_JSON)
+                                .withBody("{\"name\":\"" + NPM_USERNAME + "\",\"password\":\"" + NPM_PASSWORD + "\"}")
+                )
+                .respond(
+                        response()
+                                .withStatusCode(OK_200.code())
+                                .withHeaders(
+                                        header(HEADER_CONTENT_TYPE, MIME_TYPE_APPLICATION_JSON)
+                                )
+                                .withBody("{\"rev\":\"_we_dont_use_revs_any_more\",\"id\":\"org.couchdb.user:undefined\"," +
+                                        "\"ok\":\"true\",\"token\":\"" + NPM_TOKEN + "\"}"));
+    }
+}

--- a/frontend-maven-plugin/src/it/npm-login/user.home/with_token/.npmrc
+++ b/frontend-maven-plugin/src/it/npm-login/user.home/with_token/.npmrc
@@ -1,0 +1,2 @@
+//localhost:${npm.registry.port}/:_authToken="NpmToken.22e3a730-9e62-11e8-98d0-529269fb1459"
+registry=https://localhost:${npm.registry.port}

--- a/frontend-maven-plugin/src/it/npm-login/user.home/without_token/.npmrc
+++ b/frontend-maven-plugin/src/it/npm-login/user.home/without_token/.npmrc
@@ -1,0 +1,2 @@
+//localhost/:_authToken="NpmToken.22e3a730-9e62-11e8-98d0-529269fb1459"
+registry=https://localhost

--- a/frontend-maven-plugin/src/it/npm-login/verify.groovy
+++ b/frontend-maven-plugin/src/it/npm-login/verify.groovy
@@ -1,0 +1,28 @@
+import java.nio.file.Paths
+
+def buildLog = new File(basedir, 'build.log').text
+assert buildLog.contains('BUILD SUCCESS') : 'build was not successful'
+assertEmpty()
+assertWithToken()
+assertWithoutToken()
+
+def assertEmpty() {
+    def npmrcFile = Paths.get(basedir.getAbsolutePath(), 'user.home', 'empty', '.npmrc').toFile()
+    assert npmrcFile.exists() : "${npmrcFile.getAbsolutePath()} does`exist";
+    assert npmrcFile.text.equals('//localhost:${npm.registry.port}/:_authToken="NpmToken.22e3a730-9e62-11e8-98d0-529269fb1459"\n') : "incorrect content"
+}
+
+def assertWithToken() {
+    def buildLog = new File(basedir, 'build.log').text
+    assert buildLog.contains('Token exists. Skipping execution.') : 'build was not successful'
+    def npmrcFile = Paths.get(basedir.getAbsolutePath(), 'user.home', 'with_token', '.npmrc').toFile()
+    assert npmrcFile.exists() : "${npmrcFile.getAbsolutePath()} does`exist";
+    assert npmrcFile.text.equals('//localhost:${npm.registry.port}/:_authToken="NpmToken.22e3a730-9e62-11e8-98d0-529269fb1459"\nregistry=https://localhost:${npm.registry.port}\n') : "incorrect content"
+}
+
+def assertWithoutToken() {
+    def npmrcFile = Paths.get(basedir.getAbsolutePath(), 'user.home', 'without_token', '.npmrc').toFile()
+    assert npmrcFile.exists() : "${npmrcFile.getAbsolutePath()} does`exist";
+    assert npmrcFile.text.equals('//localhost:${npm.registry.port}/:_authToken="NpmToken.22e3a730-9e62-11e8-98d0-529269fb1459"\n//localhost/:_authToken="NpmToken.22e3a730-9e62-11e8-98d0-529269fb1459"\n' +
+            'registry=https://localhost\n') : "incorrect content"
+}

--- a/frontend-maven-plugin/src/it/settings.xml
+++ b/frontend-maven-plugin/src/it/settings.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0"?>
 <settings>
+  <servers>
+    <server>
+      <id>npm-registry</id>
+        <username>username</username>
+        <password>password</password>
+    </server>
+  </servers>
   <mirrors>
     <mirror>
       <id>mrm-maven-plugin</id>

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmLoginMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmLoginMojo.java
@@ -1,0 +1,221 @@
+package com.github.eirslett.maven.plugins.frontend.mojo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig.Proxy;
+import static org.apache.http.entity.ContentType.APPLICATION_JSON;
+
+@Mojo(name = "npm-login", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
+public class NpmLoginMojo extends AbstractMojo {
+
+    @Parameter(property = "frontend.npm-login.npmInheritsProxyConfigFromMaven", defaultValue = "true")
+    private boolean npmInheritsProxyConfigFromMaven;
+
+    /**
+     * Registry override, passed as the registry option during npm install if set.
+     */
+    @Parameter(property = "npmRegistryURL", required = true)
+    private String npmRegistryURL;
+
+    /**
+     * Server Id for access to npm registry
+     */
+    @Parameter(property = "npmRegistryServerId", required = true)
+    private String npmRegistryServerId;
+
+    @Parameter(property = "session", defaultValue = "${session}", readonly = true)
+    private MavenSession session;
+
+    @Component(role = SettingsDecrypter.class)
+    private SettingsDecrypter decrypter;
+
+    /**
+     * Skips execution of this mojo.
+     */
+    @Parameter(property = "skip.npm-login", defaultValue = "${skip.npm-login}")
+    private boolean skip;
+
+    @Parameter(property = "userHome", defaultValue = "${user.home}")
+    private String userHome;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Skipping execution.");
+            return;
+        }
+
+        String npmRegistryAuth = "//" + npmRegistryURL
+                .replaceAll("http.?://", "")
+                .replaceFirst("/$", "") + "/";
+        try {
+            Path npmrcPath = Paths.get(userHome, ".npmrc");
+            int position = -1;
+            List<String> lines;
+            if (Files.exists(npmrcPath)) {
+                lines = Files.readAllLines(npmrcPath);
+                int i = -1;
+                for (String line : lines) {
+                    if (line.startsWith(npmRegistryAuth)) {
+                        getLog().info("Token exists. Skipping execution.");
+                        return;
+                    }
+
+                    i++;
+                    if (position == -1 && line.startsWith("//") && line.contains(":_authToken=")) {
+                        position = i;
+                    }
+                }
+            } else {
+                lines = new ArrayList<>();
+                position = 0;
+                Files.createFile(npmrcPath);
+            }
+            lines.add(Math.max(position, 0), npmRegistryAuth + ":_authToken=\"" + getToken() + "\"");
+            Files.write(npmrcPath, lines);
+        } catch (MojoExecutionException | MojoFailureException e) {
+            throw e;
+        } catch (Exception e) {
+            throw MojoUtils.toMojoFailureException(e);
+        }
+    }
+
+
+    private String getToken() throws Exception {
+        Server server = MojoUtils.decryptServer(npmRegistryServerId, session, decrypter);
+        if (server == null) {
+            throw new IllegalStateException("Unknown serverId: " + npmRegistryServerId);
+        }
+        String npmRegistryUsername = server.getUsername();
+        String npmRegistryPassword = server.getPassword();
+
+        ProxyConfig proxyConfig;
+        if (npmInheritsProxyConfigFromMaven) {
+            proxyConfig = MojoUtils.getProxyConfig(session, decrypter);
+        } else {
+            getLog().info("npm-login not inheriting proxy config from Maven");
+            proxyConfig = new ProxyConfig(Collections.emptyList());
+        }
+
+        HttpClientBuilder httpClientBuilder = HttpClients.custom()
+                .disableContentCompression()
+                .useSystemProperties();
+        RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+        Proxy proxy = proxyConfig.getProxyForUrl(npmRegistryURL);
+
+        if (proxy != null) {
+            if (proxy.useAuthentication()) {
+                final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+                credentialsProvider.setCredentials(
+                        new AuthScope(proxy.host, proxy.port),
+                        new UsernamePasswordCredentials(proxy.username, proxy.password)
+                );
+
+                httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+            }
+            HttpHost proxyHttpHost = new HttpHost(proxy.host, proxy.port);
+            requestConfigBuilder.setProxy(proxyHttpHost);
+        }
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        HttpPut httpPut = new HttpPut(npmRegistryURL.replaceFirst("/$", "") + "/-/user/org.couchdb.user:" + npmRegistryUsername);
+        httpPut.setConfig(requestConfigBuilder.build());
+        TokenRequest tokenRequest = new TokenRequest(npmRegistryUsername, npmRegistryPassword);
+        httpPut.setEntity(new StringEntity(objectMapper.writeValueAsString(tokenRequest), APPLICATION_JSON));
+
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            CloseableHttpResponse response = client.execute(httpPut);
+            TokenResponse tokenResponse = objectMapper.readValue(response.getEntity().getContent(), TokenResponse.class);
+            if (tokenResponse.getError() != null) {
+                throw new MojoFailureException("Error get token: " + tokenResponse.getError());
+            }
+            return tokenResponse.getToken();
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class TokenRequest {
+        private String name;
+        private String password;
+
+        public TokenRequest() {
+        }
+
+        public TokenRequest(String name, String password) {
+            this.name = name;
+            this.password = password;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class TokenResponse {
+        private String token;
+        private String error;
+
+        public TokenResponse() {
+        }
+
+        public String getToken() {
+            return token;
+        }
+
+        public void setToken(String token) {
+            this.token = token;
+        }
+
+        public String getError() {
+            return error;
+        }
+
+        public void setError(String error) {
+            this.error = error;
+        }
+    }
+}


### PR DESCRIPTION
Hello. In our organization, we use Nexus as a private npm registry and maven repository. To simplify the initial project setup and to store the authentication settings in one place (~/.m2/settings.xml), we developed the "npm-login" goal, which is identical to the npm login command - getting an authentication token and writing it to ~/.npmrc

**Running Npm Login**

```xml
<execution>
    <id>npm login</id>
    <goals>
        <goal>npm-login</goal>
    </goals>

    <!-- optional: the default phase is "generate-resources" -->
    <phase>generate-resources</phase>

    <configuration>
       <npmRegistryURL>https://npm-registry.com</npmRegistryURL>
       <npmRegistryServerId>npm-registry</npmRegistryServerId>
    </configuration>
</execution>
```

and server section in ~/.m2/settings.xml
```xml
<?xml version="1.0"?>
<settings>
  ... 
  <servers>
    <server>
      <id>npm-registry</id>
        <username>username</username>
        <password>password</password>
    </server>
  </servers>
  ...
```
