### PR TITLE
Avoid modification of https.protocols

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,13 +18,12 @@ install:
   - cmd: SET M2_HOME=C:\maven\apache-maven-%MAVEN_VERSION%
   # Prepend Java entry, remove Ruby entry (C:\Ruby193\bin;) from PATH
   - cmd: SET PATH=%M2_HOME%\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%;
-  # Required to avoid errors with JDK 8 because TSL 1.0 & 1.1 support was removed
-  - cmd: SET MAVEN_OPTS=-Xmx2g -Dhttps.protocols=TLSv1.2
+  - cmd: SET MAVEN_OPTS=-Xmx2g
   - cmd: SET JAVA_OPTS=-Xmx2g
   - cmd: mvn --version
   - cmd: java -version
 build_script:
-  - mvn clean package --batch-mode -DskipTest -Dhttps.protocols=TLSv1.2
+  - mvn clean package --batch-mode -DskipTest
 test_script:
   - mvn clean install --batch-mode
 cache:

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FileDownloader.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FileDownloader.java
@@ -54,9 +54,6 @@ final class DefaultFileDownloader implements FileDownloader {
 
     @Override
     public void download(String downloadUrl, String destination, String userName, String password, Map<String, String> httpHeaders) throws DownloadException {
-        // force tls to 1.2 since github removed weak cryptographic standards
-        // https://blog.github.com/2018-02-02-weak-cryptographic-standards-removal-notice/
-        System.setProperty("https.protocols", "TLSv1.2");
         String fixedDownloadUrl = downloadUrl;
         try {
             fixedDownloadUrl = FilenameUtils.separatorsToUnix(fixedDownloadUrl);


### PR DESCRIPTION
This disables TLSv1.3 and changes global state that shouldn't be changed.

Fixes #1170.