### PR TITLE
Use a script to proxy PNPM executable on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
           distribution: temurin
       - name: "Run Maven"
         shell: bash
-        run: mvn clean install --batch-mode -PintegrationTests -DintegrationTestProfiles=it-${{ runner.os }}
+        run: mvn clean install --batch-mode -PintegrationTests
       - name: "Deploy"
         if: github.repository_owner == 'eirslett' && github.ref == 'refs/heads/master' && matrix.os == 'ubuntu-latest'
         shell: bash

--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -15,10 +15,6 @@
     <maven>3.6.0</maven>
   </prerequisites>
 
-  <properties>
-    <integrationTestProfiles>it-Linux</integrationTestProfiles>
-  </properties>
-
   <description>
         This Maven plugin lets you install Node/NPM locally
         for your project, install dependencies with NPM,
@@ -134,7 +130,6 @@
 
             <configuration>
               <debug>true</debug>
-              <profiles>${integrationTestProfiles}</profiles>
               <projectsDirectory>src/it</projectsDirectory>
               <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
               <settingsFile>src/it/settings.xml</settingsFile>

--- a/frontend-maven-plugin/src/it/pnpm-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/pnpm-integration/pom.xml
@@ -41,65 +41,19 @@
                             <arguments>install</arguments>
                         </configuration>
                     </execution>
+
+                    <execution>
+                        <id>pnpm test</id>
+                        <goals>
+                            <goal>pnpm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>test</arguments>
+                        </configuration>
+                    </execution>
+
                 </executions>
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>it-Linux</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.github.eirslett</groupId>
-                        <artifactId>frontend-maven-plugin</artifactId>
-
-                        <configuration>
-                            <installDirectory>target</installDirectory>
-                        </configuration>
-
-                        <executions>
-                            <execution>
-                                <id>pnpm test</id>
-                                <goals>
-                                    <goal>pnpm</goal>
-                                </goals>
-                                <configuration>
-                                    <arguments>test</arguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>it-macOs</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.github.eirslett</groupId>
-                        <artifactId>frontend-maven-plugin</artifactId>
-
-                        <configuration>
-                            <installDirectory>target</installDirectory>
-                        </configuration>
-
-                        <executions>
-                            <execution>
-                                <id>pnpm test</id>
-                                <goals>
-                                    <goal>pnpm</goal>
-                                </goals>
-                                <configuration>
-                                    <arguments>test</arguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
Since Windows does not support symbolic links (or at least not consistently), the choice was made [not to support](https://github.com/eirslett/frontend-maven-plugin/pull/1045#issuecomment-1272384510) the PNPM executable under Windows. This PR adds support for running the PNPM executable by adding a script under the same name in the installation directory, and proxy any commands sent to it to the PNPM executable.

This also allow the removal of some of the testing profiles that were previously added as the tests would not pass under Windows. And also removes the legacy linking code that was copied from the NPM version that never worked.

Closes #1115