### PR TITLE
readme: replace unresolving badge with pointer to github actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # frontend-maven-plugin
 
-[![Build Status OSX and Linux](https://travis-ci.org/eirslett/frontend-maven-plugin.png?branch=master)](https://travis-ci.org/eirslett/frontend-maven-plugin)
-[![Build status Windows](https://ci.appveyor.com/api/projects/status/vxbccc1t9ceadhi9?svg=true)](https://ci.appveyor.com/project/eirslett/frontend-maven-plugin)
+[![Build](https://github.com/eirslett/frontend-maven-plugin/actions/workflows/main.yml/badge.svg)](https://github.com/eirslett/frontend-maven-plugin/actions/workflows/main.yml)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.eirslett/frontend-maven-plugin/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/com.github.eirslett/frontend-maven-plugin/)
 
 This plugin downloads/installs Node and NPM locally for your project, runs `npm install`, and then any combination of 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Current readme has unresolvable images
<img width="373" height="121" alt="image" src="https://github.com/user-attachments/assets/1f91cbe8-6f09-492e-a8c5-9e0ee8d72b6c" />
Fixed version
<img width="477" height="70" alt="image" src="https://github.com/user-attachments/assets/daa62622-c0b5-43c0-923c-aa4cbb68e3c4" />


**Tests and Documentation**

<!-- Demonstrate the code is solid. Add a simple description to CHANGELOG.md and add some infos to README.md or Wiki, if necessary. -->
