### PR TITLE
Fix pnpm broken symlink replacement

### DIFF
--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/PnpmInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/PnpmInstaller.java
@@ -197,9 +197,12 @@ public class PnpmInstaller {
             throw new InstallationException("Could not link to pnpm executable, no pnpm installation found.");
         }
 
-        this.logger.info("No pnpm executable found, creating symbolic link to {}.", pnpmJsExecutable.toPath());
-
         try {
+            if (Files.isSymbolicLink(pnpmExecutable.toPath())) {
+                Files.delete(pnpmExecutable.toPath());
+            }
+
+            this.logger.info("No pnpm executable found, creating symbolic link to {}.", pnpmJsExecutable.toPath());
             Files.createSymbolicLink(pnpmExecutable.toPath(), pnpmJsExecutable.toPath());
         } catch (IOException e) {
             throw new InstallationException("Could not create symbolic link for pnpm executable.", e);

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/PnpmInstallerTest.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/PnpmInstallerTest.java
@@ -1,0 +1,47 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class PnpmInstallerTest {
+
+    @TempDir
+    public File temp;
+
+    @Test
+    public void replacesBrokenPnpmSymlink() throws Exception {
+        File installDirectory = new File(temp, "install");
+        Path nodeDirectory = installDirectory.toPath().resolve("node");
+        Path pnpmBinDirectory = nodeDirectory.resolve("node_modules/pnpm/bin");
+        Files.createDirectories(pnpmBinDirectory);
+        Files.writeString(nodeDirectory.resolve("node_modules/pnpm/package.json"), "{\"version\":\"10.0.0\"}");
+        Files.writeString(pnpmBinDirectory.resolve("pnpm.cjs"), "");
+        createSymlinkOrSkipTest(nodeDirectory.resolve("pnpm"), temp.toPath().resolve("missing-container-path/pnpm"));
+
+        PnpmInstaller installer = new FrontendPluginFactory(temp, installDirectory)
+            .getPnpmInstaller(new ProxyConfig(Collections.emptyList()))
+            .setPnpmVersion("10.0.0");
+
+        assertDoesNotThrow(installer::install);
+
+        assertEquals(pnpmBinDirectory.resolve("pnpm.cjs"), Files.readSymbolicLink(nodeDirectory.resolve("pnpm")));
+    }
+
+    private Path createSymlinkOrSkipTest(Path link, Path target) {
+        try {
+            return Files.createSymbolicLink(link, target);
+        } catch (UnsupportedOperationException | java.io.IOException e) {
+            assumeTrue(false, "symlinks not supported");
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
**Summary**

Replace an existing broken `pnpm` symlink before creating the link to the installed pnpm CLI.

Fixes #1188

**Tests and Documentation**

`mvn -pl frontend-plugin-core -Dtest=PnpmInstallerTest#replacesBrokenPnpmSymlink test`

`mvn -pl frontend-plugin-core test`

No documentation changes were needed.
