### PR TITLE
Fix: delete only bun directory inside the installation directory 

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/BunInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/BunInstaller.java
@@ -111,9 +111,10 @@ public class BunInstaller {
 
             // We need to delete the existing bun directory first so we clean out any old files, and
             // so we can rename the package directory below.
+            File bunExtractDirectory = new File(installDirectory, createBunTargetArchitecturePath());
             try {
-                if (installDirectory.isDirectory()) {
-                    FileUtils.deleteDirectory(installDirectory);
+                if (bunExtractDirectory.isDirectory()) {
+                    FileUtils.deleteDirectory(bunExtractDirectory);
                 }
             } catch (IOException e) {
                 logger.warn("Failed to delete existing Bun installation.");


### PR DESCRIPTION
**Summary**

"install-bun" deletes the entire installation directory if bun is not installed.
With this PR, only the bun directory inside of the installation directory will be deleted, similar on how it works for the NPM installation.

Fixes: #1159 
