### PR TITLE
Fix issues for pnpm

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/PnpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/PnpmMojo.java
@@ -18,7 +18,7 @@ import java.util.Collections;
 public final class PnpmMojo extends AbstractFrontendMojo {
 
     private static final String PNPM_REGISTRY_URL = "npmRegistryURL";
-    
+
     /**
      * pnpm arguments. Default is "install".
      */
@@ -29,11 +29,11 @@ public final class PnpmMojo extends AbstractFrontendMojo {
     private boolean pnpmInheritsProxyConfigFromMaven;
 
     /**
-     * Registry override, passed as the registry option during npm install if set.
+     * Registry override, passed as the registry option during pnpm install if set.
      */
     @Parameter(property = PNPM_REGISTRY_URL, required = false, defaultValue = "")
     private String pnpmRegistryURL;
-    
+
     @Parameter(property = "session", defaultValue = "${session}", readonly = true)
     private MavenSession session;
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -3,7 +3,7 @@ package com.github.eirslett.maven.plugins.frontend.lib;
 import java.io.File;
 
 public final class FrontendPluginFactory {
-    
+
     private static final Platform defaultPlatform = Platform.guess();
     private static final String DEFAULT_CACHE_PATH = "cache";
 
@@ -29,17 +29,17 @@ public final class FrontendPluginFactory {
         return new NPMInstaller(getInstallConfig(), new DefaultArchiveExtractor(), new DefaultFileDownloader(proxy));
     }
 
-    public PNPMInstaller getPNPMInstaller(ProxyConfig proxy) {
-        return new PNPMInstaller(getInstallConfig(), new DefaultArchiveExtractor(), new DefaultFileDownloader(proxy));
+    public PnpmInstaller getPnpmInstaller(ProxyConfig proxy) {
+        return new PnpmInstaller(getInstallConfig(), new DefaultArchiveExtractor(), new DefaultFileDownloader(proxy));
     }
 
     public YarnInstaller getYarnInstaller(ProxyConfig proxy) {
         return new YarnInstaller(getInstallConfig(), new DefaultArchiveExtractor(), new DefaultFileDownloader(proxy));
     }
-    
+
     public BowerRunner getBowerRunner(ProxyConfig proxy) {
         return new DefaultBowerRunner(getExecutorConfig(), proxy);
-    }    
+    }
 
     public JspmRunner getJspmRunner() {
         return new DefaultJspmRunner(getExecutorConfig());

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/PnpmInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/PnpmInstaller.java
@@ -10,7 +10,7 @@ import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PNPMInstaller {
+public class PnpmInstaller {
 
     private static final String VERSION = "version";
 
@@ -28,33 +28,33 @@ public class PNPMInstaller {
 
     private final FileDownloader fileDownloader;
 
-    PNPMInstaller(InstallConfig config, ArchiveExtractor archiveExtractor, FileDownloader fileDownloader) {
+    PnpmInstaller(InstallConfig config, ArchiveExtractor archiveExtractor, FileDownloader fileDownloader) {
         this.logger = LoggerFactory.getLogger(getClass());
         this.config = config;
         this.archiveExtractor = archiveExtractor;
         this.fileDownloader = fileDownloader;
     }
 
-    public PNPMInstaller setNodeVersion(String nodeVersion) {
+    public PnpmInstaller setNodeVersion(String nodeVersion) {
         return this;
     }
 
-    public PNPMInstaller setPnpmVersion(String pnpmVersion) {
+    public PnpmInstaller setPnpmVersion(String pnpmVersion) {
         this.pnpmVersion = pnpmVersion;
         return this;
     }
 
-    public PNPMInstaller setPnpmDownloadRoot(String pnpmDownloadRoot) {
+    public PnpmInstaller setPnpmDownloadRoot(String pnpmDownloadRoot) {
         this.pnpmDownloadRoot = pnpmDownloadRoot;
         return this;
     }
 
-    public PNPMInstaller setUserName(String userName) {
+    public PnpmInstaller setUserName(String userName) {
         this.userName = userName;
         return this;
     }
 
-    public PNPMInstaller setPassword(String password) {
+    public PnpmInstaller setPassword(String password) {
         this.password = password;
         return this;
     }


### PR DESCRIPTION
## Summary

This commit fixes the following issues for pnpm:

- Comment mismatch.
- pnpm is never "provided" by Node.js so `<pnpmVersion>` is required.
- Java class name CamelCase: `PNPMInstaller` -> `PnpmInstaller`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Tests and Documentation

Although pnpm support was added in https://github.com/eirslett/frontend-maven-plugin/pull/927, documentation is lacking in `README.md` and the project wiki. I will add documentation in a follow-up pull request.