### PR TITLE
Use minimal required maven version in pom.xml

### DIFF
--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -12,7 +12,7 @@
 
   <name>Maven Frontend Plugin</name>
   <prerequisites>
-    <maven>3.6.0</maven>
+    <maven>3.3.1</maven>
   </prerequisites>
 
   <description>


### PR DESCRIPTION
Summary
Some of us are stuck using older versions of maven and the projects builds with 3.3.1.
Lower than 3.2.5 and maven-compiler-plugin complains.
Lower than 3.3.1 and the integrationTests fail with missing method exceptions for maven stuff.

Tests and Documentation
Ran `mvn clean install --batch-mode -PintegrationTests` with success, on windows and osx with maven 3.3.1 installed.

Any suggestions and what else would need to be tested? At worst it'll break someone who could run the project before the change, anyone currently using it won't see a difference as they're already using maven 3.6.0.
