### PR TITLE
Refining logging level for OS command calls

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProcessExecutor.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/ProcessExecutor.java
@@ -7,6 +7,7 @@ import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
@@ -60,8 +61,10 @@ final class ProcessExecutor {
     }
 
     public int executeAndRedirectOutput(final Logger logger) throws ProcessExecutionException {
-        OutputStream stdout = new LoggerOutputStream(logger, 0);
-        return execute(logger, stdout, stdout);
+        OutputStream stdout = new LoggerOutputStream(logger::info);
+        OutputStream stderr = new LoggerOutputStream(logger::error);
+
+        return execute(logger, stdout, stderr);
     }
 
     private int execute(final Logger logger, final OutputStream stdout, final OutputStream stderr)
@@ -143,10 +146,10 @@ final class ProcessExecutor {
     }
 
     private static class LoggerOutputStream extends LogOutputStream {
-        private final Logger logger;
+        private final Consumer<String> logger;
 
-        LoggerOutputStream(Logger logger, int logLevel) {
-            super(logLevel);
+        LoggerOutputStream(Consumer<String> logger) {
+            super(0);
             this.logger = logger;
         }
 
@@ -157,7 +160,7 @@ final class ProcessExecutor {
 
         @Override
         protected void processLine(final String line, final int logLevel) {
-            logger.info(line);
+            logger.accept(line);
         }
     }
 }


### PR DESCRIPTION
Dear maintainers,

I have been utilizing this library for integration within my environment (private fork [sbt-frontend](https://github.com/eltimn/sbt-frontend)). I came across a minor yet irksome issue related to the logging of operating system commands. When the workflow runs seamlessly, the logs are not of particular interest to me. However, in the event of an error, I would greatly appreciate the ability to access detailed information regarding the problem.

Currently, all logs are written at the `INFO` level which means I have to sift through a significant amount of "noise" in the logs when all is well, just to ensure I will have available error messages in case of issues arising. 

I have submitted a pull request addressing this specific issue and would appreciate if you could kindly review it. Thank you in advance for your time and consideration.