### PR TITLE
Add warning if determination of node version fails

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
@@ -118,6 +118,7 @@ public class NodeInstaller {
                 return false;
             }
         } catch (ProcessExecutionException e) {
+            this.logger.warn("Unable to determine current node version: {}", e.getMessage());
             return false;
         }
     }


### PR DESCRIPTION
**Summary**

We're currently facing an issue on macOS, which always installs node again, because it can't execute it correctly. Manual invocation of `<path>/node --version` works as expected. This will hopefully help to debug this.