### PR TITLE
Support corepack

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ to see how it should be set up: https://github.com/eirslett/frontend-maven-plugi
 
  - [Installing node and npm](#installing-node-and-npm)
  - [Installing node and yarn](#installing-node-and-yarn)
+ - [Installing node and corepack](#installing-node-and-corepack)
  - Running 
     - [npm](#running-npm)
     - [yarn](#running-yarn)
+    - [corepack](#running-corepack)
     - [bower](#running-bower)
     - [grunt](#running-grunt)
     - [gulp](#running-gulp)
@@ -171,6 +173,45 @@ https://github.com/eirslett/frontend-maven-plugin/blob/master/frontend-maven-plu
 </plugin>
 ```
 
+### Installing node and corepack
+
+You can choose to let corepack manage the package manager version in use. Node is
+downloaded from `https://nodejs.org/dist`, and corepack currently comes from
+`https://repository.npmjs.org`, extracted and put into a `node` folder created
+in your installation directory.
+
+Node/corepack and any package managers will only be "installed" locally to your project.
+It will not be installed globally on the whole system (and it will not interfere with any
+Node/corepack installations already present).
+
+Have a look at the example `POM` to see how it should be set up with corepack:
+https://github.com/eirslett/frontend-maven-plugin/blob/master/frontend-maven-plugin/src/it/corepack-integration/pom.xml
+
+
+```xml
+<plugin>
+    ...
+    <execution>
+        <!-- optional: you don't really need execution ids, but it looks nice in your build log. -->
+        <id>install-node-and-corepack</id>
+        <goals>
+            <goal>install-node-and-corepack</goal>
+        </goals>
+        <!-- optional: default phase is "generate-resources" -->
+        <phase>generate-resources</phase>
+    </execution>
+    <configuration>
+        <nodeVersion>v20.12.2</nodeVersion>
+        <corepackVersion>v0.25.2</corepackVersion>
+
+        <!-- optional: where to download node from. Defaults to https://nodejs.org/dist/ -->
+        <nodeDownloadRoot>http://myproxy.example.org/nodejs/</nodeDownloadRoot>
+        <!-- optional: where to download corepack from. Defaults to https://registry.npmjs.org/corepack/-/ -->
+        <corepackDownloadRoot>http://myproxy.example.org/corepack/</corepackDownloadRoot>
+    </configuration>
+</plugin>
+```
+
 ### Running npm
 
 All node packaged modules will be installed in the `node_modules` folder in your [working directory](#working-directory).
@@ -270,6 +311,55 @@ Also you can set a registry using a tag `npmRegistryURL`
         <arguments>install</arguments>
 	<!-- optional: where to download npm modules from. Defaults to https://registry.yarnpkg.com/ -->
 	<npmRegistryURL>http://myregistry.example.org/</npmRegistryURL>
+    </configuration>
+</execution>
+```
+
+### Running corepack
+
+If your `packageManager` specifies `yarn`, then you'll want to have something like:
+
+
+```xml
+<execution>
+    <id>install</id>
+    <goals>
+        <goal>corepack</goal>
+    </goals>
+    <configuration>
+        <arguments>yarn install</arguments>
+    </configuration>
+</execution>
+<execution>
+    <id>build</id>
+    <goals>
+        <goal>corepack</goal>
+    </goals>
+    <configuration>
+        <arguments>yarn build</arguments>
+    </configuration>
+</execution>
+```
+
+and if you're using `pnpm` instead, you'll want something like
+
+```xml
+<execution>
+    <id>install</id>
+    <goals>
+        <goal>corepack</goal>
+    </goals>
+    <configuration>
+        <arguments>pnpm install</arguments>
+    </configuration>
+</execution>
+<execution>
+    <id>build</id>
+    <goals>
+        <goal>corepack</goal>
+    </goals>
+    <configuration>
+        <arguments>pnpm build</arguments>
     </configuration>
 </execution>
 ```

--- a/README.md
+++ b/README.md
@@ -176,16 +176,19 @@ https://github.com/eirslett/frontend-maven-plugin/blob/master/frontend-maven-plu
 ### Installing node and corepack
 
 You can choose to let corepack manage the package manager version in use. Node is
-downloaded from `https://nodejs.org/dist`, and corepack currently comes from
-`https://repository.npmjs.org`, extracted and put into a `node` folder created
-in your installation directory.
+downloaded from `https://nodejs.org/dist`, and corepack either comes provided with
+Node, or will currently be downloaded from `https://repository.npmjs.org`, extracted
+and put into a `node` folder created in your installation directory.
 
 Node/corepack and any package managers will only be "installed" locally to your project.
 It will not be installed globally on the whole system (and it will not interfere with any
 Node/corepack installations already present).
 
 Have a look at the example `POM` to see how it should be set up with corepack:
+https://github.com/eirslett/frontend-maven-plugin/blob/master/frontend-maven-plugin/src/it/corepack-provided-integration/pom.xml
+or
 https://github.com/eirslett/frontend-maven-plugin/blob/master/frontend-maven-plugin/src/it/corepack-integration/pom.xml
+if you need to override the version of corepack in use.
 
 
 ```xml
@@ -202,6 +205,9 @@ https://github.com/eirslett/frontend-maven-plugin/blob/master/frontend-maven-plu
     </execution>
     <configuration>
         <nodeVersion>v20.12.2</nodeVersion>
+
+        <!-- Optional - only needed if Node <16.9, or if you need to use a version different
+             from the one packaged with Node -->
         <corepackVersion>v0.25.2</corepackVersion>
 
         <!-- optional: where to download node from. Defaults to https://nodejs.org/dist/ -->

--- a/frontend-maven-plugin/src/it/corepack-integration/.yarnrc.yml
+++ b/frontend-maven-plugin/src/it/corepack-integration/.yarnrc.yml
@@ -1,0 +1,3 @@
+enableGlobalCache: false
+
+nodeLinker: node-modules

--- a/frontend-maven-plugin/src/it/corepack-integration/package.json
+++ b/frontend-maven-plugin/src/it/corepack-integration/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "example",
+  "version": "0.0.1",
+  "dependencies": {
+    "less": "~3.0.2"
+  },
+  "packageManager": "yarn@4.1.1"
+}

--- a/frontend-maven-plugin/src/it/corepack-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/corepack-integration/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.eirslett</groupId>
+    <artifactId>example</artifactId>
+    <version>0</version>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
+                <version>@project.version@</version>
+
+                <configuration>
+                    <installDirectory>target</installDirectory>
+                </configuration>
+
+                <executions>
+
+                    <execution>
+                        <id>install node and corepack</id>
+                        <goals>
+                            <goal>install-node-and-corepack</goal>
+                        </goals>
+                        <configuration>
+                            <nodeVersion>v20.12.2</nodeVersion>
+                            <corepackVersion>0.25.2</corepackVersion>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>yarn install</id>
+                        <goals>
+                            <goal>corepack</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>yarn install --no-immutable</arguments>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/frontend-maven-plugin/src/it/corepack-integration/verify.groovy
+++ b/frontend-maven-plugin/src/it/corepack-integration/verify.groovy
@@ -1,0 +1,6 @@
+assert new File(basedir, 'target/node').exists() : "Node was not installed in the custom install directory";
+assert new File(basedir, 'node_modules').exists() : "Node modules were not installed in the base directory";
+assert new File(basedir, 'node_modules/less/package.json').exists() : "Less dependency has not been installed successfully";
+
+String buildLog = new File(basedir, 'build.log').text
+assert buildLog.contains('BUILD SUCCESS') : 'build was not successful'

--- a/frontend-maven-plugin/src/it/corepack-provided-integration/.yarnrc.yml
+++ b/frontend-maven-plugin/src/it/corepack-provided-integration/.yarnrc.yml
@@ -1,0 +1,3 @@
+enableGlobalCache: false
+
+nodeLinker: node-modules

--- a/frontend-maven-plugin/src/it/corepack-provided-integration/package.json
+++ b/frontend-maven-plugin/src/it/corepack-provided-integration/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "example",
+  "version": "0.0.1",
+  "dependencies": {
+    "less": "~3.0.2"
+  },
+  "packageManager": "yarn@4.1.1"
+}

--- a/frontend-maven-plugin/src/it/corepack-provided-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/corepack-provided-integration/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.eirslett</groupId>
+    <artifactId>example</artifactId>
+    <version>0</version>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
+                <version>@project.version@</version>
+
+                <configuration>
+                    <installDirectory>target</installDirectory>
+                </configuration>
+
+                <executions>
+
+                    <execution>
+                        <id>install node and corepack</id>
+                        <goals>
+                            <goal>install-node-and-corepack</goal>
+                        </goals>
+                        <configuration>
+                            <nodeVersion>v20.12.2</nodeVersion>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>yarn install</id>
+                        <goals>
+                            <goal>corepack</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>yarn install --no-immutable</arguments>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/frontend-maven-plugin/src/it/corepack-provided-integration/verify.groovy
+++ b/frontend-maven-plugin/src/it/corepack-provided-integration/verify.groovy
@@ -1,0 +1,6 @@
+assert new File(basedir, 'target/node').exists() : "Node was not installed in the custom install directory";
+assert new File(basedir, 'node_modules').exists() : "Node modules were not installed in the base directory";
+assert new File(basedir, 'node_modules/less/package.json').exists() : "Less dependency has not been installed successfully";
+
+String buildLog = new File(basedir, 'build.log').text
+assert buildLog.contains('BUILD SUCCESS') : 'build was not successful'

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/CorepackMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/CorepackMojo.java
@@ -1,0 +1,54 @@
+package com.github.eirslett.maven.plugins.frontend.mojo;
+
+import java.io.File;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
+import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
+
+@Mojo(name="corepack",  defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
+public final class CorepackMojo extends AbstractFrontendMojo {
+
+    /**
+     * corepack arguments. Default is "enable".
+     */
+    @Parameter(defaultValue = "enable", property = "frontend.corepack.arguments", required = false)
+    private String arguments;
+
+    @Parameter(property = "session", defaultValue = "${session}", readonly = true)
+    private MavenSession session;
+
+    @Component
+    private BuildContext buildContext;
+
+    @Component(role = SettingsDecrypter.class)
+    private SettingsDecrypter decrypter;
+
+    /**
+     * Skips execution of this mojo.
+     */
+    @Parameter(property = "skip.corepack", defaultValue = "${skip.corepack}")
+    private boolean skip;
+
+    @Override
+    protected boolean skipExecution() {
+        return this.skip;
+    }
+
+    @Override
+    public synchronized void execute(FrontendPluginFactory factory) throws TaskRunnerException {
+        File packageJson = new File(workingDirectory, "package.json");
+        if (buildContext == null || buildContext.hasDelta(packageJson) || !buildContext.isIncremental()) {
+            factory.getCorepackRunner().execute(arguments, environmentVariables);
+        } else {
+            getLog().info("Skipping corepack install as package.json unchanged");
+        }
+    }
+}

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndCorepackMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndCorepackMojo.java
@@ -1,0 +1,104 @@
+package com.github.eirslett.maven.plugins.frontend.mojo;
+
+import com.github.eirslett.maven.plugins.frontend.lib.CorepackInstaller;
+import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
+import com.github.eirslett.maven.plugins.frontend.lib.InstallationException;
+import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.apache.maven.settings.Server;
+
+@Mojo(name="install-node-and-corepack", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
+public final class InstallNodeAndCorepackMojo extends AbstractFrontendMojo {
+
+    /**
+     * Where to download Node.js binary from. Defaults to https://nodejs.org/dist/
+     */
+    @Parameter(property = "nodeDownloadRoot", required = false)
+    private String nodeDownloadRoot;
+
+    /**
+     * Where to download corepack binary from. Defaults to https://registry.npmjs.org/corepack/-/
+     */
+    @Parameter(property = "corepackDownloadRoot", required = false, defaultValue = CorepackInstaller.DEFAULT_COREPACK_DOWNLOAD_ROOT)
+    private String corepackDownloadRoot;
+
+    /**
+     * The version of Node.js to install. IMPORTANT! Most Node.js version names start with 'v', for example 'v0.10.18'
+     */
+    @Parameter(property="nodeVersion", required = true)
+    private String nodeVersion;
+
+    /**
+     * The version of corepack to install. Note that the version string can optionally be prefixed with
+     * 'v' (i.e., both 'v1.2.3' and '1.2.3' are valid).
+     */
+    @Parameter(property = "corepackVersion", required = true)
+    private String corepackVersion;
+
+    /**
+     * Server Id for download username and password
+     */
+    @Parameter(property = "serverId", defaultValue = "")
+    private String serverId;
+
+    @Parameter(property = "session", defaultValue = "${session}", readonly = true)
+    private MavenSession session;
+
+    /**
+     * Skips execution of this mojo.
+     */
+    @Parameter(property = "skip.installnodecorepack", defaultValue = "${skip.installnodecorepack}")
+    private boolean skip;
+
+    @Component(role = SettingsDecrypter.class)
+    private SettingsDecrypter decrypter;
+
+    @Override
+    protected boolean skipExecution() {
+        return this.skip;
+    }
+
+    @Override
+    public void execute(FrontendPluginFactory factory) throws InstallationException {
+        ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session, decrypter);
+        String resolvedNodeDownloadRoot = getNodeDownloadRoot();
+        String resolvedCorepackDownloadRoot = getCorepackDownloadRoot();
+        Server server = MojoUtils.decryptServer(serverId, session, decrypter);
+        if (null != server) {
+            factory.getNodeInstaller(proxyConfig)
+                .setNodeVersion(nodeVersion)
+                .setNodeDownloadRoot(resolvedNodeDownloadRoot)
+                .setUserName(server.getUsername())
+                .setPassword(server.getPassword())
+                .install();
+            factory.getCorepackInstaller(proxyConfig)
+                .setCorepackVersion(corepackVersion)
+                .setCorepackDownloadRoot(resolvedCorepackDownloadRoot)
+                .setUserName(server.getUsername())
+                .setPassword(server.getPassword())
+                .install();
+        } else {
+            factory.getNodeInstaller(proxyConfig)
+                .setNodeVersion(nodeVersion)
+                .setNodeDownloadRoot(resolvedNodeDownloadRoot)
+                .install();
+            factory.getCorepackInstaller(proxyConfig)
+                .setCorepackVersion(this.corepackVersion)
+                .setCorepackDownloadRoot(resolvedCorepackDownloadRoot)
+                .install();
+        }
+    }
+
+    private String getNodeDownloadRoot() {
+        return nodeDownloadRoot;
+    }
+
+    private String getCorepackDownloadRoot() {
+        return corepackDownloadRoot;
+    }
+}

--- a/frontend-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/frontend-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -4,6 +4,7 @@
 		<pluginExecution>
 			<pluginExecutionFilter>
 				<goals>
+                    <goal>install-node-and-corepack</goal>
 					<goal>install-node-and-npm</goal>
 					<goal>install-node-and-pnpm</goal>
 					<goal>install-node-and-yarn</goal>
@@ -20,6 +21,7 @@
         <pluginExecution>
             <pluginExecutionFilter>
                 <goals>
+                    <goal>corepack</goal>
                     <goal>npm</goal>
                     <goal>npx</goal>
                     <goal>pnpm</goal>

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/CorepackInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/CorepackInstaller.java
@@ -1,0 +1,271 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+
+public class CorepackInstaller {
+
+    private static final String VERSION = "version";
+
+    public static final String DEFAULT_COREPACK_DOWNLOAD_ROOT = "https://registry.npmjs.org/corepack/-/";
+
+    private static final Object LOCK = new Object();
+
+    private String corepackVersion, corepackDownloadRoot, userName, password;
+
+    private final Logger logger;
+
+    private final InstallConfig config;
+
+    private final ArchiveExtractor archiveExtractor;
+
+    private final FileDownloader fileDownloader;
+
+    CorepackInstaller(InstallConfig config, ArchiveExtractor archiveExtractor, FileDownloader fileDownloader) {
+        this.logger = LoggerFactory.getLogger(getClass());
+        this.config = config;
+        this.archiveExtractor = archiveExtractor;
+        this.fileDownloader = fileDownloader;
+    }
+
+    public CorepackInstaller setNodeVersion(String nodeVersion) {
+        return this;
+    }
+
+    public CorepackInstaller setCorepackVersion(String corepackVersion) {
+        this.corepackVersion = corepackVersion;
+        return this;
+    }
+
+    public CorepackInstaller setCorepackDownloadRoot(String corepackDownloadRoot) {
+        this.corepackDownloadRoot = corepackDownloadRoot;
+        return this;
+    }
+
+    public CorepackInstaller setUserName(String userName) {
+        this.userName = userName;
+        return this;
+    }
+
+    public CorepackInstaller setPassword(String password) {
+        this.password = password;
+        return this;
+    }
+
+    public void install() throws InstallationException {
+        // use static lock object for a synchronized block
+        synchronized (LOCK) {
+            if (this.corepackDownloadRoot == null || this.corepackDownloadRoot.isEmpty()) {
+                this.corepackDownloadRoot = DEFAULT_COREPACK_DOWNLOAD_ROOT;
+            }
+            if (!corepackIsAlreadyInstalled()) {
+                installCorepack();
+            }
+
+            if (this.config.getPlatform().isWindows()) {
+                linkExecutableWindows();
+            } else {
+                linkExecutable();
+            }
+        }
+    }
+
+    private boolean corepackIsAlreadyInstalled() {
+        try {
+            final File corepackPackageJson = new File(
+                this.config.getInstallDirectory() + Utils.normalize("/node/node_modules/corepack/package.json"));
+            if (corepackPackageJson.exists()) {
+                HashMap<String, Object> data = new ObjectMapper().readValue(corepackPackageJson, HashMap.class);
+                if (data.containsKey(VERSION)) {
+                    final String foundCorepackVersion = data.get(VERSION).toString();
+                    if (foundCorepackVersion.equals(this.corepackVersion.replaceFirst("^v", ""))) {
+                        this.logger.info("corepack {} is already installed.", foundCorepackVersion);
+                        return true;
+                    } else {
+                        this.logger.info("corepack {} was installed, but we need version {}", foundCorepackVersion,
+                            this.corepackVersion);
+                        return false;
+                    }
+                } else {
+                    this.logger.info("Could not read corepack version from package.json");
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        } catch (IOException ex) {
+            throw new RuntimeException("Could not read package.json", ex);
+        }
+    }
+
+    private void installCorepack() throws InstallationException {
+        try {
+            this.logger.info("Installing corepack version {}", this.corepackVersion);
+            String corepackVersionClean = this.corepackVersion.replaceFirst("^v(?=[0-9]+)", "");
+            final String downloadUrl = this.corepackDownloadRoot + "corepack-" + corepackVersionClean + ".tgz";
+
+            CacheDescriptor cacheDescriptor = new CacheDescriptor("corepack", corepackVersionClean, "tar.gz");
+
+            File archive = this.config.getCacheResolver().resolve(cacheDescriptor);
+
+            downloadFileIfMissing(downloadUrl, archive, this.userName, this.password);
+
+            File installDirectory = getNodeInstallDirectory();
+            File nodeModulesDirectory = new File(installDirectory, "node_modules");
+
+            // We need to delete the existing corepack directory first so we clean out any old files, and
+            // so we can rename the package directory below.
+            File oldDirectory = new File(installDirectory, "corepack");
+            File corepackDirectory = new File(nodeModulesDirectory, "corepack");
+            try {
+                if (oldDirectory.isDirectory()) {
+                    FileUtils.deleteDirectory(oldDirectory);
+                }
+                FileUtils.deleteDirectory(corepackDirectory);
+            } catch (IOException e) {
+                this.logger.warn("Failed to delete existing corepack installation.");
+            }
+
+            File packageDirectory = new File(nodeModulesDirectory, "package");
+            try {
+                extractFile(archive, nodeModulesDirectory);
+            } catch (ArchiveExtractionException e) {
+                if (e.getCause() instanceof EOFException) {
+                    // https://github.com/eirslett/frontend-maven-plugin/issues/794
+                    // The downloading was probably interrupted and archive file is incomplete:
+                    // delete it to retry from scratch
+                    this.logger.error("The archive file {} is corrupted and will be deleted. "
+                            + "Please try the build again.", archive.getPath());
+                    archive.delete();
+                    if (packageDirectory.exists()) {
+                        FileUtils.deleteDirectory(packageDirectory);
+                    }
+                }
+
+                throw e;
+            }
+
+            // handles difference between old and new download root (nodejs.org/dist/npm and
+            // registry.npmjs.org)
+            // see https://github.com/eirslett/frontend-maven-plugin/issues/65#issuecomment-52024254
+            if (packageDirectory.exists() && !corepackDirectory.exists()) {
+                if (!packageDirectory.renameTo(corepackDirectory)) {
+                    this.logger.warn("Cannot rename corepack directory, making a copy.");
+                    FileUtils.copyDirectory(packageDirectory, corepackDirectory);
+                }
+            }
+
+            this.logger.info("Installed corepack locally.");
+
+        } catch (DownloadException e) {
+            throw new InstallationException("Could not download corepack", e);
+        } catch (ArchiveExtractionException e) {
+            throw new InstallationException("Could not extract the corepack archive", e);
+        } catch (IOException e) {
+            throw new InstallationException("Could not copy corepack", e);
+        }
+    }
+
+    private void linkExecutable() throws InstallationException{
+        File nodeInstallDirectory = getNodeInstallDirectory();
+        File corepackExecutable = new File(nodeInstallDirectory, "corepack");
+
+        if (corepackExecutable.exists()) {
+            this.logger.info("Existing corepack executable found, skipping linking.");
+            return;
+        }
+
+        NodeExecutorConfig executorConfig = new InstallNodeExecutorConfig(this.config);
+        File corepackJsExecutable = executorConfig.getCorepackPath();
+
+        if (!corepackJsExecutable.exists()) {
+            throw new InstallationException("Could not link to corepack executable, no corepack installation found.");
+        }
+
+        this.logger.info("No corepack executable found, creating symbolic link to {}.", corepackJsExecutable.toPath());
+
+        try {
+            Files.createSymbolicLink(corepackExecutable.toPath(), corepackJsExecutable.toPath());
+        } catch (IOException e) {
+            throw new InstallationException("Could not create symbolic link for corepack executable.", e);
+        }
+    }
+
+    private void linkExecutableWindows() throws InstallationException{
+        File nodeInstallDirectory = getNodeInstallDirectory();
+        File corepackExecutable = new File(nodeInstallDirectory, "corepack.cmd");
+
+        if (corepackExecutable.exists()) {
+            this.logger.info("Existing corepack executable found, skipping linking.");
+            return;
+        }
+
+        NodeExecutorConfig executorConfig = new InstallNodeExecutorConfig(this.config);
+        File corepackJsExecutable = executorConfig.getCorepackPath();
+
+        if (!corepackJsExecutable.exists()) {
+            throw new InstallationException("Could not link to corepack executable, no corepack installation found.");
+        }
+
+        this.logger.info("No corepack executable found, creating proxy script to {}.", corepackJsExecutable.toPath());
+
+        Path nodePath = executorConfig.getNodePath().toPath();
+        Path relativeNodePath = nodeInstallDirectory.toPath().relativize(nodePath);
+        Path relativeCorepackPath = nodeInstallDirectory.toPath().relativize(corepackJsExecutable.toPath());
+
+        // Create a script that will proxy any commands passed into it to the corepack executable.
+        String scriptContents = new StringBuilder()
+                .append(":: Created by frontend-maven-plugin, please don't edit manually.\r\n")
+                .append("@ECHO OFF\r\n")
+                .append("\r\n")
+                .append("SETLOCAL\r\n")
+                .append("\r\n")
+                .append(String.format("SET \"NODE_EXE=%%~dp0\\%s\"\r\n", relativeNodePath))
+                .append(String.format("SET \"COREPACK_CLI_JS=%%~dp0\\%s\"\r\n", relativeCorepackPath))
+                .append("\r\n")
+                .append("\"%NODE_EXE%\" \"%COREPACK_CLI_JS%\" %*")
+                .toString();
+
+        try {
+            BufferedWriter writer = new BufferedWriter(new FileWriter(corepackExecutable));
+            writer.write(scriptContents);
+            writer.close();
+        } catch (IOException e) {
+            throw new InstallationException("Could not create proxy script for corepack executable.", e);
+        }
+    }
+
+    private File getNodeInstallDirectory() {
+        File installDirectory = new File(this.config.getInstallDirectory(), NodeInstaller.INSTALL_PATH);
+        if (!installDirectory.exists()) {
+            this.logger.debug("Creating install directory {}", installDirectory);
+            installDirectory.mkdirs();
+        }
+        return installDirectory;
+    }
+
+    private void extractFile(File archive, File destinationDirectory) throws ArchiveExtractionException {
+        this.logger.info("Unpacking {} into {}", archive, destinationDirectory);
+        this.archiveExtractor.extract(archive.getPath(), destinationDirectory.getPath());
+    }
+
+    private void downloadFileIfMissing(String downloadUrl, File destination, String userName, String password)
+        throws DownloadException {
+        if (!destination.exists()) {
+            downloadFile(downloadUrl, destination, userName, password);
+        }
+    }
+
+    private void downloadFile(String downloadUrl, File destination, String userName, String password)
+        throws DownloadException {
+        this.logger.info("Downloading {} to {}", downloadUrl, destination);
+        this.fileDownloader.download(downloadUrl, destination.getPath(), userName, password);
+    }
+}

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/CorepackInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/CorepackInstaller.java
@@ -82,6 +82,11 @@ public class CorepackInstaller {
             final File corepackPackageJson = new File(
                 this.config.getInstallDirectory() + Utils.normalize("/node/node_modules/corepack/package.json"));
             if (corepackPackageJson.exists()) {
+                if ("provided".equals(this.corepackVersion)) {
+                    // Since we don't know which version it should be, we must assume that we have
+                    // correctly setup the packaged version
+                    return true;
+                }
                 HashMap<String, Object> data = new ObjectMapper().readValue(corepackPackageJson, HashMap.class);
                 if (data.containsKey(VERSION)) {
                     final String foundCorepackVersion = data.get(VERSION).toString();

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/CorepackRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/CorepackRunner.java
@@ -1,0 +1,15 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+public interface CorepackRunner extends NodeTaskRunner {}
+
+final class DefaultCorepackRunner extends NodeTaskExecutor implements CorepackRunner {
+    static final String TASK_NAME = "corepack";
+
+    public DefaultCorepackRunner(NodeExecutorConfig config) {
+        super(config, TASK_NAME, config.getCorepackPath().getAbsolutePath());
+
+        if (!config.getCorepackPath().exists()) {
+            setTaskLocation(config.getCorepackPath().getAbsolutePath());
+        }
+    }
+}

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -32,6 +32,10 @@ public final class FrontendPluginFactory {
         return new NPMInstaller(getInstallConfig(), new DefaultArchiveExtractor(), new DefaultFileDownloader(proxy));
     }
 
+    public CorepackInstaller getCorepackInstaller(ProxyConfig proxy) {
+        return new CorepackInstaller(getInstallConfig(), new DefaultArchiveExtractor(), new DefaultFileDownloader(proxy));
+    }
+
     public PnpmInstaller getPnpmInstaller(ProxyConfig proxy) {
         return new PnpmInstaller(getInstallConfig(), new DefaultArchiveExtractor(), new DefaultFileDownloader(proxy));
     }
@@ -54,6 +58,10 @@ public final class FrontendPluginFactory {
 
     public NpmRunner getNpmRunner(ProxyConfig proxy, String npmRegistryURL) {
         return new DefaultNpmRunner(getExecutorConfig(), proxy, npmRegistryURL);
+    }
+
+    public CorepackRunner getCorepackRunner() {
+        return new DefaultCorepackRunner(getExecutorConfig());
     }
 
     public PnpmRunner getPnpmRunner(ProxyConfig proxyConfig, String npmRegistryUrl) {

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutorConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutorConfig.java
@@ -7,6 +7,7 @@ public interface NodeExecutorConfig {
   File getNpmPath();
   File getPnpmPath();
   File getPnpmCjsPath();
+  File getCorepackPath();
 
   File getNpxPath();
   File getInstallDirectory();
@@ -21,6 +22,7 @@ final class InstallNodeExecutorConfig implements NodeExecutorConfig {
   private static final String NPM = NodeInstaller.INSTALL_PATH + "/node_modules/npm/bin/npm-cli.js";
   private static final String PNPM = NodeInstaller.INSTALL_PATH + "/node_modules/pnpm/bin/pnpm.js";
   private static final String PNPM_CJS = NodeInstaller.INSTALL_PATH + "/node_modules/pnpm/bin/pnpm.cjs";
+  private static final String COREPACK = NodeInstaller.INSTALL_PATH + "/node_modules/corepack/dist/corepack.js";
   private static final String NPX = NodeInstaller.INSTALL_PATH + "/node_modules/npm/bin/npx-cli.js";
 
   private final InstallConfig installConfig;
@@ -49,6 +51,11 @@ final class InstallNodeExecutorConfig implements NodeExecutorConfig {
   @Override
   public File getPnpmCjsPath() {
     return new File(installConfig.getInstallDirectory() + Utils.normalize(PNPM_CJS));
+  }
+
+  @Override
+  public File getCorepackPath() {
+    return new File(installConfig.getInstallDirectory() + Utils.normalize(COREPACK));
   }
 
   @Override


### PR DESCRIPTION
**Summary**

Adds support for using `corepack` to manage the package manager in use on a given build project.

**Tests and Documentation**

README is updated, an integration example has been provided

Fixes: https://github.com/eirslett/frontend-maven-plugin/issues/1032