### PR TITLE
Fix broken npx goal when using a proxy

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParser.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParser.java
@@ -39,6 +39,7 @@ class ArgumentsParser {
         }
 
         final List<String> arguments = new LinkedList<>();
+        final List<String> allArguments = new LinkedList<>();
         final StringBuilder argumentBuilder = new StringBuilder();
         Character quote = null;
 
@@ -64,13 +65,15 @@ class ArgumentsParser {
 
         addArgument(argumentBuilder, arguments);
 
+        // Prepend additionalArguments before the other arguments
         for (String argument : this.additionalArguments) {
             if (!arguments.contains(argument)) {
-                arguments.add(argument);
+                allArguments.add(argument);
             }
         }
+        allArguments.addAll(arguments);
 
-        return new ArrayList<>(arguments);
+        return new ArrayList<>(allArguments);
     }
 
     private static void addArgument(StringBuilder argumentBuilder, List<String> arguments) {

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpxRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpxRunner.java
@@ -16,10 +16,10 @@ final class DefaultNpxRunner extends NodeTaskExecutor implements NpxRunner {
 
     // Visible for testing only.
     /**
-     * These are, in fact, npm arguments, that need to be split from the npx arguments by '--'.
+     * These are, in fact, npm arguments, that need to come before the package arguments.
      *
      * See an example:
-     * npx some-package -- --registry=http://myspecialregisty.com
+     * npx --registry=http://myspecialregisty.com some-package
      */
     static List<String> buildNpmArguments(ProxyConfig proxyConfig, String npmRegistryURL) {
         List<String> arguments = new ArrayList<>();
@@ -51,7 +51,6 @@ final class DefaultNpxRunner extends NodeTaskExecutor implements NpxRunner {
             npmArguments = arguments;
         } else {
             npmArguments = new ArrayList<>();
-            npmArguments.add("--");
             npmArguments.addAll(arguments);
         }
         

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParserTest.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/ArgumentsParserTest.java
@@ -60,13 +60,13 @@ public class ArgumentsParserTest {
     public void testAdditionalArgumentsNoIntersection() {
         ArgumentsParser parser = new ArgumentsParser(Arrays.asList("foo", "bar"));
 
-        assertArrayEquals(new Object[] { "foobar", "foo", "bar" }, parser.parse("foobar").toArray());
+        assertArrayEquals(new Object[] { "foo", "bar", "foobar" }, parser.parse("foobar").toArray());
     }
 
     @Test
     public void testAdditionalArgumentsWithIntersection() {
         ArgumentsParser parser = new ArgumentsParser(Arrays.asList("foo", "foobar"));
 
-        assertArrayEquals(new Object[] { "bar", "foobar", "foo" }, parser.parse("bar foobar").toArray());
+        assertArrayEquals(new Object[] { "foo", "bar", "foobar" }, parser.parse("bar foobar").toArray());
     }
 }

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/DefaultNpxRunnerTest.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/DefaultNpxRunnerTest.java
@@ -23,7 +23,7 @@ public class DefaultNpxRunnerTest {
     @Test
     public void buildArgument_withRegistryUrl() {
         List<String> arguments = DefaultNpxRunner.buildNpmArguments(new ProxyConfig(Collections.emptyList()), registryUrl);
-        Assertions.assertEquals(2, arguments.size());
-        assertThat(arguments, CoreMatchers.hasItems("--", "--registry=" + registryUrl));
+        Assertions.assertEquals(1, arguments.size());
+        assertThat(arguments, CoreMatchers.hasItems("--registry=" + registryUrl));
     }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This PR 
fixes #1030 
fixes #1121
fixes #1105
in the current version of the plugin the npx goal is broken when using a proxy.  

As you can read in the npm documentation npx does not support the syntax that was used by the plugin before:
https://docs.npmjs.com/cli/v8/commands/npm-exec#npx-vs-npm-exec  

> When run via the `npx` binary, all flags and options _**must**_ be set prior to any positional arguments.

syntax before:
`npx @sompackage arg1 arg2 -- --proxy=someproxy --https-proxy=someproxy --registry=someregistry`

syntax after:
`npx --proxy=someproxy --https-proxy=someproxy --registry=someregistry @somepackage arg1 arg2`

`npm` supports both syntax so no harm done in switching it.

**Tests and Documentation**

<!-- Demonstrate the code is solid. Add a simple description to CHANGELOG.md and add some infos to README.md or Wiki, if necessary. -->
I've changed the 3 existing tests to check for the new syntax. 
Please let me know if you need other changes. I'll try to get to it asap 😃 