### PR TITLE
Fix #1152: Copy npm script file

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
@@ -193,7 +193,18 @@ public class NodeInstaller {
                     for (String script : Arrays.asList("npm", "npm.cmd")) {
                         File scriptFile = new File(npmDirectory, "bin" + File.separator + script);
                         if (scriptFile.exists()) {
-                            scriptFile.setExecutable(true);
+                            File copy = new File(destinationDirectory, script);
+                            if (!copy.exists()) {
+                                try
+                                {
+                                    FileUtils.copyFile(scriptFile, copy);
+                                }
+                                catch (IOException e)
+                                {
+                                    throw new InstallationException("Could not copy npm", e);
+                                }
+                                copy.setExecutable(true);
+                            }
                         }
                     }
                 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeInstaller.java
@@ -190,7 +190,7 @@ public class NodeInstaller {
                     FileUtils.copyDirectory(tmpNodeModulesDir, nodeModulesDirectory);
                     this.logger.info("Extracting NPM");
                     // create a copy of the npm scripts next to the node executable
-                    for (String script : Arrays.asList("npm", "npm.cmd")) {
+                    for (String script : Arrays.asList("npm", "npm.cmd", "npx", "npx.cmd")) {
                         File scriptFile = new File(npmDirectory, "bin" + File.separator + script);
                         if (scriptFile.exists()) {
                             File copy = new File(destinationDirectory, script);


### PR DESCRIPTION
**Summary**

Fix #1152: Copy npm script file

As mentioned in the ticket the comment said it was copying the script and it was not.  

Originally reported on Quarkus Quinoa: https://github.com/quarkiverse/quarkus-quinoa/issues/683