### PR TITLE
Add basic Rspack integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This plugin downloads/installs Node and NPM locally for your project, runs `npm install`, and then any combination of 
 [Bower](http://bower.io/), [Grunt](http://gruntjs.com/), [Gulp](http://gulpjs.com/), [Jspm](http://jspm.io), 
-[Karma](http://karma-runner.github.io/), or [Webpack](http://webpack.github.io/).
+[Karma](http://karma-runner.github.io/), [Webpack](http://webpack.github.io/), or [Rspack](http://www.rspack.dev/).
 It's supposed to work on Windows, OS X and Linux.
 
 If you prefer [Yarn](https://yarnpkg.com/) over [NPM](https://www.npmjs.com/) for your node package fetching, 
@@ -64,6 +64,7 @@ to see how it should be set up: https://github.com/eirslett/frontend-maven-plugi
     - [gulp](#running-gulp)
     - [jspm](#running-jspm)
     - [karma](#running-karma)
+    - [rspack](#running-rspack)
     - [webpack](#running-webpack)
  - Configuration
     - [Working Directory](#working-directory)
@@ -402,6 +403,26 @@ code coverage reports.
 or [through gulp](https://github.com/karma-runner/gulp-karma) instead, as part of the `grunt` or `gulp` execution. That 
 will help to separate your frontend and backend builds even more.
 
+### Running Rspack
+
+```xml
+<execution>
+    <id>rspack build</id>
+    <goals>
+        <goal>rspack</goal>
+    </goals>
+
+    <!-- optional: the default phase is "generate-resources" -->
+    <phase>generate-resources</phase>
+
+    <configuration>
+        <!-- optional: if not specified, it will run rspack's default
+        build (and you can remove this whole <configuration> section.) -->
+        <arguments>-p</arguments>
+    </configuration>
+</execution>
+```
+
 ### Running Webpack
 
 ```xml
@@ -552,6 +573,7 @@ Tools and property to enable skipping
 * gulp `-Dskip.gulp`
 * jspm `-Dskip.jspm`
 * karma `-Dskip.karma`
+* rspack `-Dskip.rsppack`
 * webpack `-Dskip.webpack`
 
 ## Eclipse M2E support

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/RspackMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/RspackMojo.java
@@ -1,0 +1,83 @@
+package com.github.eirslett.maven.plugins.frontend.mojo;
+
+import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
+import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+@Mojo(name="rspack", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
+public final class RspackMojo extends AbstractFrontendMojo {
+
+    /**
+     * Rspack arguments. Default is empty (runs just the "rspack" command).
+     */
+    @Parameter(property = "frontend.rspack.arguments")
+    private String arguments;
+
+    /**
+     * Files that should be checked for changes, in addition to the srcdir files.
+     * Defaults to rspack.config.js in the {@link #workingDirectory}.
+     */
+    @Parameter(property = "triggerfiles")
+    private List<File> triggerfiles;
+
+    /**
+     * The directory containing front end files that will be processed by rspack.
+     * If this is set then files in the directory will be checked for
+     * modifications before running rspack.
+     */
+    @Parameter(property = "srcdir")
+    private File srcdir;
+
+    /**
+     * The directory where front end files will be output by rspack. If this is
+     * set then they will be refreshed so they correctly show as modified in
+     * Eclipse.
+     */
+    @Parameter(property = "outputdir")
+    private File outputdir;
+
+    /**
+     * Skips execution of this mojo.
+     */
+    @Parameter(property = "skip.rspack", defaultValue = "${skip.rspack}")
+    private boolean skip;
+
+    @Component
+    private BuildContext buildContext;
+
+    @Override
+    protected boolean skipExecution() {
+        return this.skip;
+    }
+
+    @Override
+    public synchronized void execute(FrontendPluginFactory factory) throws TaskRunnerException {
+        if (shouldExecute()) {
+            factory.getRspackRunner().execute(arguments, environmentVariables);
+
+            if (outputdir != null) {
+                getLog().info("Refreshing files after rspack: " + outputdir);
+                buildContext.refresh(outputdir);
+            }
+        } else {
+            getLog().info("Skipping rspack as no modified files in " + srcdir);
+        }
+    }
+
+    private boolean shouldExecute() {
+        if (triggerfiles == null || triggerfiles.isEmpty()) {
+            triggerfiles = Arrays.asList(new File(workingDirectory, "rspack.config.js"));
+        }
+
+        return MojoUtils.shouldExecute(buildContext, triggerfiles, srcdir);
+    }
+
+}

--- a/frontend-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/frontend-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -29,6 +29,7 @@
                     <goal>bun</goal>
                     <goal>jspm</goal>
                     <goal>ember</goal>
+                    <goal>rspack</goal>
                     <goal>webpack</goal>
                 </goals>
             </pluginExecutionFilter>

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -88,6 +88,10 @@ public final class FrontendPluginFactory {
         return new DefaultWebpackRunner(getExecutorConfig());
     }
 
+    public RspackRunner getRspackRunner(){
+        return new DefaultRspackRunner(getExecutorConfig());
+    }
+
     private NodeExecutorConfig getExecutorConfig() {
         return new InstallNodeExecutorConfig(getInstallConfig());
     }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/RspackRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/RspackRunner.java
@@ -1,0 +1,12 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+public interface RspackRunner extends NodeTaskRunner {}
+
+final class DefaultRspackRunner extends NodeTaskExecutor implements RspackRunner {
+
+    private static final String TASK_LOCATION = "node_modules/@rspack/cli/bin/rspack";
+
+    DefaultRspackRunner(NodeExecutorConfig config) {
+        super(config, TASK_LOCATION);
+    }
+}


### PR DESCRIPTION
Add initial Rspack support, based on the current webpack integration.
Configuration file tracking is limited to the default rspack.config.js.