### PR TITLE
Add no_proxy to proxy envs Fixes #1172

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
@@ -1,6 +1,7 @@
 package com.github.eirslett.maven.plugins.frontend.lib;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -53,6 +54,11 @@ final class DefaultNpmRunner extends NodeTaskExecutor implements NpmRunner {
 
             proxyEnvironmentVariables.put("https_proxy", proxy.getUri().toString());
             proxyEnvironmentVariables.put("http_proxy", proxy.getUri().toString());
+            final String nonProxyHosts = proxy.getNonProxyHosts();
+            if (nonProxyHosts != null && !nonProxyHosts.isEmpty()) {
+                proxyEnvironmentVariables.put("no_proxy", nonProxyHosts.replaceAll("\\|",",").replaceAll("\\*",""));
+
+            }
         }
 
         return proxyEnvironmentVariables;

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NpmRunner.java
@@ -56,7 +56,7 @@ final class DefaultNpmRunner extends NodeTaskExecutor implements NpmRunner {
             proxyEnvironmentVariables.put("http_proxy", proxy.getUri().toString());
             final String nonProxyHosts = proxy.getNonProxyHosts();
             if (nonProxyHosts != null && !nonProxyHosts.isEmpty()) {
-                proxyEnvironmentVariables.put("no_proxy", nonProxyHosts.replaceAll("\\|",",").replaceAll("\\*",""));
+                proxyEnvironmentVariables.put("no_proxy", nonProxyHosts.replace('|',',').replace("*",""));
 
             }
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

As pointed out in #1172  Non Proxy hosts are not added to the proxy environment vars.
This PR adds the missing environment var. It converts from the maven format *.host1|*.host2 to .host1,.host2 


**Tests and Documentation**

<!-- Demonstrate the code is solid. Add a simple description to CHANGELOG.md and add some infos to README.md or Wiki, if necessary. -->
