### PR TITLE
Delete previous node installation before upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 
 ## Changelog
 
+### 1.14.3
+
+* if upgrading, first delete the full "node" dir ([#994](https://github.com/eirslett/frontend-maven-plugin/issues/994))
+
 ### 1.14.2
 
 * Prevent corrupt downloaded files by waiting for the download to complete before writing the file to disk.

--- a/frontend-maven-plugin/src/it/node-provided-npm-upgrades/invoker.properties
+++ b/frontend-maven-plugin/src/it/node-provided-npm-upgrades/invoker.properties
@@ -1,0 +1,4 @@
+# first install v14
+invoker.goals.1 = generate-resources -DnodeVersion=v14.21.3
+# then upgrade to v18
+invoker.goals.2 = generate-resources -DnodeVersion=v18.18.2

--- a/frontend-maven-plugin/src/it/node-provided-npm-upgrades/package-lock.json
+++ b/frontend-maven-plugin/src/it/node-provided-npm-upgrades/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "node-provided-npm-upgrades",
+  "version": "0.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node-provided-npm-upgrades",
+      "version": "0.0.1",
+      "dependencies": {
+        "classnames": "^2.3.2"
+      }
+    },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+    }
+  },
+  "dependencies": {
+    "classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+    }
+  }
+}

--- a/frontend-maven-plugin/src/it/node-provided-npm-upgrades/package.json
+++ b/frontend-maven-plugin/src/it/node-provided-npm-upgrades/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "node-provided-npm-upgrades",
+  "version": "0.0.1",
+  "dependencies": {
+    "classnames": "^2.3.2"
+  },
+  "scripts": {
+    "prebuild": "npm install"
+  }
+}

--- a/frontend-maven-plugin/src/it/node-provided-npm-upgrades/pom.xml
+++ b/frontend-maven-plugin/src/it/node-provided-npm-upgrades/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.eirslett.it</groupId>
+    <artifactId>node-provided-npm-upgrades</artifactId>
+    <version>0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <!-- will be overwritten from command line via -DnodeVersion=... -->
+        <nodeVersion>v14.21.3</nodeVersion>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>@project.version@</version>
+
+                <configuration>
+                    <installDirectory>target</installDirectory>
+                </configuration>
+
+                <executions>
+
+                    <execution>
+                        <id>install node and npm</id>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
+                    </execution>
+
+                    <execution>
+                        <id>npm ci</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>ci</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/frontend-maven-plugin/src/it/node-provided-npm-upgrades/verify.groovy
+++ b/frontend-maven-plugin/src/it/node-provided-npm-upgrades/verify.groovy
@@ -1,0 +1,10 @@
+assert new File(basedir, 'target/node').exists() : "Node was not installed in the custom install directory";
+assert new File(basedir, 'node_modules').exists() : "Node modules were not installed in the base directory";
+assert new File(basedir, 'target/node/npm').exists() : "npm was not copied to the node directory";
+
+import org.codehaus.plexus.util.FileUtils;
+
+String buildLog = FileUtils.fileRead(new File(basedir, 'build.log'));
+
+assert !buildLog.contains('TypeError: Class extends value undefined is not a constructor or null') : 'old npm version still seems to be used'
+assert buildLog.contains('BUILD SUCCESS') : 'build was not successful'


### PR DESCRIPTION
**Summary**

When changing the node version from e.g. v14 to v18 with provided npm, then npm fails with the following exception:

```
TypeError: Class extends value undefined is not a constructor or null
    at Object.<anonymous> (.../node/node_modules/npm/node_modules/fs-minipass/lib/index.js:136:4)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Module.require (node:internal/modules/cjs/loader:1143:19)
    at require (node:internal/modules/cjs/helpers:119:18)
    at Object.<anonymous> (.../node/node_modules/npm/node_modules/cacache/lib/content/read.js:4:13)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
```

The reason is, that the provided npm is left as a mixture of the old provided npm version and the new npm version.

This PR removes the old node installation (including node_modules and npm, npm.cmd, npx, npx.cmd) entirely, so that only the new files for npm are there in the end.

This fixes #994.

**Tests and Documentation**

I created a new integration test "node-provided-npm-upgrades".
