### PR TITLE
Add configurable number of retries and interval between retries

### DIFF
--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -63,6 +63,12 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
     @Parameter(property = "skip.installnodenpm", defaultValue = "${skip.installnodenpm}")
     private boolean skip;
 
+    @Parameter(property = "numberOfRetries", defaultValue = "1")
+    private int numberOfRetries;
+
+    @Parameter(property = "intervalBetweenRetriesMs", defaultValue = "10000")
+    private int intervalBetweenRetriesMs;
+
     @Component(role = SettingsDecrypter.class)
     private SettingsDecrypter decrypter;
 
@@ -82,12 +88,16 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
                 .setNodeVersion(nodeVersion)
                 .setNodeDownloadRoot(nodeDownloadRoot)
                 .setNpmVersion(npmVersion)
+                .setNumberOfRetries(numberOfRetries)
+                .setIntervalBetweenRetries(intervalBetweenRetriesMs)
                 .setUserName(server.getUsername())
                 .setPassword(server.getPassword())
                 .install();
             factory.getNPMInstaller(proxyConfig)
                 .setNodeVersion(nodeVersion)
                 .setNpmVersion(npmVersion)
+                .setNumberOfRetries(numberOfRetries)
+                .setIntervalBetweenRetries(intervalBetweenRetriesMs)
                 .setNpmDownloadRoot(npmDownloadRoot)
                 .setUserName(server.getUsername())
                 .setPassword(server.getPassword())
@@ -97,10 +107,14 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
                 .setNodeVersion(nodeVersion)
                 .setNodeDownloadRoot(nodeDownloadRoot)
                 .setNpmVersion(npmVersion)
+                .setNumberOfRetries(numberOfRetries)
+                .setIntervalBetweenRetries(intervalBetweenRetriesMs)
                 .install();
             factory.getNPMInstaller(proxyConfig)
                 .setNodeVersion(this.nodeVersion)
                 .setNpmVersion(this.npmVersion)
+                .setNumberOfRetries(numberOfRetries)
+                .setIntervalBetweenRetries(intervalBetweenRetriesMs)
                 .setNpmDownloadRoot(npmDownloadRoot)
                 .install();
         }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
@@ -61,6 +61,12 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
     @Parameter(property = "skip.installyarn", alias = "skip.installyarn", defaultValue = "${skip.installyarn}")
     private boolean skip;
 
+    @Parameter(property = "numberOfRetries", defaultValue = "1")
+    private int numberOfRetries;
+
+    @Parameter(property = "intervalBetweenRetriesMs", defaultValue = "10000")
+    private int intervalBetweenRetriesMs;
+
     @Component(role = SettingsDecrypter.class)
     private SettingsDecrypter decrypter;
 
@@ -95,6 +101,7 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
                 .setUserName(server.getUsername()).install();
             factory.getYarnInstaller(proxyConfig).setYarnDownloadRoot(this.yarnDownloadRoot)
                 .setYarnVersion(this.yarnVersion).setUserName(server.getUsername())
+                .setNumberOfRetries(numberOfRetries).setIntervalBetweenRetries(intervalBetweenRetriesMs)
                 .setPassword(server.getPassword()).setIsYarnBerry(isYarnrcYamlFilePresent()).install();
         } else {
             factory.getNodeInstaller(proxyConfig).setNodeDownloadRoot(this.nodeDownloadRoot)


### PR DESCRIPTION
The PR adds retry option of download and install for node, npm, yarn.

We (Flink community) sometimes faced an issue like 
```
[ERROR] The archive file /__w/1/.m2/repository/com/github/eirslett/node/16.13.2/node-16.13.2-linux-x64.tar.gz is corrupted and will be deleted. Please try the build again.
```
so archive was corrupted and removed. However it would be nice to have an autoretry for this case
i guess it could also partially address #882 