### PR TITLE
fix(sec): upgrade com.fasterxml.jackson.core:jackson-databind to 2.14.0-rc1

### DIFF
--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.4.1</version>
+            <version>2.14.0-rc1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.fasterxml.jackson.core:jackson-databind 2.13.4.1
- [CVE-2022-42003](https://www.oscs1024.com/hd/CVE-2022-42003)


### What did I do？
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.13.4.1 to 2.14.0-rc1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>