### PR TITLE
Fixes #1000 Use case insensitive match when guessing AIX OS.

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
@@ -34,7 +34,7 @@ enum OS { Windows, Mac, Linux, SunOS, AIX;
         return  osName.contains("Windows") ? OS.Windows :
                 osName.contains("Mac") ? OS.Mac :
                         osName.contains("SunOS") ? OS.SunOS :
-                            osName.contains("Aix") ? OS.AIX :
+                            osName.toUpperCase().contains("AIX") ? OS.AIX :
                                 OS.Linux;
     }
 


### PR DESCRIPTION
Small isolated change to fix the reported issue #1000 where the plugin does not match the "Aix" operating system.
A case insensitive match has been implemented, just for this OS not all.
