### PR TITLE
fix(sec): upgrade jackson-databind to 2.13.2.1

### DIFF
--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.0</version>
+            <version>2.13.2.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Upgrade jackson-databind from 2.13.0 to 2.13.2.1 for vulnerability fix:
- [CVE-2020-36518](https://www.oscs1024.com/hd/MPS-2022-6242)
- [MPS-2022-12500](https://www.oscs1024.com/hd/MPS-2022-12500)