### PR TITLE
fix(sec): upgrade org.codehaus.plexus:plexus-utils to 3.0.24

### DIFF
--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.0.22</version>
+            <version>3.0.24</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in org.codehaus.plexus:plexus-utils 3.0.22
- [MPS-2022-11760](https://www.oscs1024.com/hd/MPS-2022-11760)
- [MPS-2022-11786](https://www.oscs1024.com/hd/MPS-2022-11786)


### What did I do？
Upgrade org.codehaus.plexus:plexus-utils from 3.0.22 to 3.0.24 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS