### PR TITLE
Make it more obvious to the user they need to specify a corepack version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 
 ## Changelog
 
+### Unreleased
+
+* Explicitly inform the user to provide a corepack version when required
+
 ### 1.15.1
 
 * Fix #1150: Update lifecycle-mapping-metadata.xml for npx

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndCorepackMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndCorepackMojo.java
@@ -16,6 +16,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.apache.maven.settings.Server;
 
+import static com.github.eirslett.maven.plugins.frontend.lib.CorepackInstaller.BUNDLED_COREPACK_VERSION;
+
 @Mojo(name="install-node-and-corepack", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public final class InstallNodeAndCorepackMojo extends AbstractFrontendMojo {
 
@@ -43,7 +45,7 @@ public final class InstallNodeAndCorepackMojo extends AbstractFrontendMojo {
      *
      * If not provided, then the corepack version bundled with Node will be used.
      */
-    @Parameter(property = "corepackVersion", required = false, defaultValue = "provided")
+    @Parameter(property = "corepackVersion", required = false, defaultValue = BUNDLED_COREPACK_VERSION)
     private String corepackVersion;
 
     /**
@@ -79,7 +81,7 @@ public final class InstallNodeAndCorepackMojo extends AbstractFrontendMojo {
         NodeInstaller nodeInstaller = factory.getNodeInstaller(proxyConfig);
         nodeInstaller.setNodeVersion(nodeVersion)
                 .setNodeDownloadRoot(resolvedNodeDownloadRoot);
-        if ("provided".equals(corepackVersion)) {
+        if (BUNDLED_COREPACK_VERSION.equals(corepackVersion)) {
             // This causes the node installer to copy over the whole
             // node_modules directory including the corepack module
             nodeInstaller.setNpmVersion("provided");

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/CorepackInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/CorepackInstaller.java
@@ -13,6 +13,8 @@ import java.util.Map;
 
 public class CorepackInstaller {
 
+    public static final String BUNDLED_COREPACK_VERSION = "provided";
+
     private static final String VERSION = "version";
 
     public static final String DEFAULT_COREPACK_DOWNLOAD_ROOT = "https://registry.npmjs.org/corepack/-/";
@@ -22,7 +24,7 @@ public class CorepackInstaller {
     private String corepackVersion, corepackDownloadRoot, userName, password;
 
     private Map<String, String> httpHeaders;
-    
+
     private final Logger logger;
 
     private final InstallConfig config;
@@ -90,7 +92,7 @@ public class CorepackInstaller {
             final File corepackPackageJson = new File(
                 this.config.getInstallDirectory() + Utils.normalize("/node/node_modules/corepack/package.json"));
             if (corepackPackageJson.exists()) {
-                if ("provided".equals(this.corepackVersion)) {
+                if (BUNDLED_COREPACK_VERSION.equals(this.corepackVersion)) {
                     // Since we don't know which version it should be, we must assume that we have
                     // correctly setup the packaged version
                     return true;
@@ -120,6 +122,10 @@ public class CorepackInstaller {
 
     private void installCorepack() throws InstallationException {
         try {
+            if (BUNDLED_COREPACK_VERSION.equals(this.corepackVersion)) {
+                throw new InstallationException("The corepack version needs to be specified.");
+            }
+
             this.logger.info("Installing corepack version {}", this.corepackVersion);
             String corepackVersionClean = this.corepackVersion.replaceFirst("^v(?=[0-9]+)", "");
             final String downloadUrl = this.corepackDownloadRoot + "corepack-" + corepackVersionClean + ".tgz";


### PR DESCRIPTION
At the moment it's not obvious, there's just an error message saying a download of corepack failed with a 404. The user has to deduce why by looking at the URL that's attempted and then realising that "provided" should actually be a version.