### PR TITLE
Refactor README for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,19 +215,19 @@ if you need to override the version of corepack in use.
         </goals>
         <!-- optional: default phase is "generate-resources" -->
         <phase>generate-resources</phase>
+		<configuration>
+	        <nodeVersion>v20.12.2</nodeVersion>
+	
+	        <!-- Optional - only needed if Node <16.9, or if you need to use a version different
+	             from the one packaged with Node -->
+	        <corepackVersion>v0.25.2</corepackVersion>
+	
+	        <!-- optional: where to download node from. Defaults to https://nodejs.org/dist/ -->
+	        <nodeDownloadRoot>http://myproxy.example.org/nodejs/</nodeDownloadRoot>
+	        <!-- optional: where to download corepack from. Defaults to https://registry.npmjs.org/corepack/-/ -->
+	        <corepackDownloadRoot>http://myproxy.example.org/corepack/</corepackDownloadRoot>
+    	</configuration>
     </execution>
-    <configuration>
-        <nodeVersion>v20.12.2</nodeVersion>
-
-        <!-- Optional - only needed if Node <16.9, or if you need to use a version different
-             from the one packaged with Node -->
-        <corepackVersion>v0.25.2</corepackVersion>
-
-        <!-- optional: where to download node from. Defaults to https://nodejs.org/dist/ -->
-        <nodeDownloadRoot>http://myproxy.example.org/nodejs/</nodeDownloadRoot>
-        <!-- optional: where to download corepack from. Defaults to https://registry.npmjs.org/corepack/-/ -->
-        <corepackDownloadRoot>http://myproxy.example.org/corepack/</corepackDownloadRoot>
-    </configuration>
 </plugin>
 ```
 


### PR DESCRIPTION
Refactor README to move the configuration to the correct place

Thanks for this useful project!

**Summary**

I tried setting the <configuration> tag in the <executions> part, but this part only accepts <execution></execution> children.

I think the <configuration></configuration> should be in the corresponding <execution>, except if it's common to multiple <execution> so we can set it as a child of <plugin></plugin> tag. 

**Tests and Documentation**

Here is my **working** pom: 
```xml
<plugin>
      <groupId>com.github.eirslett</groupId>
      <artifactId>frontend-maven-plugin</artifactId>
      <version>1.15.4</version>
      <executions>
            <execution>
                  <id>install-node-and-corepack</id>
                  <goals>
                        <goal>install-node-and-corepack</goal>
                        <goal>yarn</goal>
                  </goals>
                  <!-- optional: default phase is "generate-resources" -->
                  <phase>generate-resources</phase>
                  <configuration>
                        <arguments>-v</arguments>
                        <nodeVersion>v22.4.1</nodeVersion>
                        <corepackVersion>v0.34.3</corepackVersion>
                        <yarnVersion>v4.11.0</yarnVersion>
                  </configuration>
            </execution>
      </executions>
</plugin>
``` 

Here is the pom if I follow the actual README. It generates an error as the <configuration> tag can't be placed here:

```xml
<plugin>
    <execution>
        <id>install-node-and-corepack</id>
        <goals>
            <goal>install-node-and-corepack</goal>
        </goals>
    </execution>
    <configuration>
        <nodeVersion>v20.12.2</nodeVersion>

        <!-- Optional - only needed if Node <16.9, or if you need to use a version different
             from the one packaged with Node -->
        <corepackVersion>v0.25.2</corepackVersion>

        <!-- optional: where to download node from. Defaults to https://nodejs.org/dist/ -->
        <nodeDownloadRoot>http://myproxy.example.org/nodejs/</nodeDownloadRoot>
        <!-- optional: where to download corepack from. Defaults to https://registry.npmjs.org/corepack/-/ -->
        <corepackDownloadRoot>http://myproxy.example.org/corepack/</corepackDownloadRoot>
    </configuration>
</plugin>
```

