### PR TITLE
Fix #967 : Add pnpm executable to PATH

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: 1.8
       - name: "Run Maven"
         shell: bash
-        run: mvn clean install --batch-mode -PintegrationTests
+        run: mvn clean install --batch-mode -PintegrationTests -DintegrationTestProfiles=it-${{ runner.os }}
       - name: "Deploy"
         if: github.repository_owner == 'eirslett' && github.ref == 'refs/heads/master' && matrix.os == 'ubuntu-latest'
         shell: bash

--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -15,6 +15,10 @@
     <maven>3.6.0</maven>
   </prerequisites>
 
+  <properties>
+    <integrationTestProfiles>it-Linux</integrationTestProfiles>
+  </properties>
+
   <description>
         This Maven plugin lets you install Node/NPM locally
         for your project, install dependencies with NPM,
@@ -128,6 +132,7 @@
 
             <configuration>
               <debug>true</debug>
+              <profiles>${integrationTestProfiles}</profiles>
               <projectsDirectory>src/it</projectsDirectory>
               <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
               <settingsFile>src/it/settings.xml</settingsFile>

--- a/frontend-maven-plugin/src/it/pnpm-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/pnpm-integration/pom.xml
@@ -41,19 +41,65 @@
                             <arguments>install</arguments>
                         </configuration>
                     </execution>
-
-                    <execution>
-                        <id>pnpm test</id>
-                        <goals>
-                            <goal>pnpm</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>test</arguments>
-                        </configuration>
-                    </execution>
-
                 </executions>
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>it-Linux</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+
+                        <configuration>
+                            <installDirectory>target</installDirectory>
+                        </configuration>
+
+                        <executions>
+                            <execution>
+                                <id>pnpm test</id>
+                                <goals>
+                                    <goal>pnpm</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>test</arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>it-macOs</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+
+                        <configuration>
+                            <installDirectory>target</installDirectory>
+                        </configuration>
+
+                        <executions>
+                            <execution>
+                                <id>pnpm test</id>
+                                <goals>
+                                    <goal>pnpm</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>test</arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/frontend-maven-plugin/src/it/pnpm-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/pnpm-integration/pom.xml
@@ -27,8 +27,8 @@
                             <goal>install-node-and-pnpm</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v12.18.3</nodeVersion>
-                            <pnpmVersion>v5.5.3</pnpmVersion>
+                            <nodeVersion>v16.17.1</nodeVersion>
+                            <pnpmVersion>v7.13.0</pnpmVersion>
                         </configuration>
                     </execution>
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/PnpmInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/PnpmInstaller.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashMap;
 import org.apache.commons.io.FileUtils;
@@ -158,6 +159,7 @@ public class PnpmInstaller {
             }
 
             this.logger.info("Installed pnpm locally.");
+
         } catch (DownloadException e) {
             throw new InstallationException("Could not download pnpm", e);
         } catch (ArchiveExtractionException e) {
@@ -187,6 +189,19 @@ public class PnpmInstaller {
                         throw new InstallationException("Could not copy pnpm", e);
                     }
                     copy.setExecutable(true);
+                }
+            }
+        }
+        // If no predefined executables exist, symlink the .cjs executable
+        File pnpmExecutable = new File(installDirectory, "pnpm");
+        if (!pnpmExecutable.exists()) {
+            File pnpmJsExecutable = new File(pnpmDirectory, "bin" + File.separator + "pnpm.cjs");
+            if (pnpmJsExecutable.exists()) {
+                this.logger.info("No pnpm executable found, creating symlink to {}", pnpmJsExecutable.toPath());
+                try {
+                    Files.createSymbolicLink(pnpmExecutable.toPath(), pnpmJsExecutable.toPath());
+                } catch (IOException e) {
+                    throw new InstallationException("Could not copy pnpm", e);
                 }
             }
         }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/PnpmInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/PnpmInstaller.java
@@ -192,9 +192,10 @@ public class PnpmInstaller {
                 }
             }
         }
-        // If no predefined executables exist, symlink the .cjs executable
+        // On non-windows platforms, if no predefined executables exist, symlink the .cjs executable
         File pnpmExecutable = new File(installDirectory, "pnpm");
-        if (!pnpmExecutable.exists()) {
+        if (!pnpmExecutable.exists() && !this.config.getPlatform().isWindows()) {
+
             File pnpmJsExecutable = new File(pnpmDirectory, "bin" + File.separator + "pnpm.cjs");
             if (pnpmJsExecutable.exists()) {
                 this.logger.info("No pnpm executable found, creating symlink to {}", pnpmJsExecutable.toPath());


### PR DESCRIPTION


**Summary**

Fix the issue described in #967 

> the PNPMInstaller tries to copy pnpm & pnpm.cmd ([copyPnpmScripts](https://github.com/eirslett/frontend-maven-plugin/blob/e727f7dbb1dfa1df0367aba43e93f88e5a8df342/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/PNPMInstaller.java#L170)), but pnpm has no such predefined files, thus it does not find anything to copy.

The solution I propose is to create a symlink to `node_modules/pnpm/bin/pnpm.cjs` when no pnpm or pnpm.cmd is available. 

**Tests and Documentation**

I tested using this dummy project : https://github.com/JulesAaelio/test-frontend-maven-plugin
