### PR TITLE
Add support for LoongArch64 (loong64) architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Last public release: [![Maven Central](https://maven-badges.herokuapp.com/maven-
 
 ## Changelog
 
+### 2.0.2 (unreleased)
+
+* Add LoongArch64 (loong64) architecture support ([#1232](https://github.com/eirslett/frontend-maven-plugin/issues/1232))
+
 ### 2.0.1
 
 * Use pnpm .mjs file if it exists to support 11+ ([#1224](https://github.com/eirslett/frontend-maven-plugin/issues/1224))

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/Platform.java
@@ -5,7 +5,7 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-enum Architecture { x86, x64, ppc64le, s390x, arm64, armv7l, ppc, ppc64;
+enum Architecture { x86, x64, ppc64le, s390x, arm64, armv7l, ppc, ppc64, loong64;
     public static Architecture guess(){
         String arch = System.getProperty("os.arch");
         String version = System.getProperty("os.version");
@@ -26,6 +26,8 @@ enum Architecture { x86, x64, ppc64le, s390x, arm64, armv7l, ppc, ppc64;
             return ppc64;
         } else if (arch.equals("ppc")) {
             return ppc;
+        } else if (arch.equals("loongarch64")) {
+            return loong64;
         } else {
             return arch.contains("64") ? x64 : x86;
         }

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/PlatformTest.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/PlatformTest.java
@@ -56,6 +56,12 @@ public class PlatformTest {
     }
 
     @Test
+    public void detect_linux_loong64() {
+        Platform platform = Platform.guess(OS.Linux, Architecture.loong64, () -> false);
+        assertEquals("linux-loong64", platform.getNodeClassifier(NODE_VERSION_16));
+    }
+
+    @Test
     public void getNodeMajorVersion() {
         assertEquals(Integer.valueOf(8), Platform.getNodeMajorVersion(NODE_VERSION_8));
         assertEquals(Integer.valueOf(15), Platform.getNodeMajorVersion(NODE_VERSION_15));


### PR DESCRIPTION
https://github.com/eirslett/frontend-maven-plugin/issues/1232

**Summary**

Add LoongArch64 (loong64) architecture support to the plugin.

**Motivation**: LoongArch64 is a CPU architecture independently developed in China (Loongson). On LoongArch platforms, Java's `os.arch` system property returns `"loongarch64"`. Currently, `Architecture.guess()` does not recognize this value and falls back to `arch.contains("64") ? x64 : x86`, incorrectly matching it to `x64` and causing the plugin to download the wrong Node.js binary.

This PR adds proper recognition so that the plugin produces the correct `linux-loong64` classifier. Node.js `linux-loong64` binaries are available from [unofficial-builds.nodejs.org](https://unofficial-builds.nodejs.org/download/release/) (earliest: v18.18.0, latest: v26.4.0, 87 versions across v18–v26).

> **Note**: `linux-loong64` builds are on `unofficial-builds.nodejs.org`, not the default `nodejs.org/dist/`. Users on LoongArch must override `nodeDownloadRoot` to `https://unofficial-builds.nodejs.org/download/release/` in plugin configuration for the download to succeed. A follow-up change could switch the download root automatically (similar to the musl/Alpine handling).

**Changes**:

| File | Change |
|------|--------|
| `Platform.java` | Add `loong64` to the `Architecture` enum; add `"loongarch64"` → `loong64` mapping in `guess()` |
| `PlatformTest.java` | Add `detect_linux_loong64` test verifying `"linux-loong64"` classifier |


**Tests and Documentation**

- **Unit test**: `detect_linux_loong64` verifies that `Platform.guess(OS.Linux, Architecture.loong64, () -> false)` resolves to classifier `"linux-loong64"`.
- The change follows the existing pattern for other architectures (ppc64le, s390x, arm64, etc.) — no new abstractions introduced.
- A one-liner add to CHANGELOG.md: "Add LoongArch64 (loong64) architecture support."
